### PR TITLE
Add comprehensive bandwidth tracking with guard/middle/exit breakdown

### DIFF
--- a/allium/allium.py
+++ b/allium/allium.py
@@ -67,6 +67,10 @@ if __name__ == "__main__":
     # miscellaneous page filename suffixes and sorted-by keys
     misc_pages = {
         "by-bandwidth": "1.bandwidth",
+        "by-overall-bandwidth": "1.bandwidth",
+        "by-guard-bandwidth": "1.guard_bandwidth",
+        "by-middle-bandwidth": "1.middle_bandwidth", 
+        "by-exit-bandwidth": "1.exit_bandwidth",
         "by-consensus-weight": "1.consensus_weight_fraction,1.bandwidth",
         "by-exit-count": "1.exit_count,1.bandwidth",
         "by-guard-count": "1.guard_count,1.bandwidth",

--- a/allium/allium.py
+++ b/allium/allium.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
         "by-bandwidth": "1.bandwidth",
         "by-consensus-weight": "1.consensus_weight_fraction,1.bandwidth",
         "by-exit-count": "1.exit_count,1.bandwidth",
+        "by-guard-count": "1.guard_count,1.bandwidth",
         "by-middle-count": "1.middle_count,1.bandwidth",
         "by-first-seen": "1.first_seen,1.bandwidth",
     }

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -316,16 +316,16 @@ class Relays:
         """Determine unit - simple threshold checking"""
         if self.use_bits:
             bits = bandwidth_bytes * 8
-            if bits > 1000000000: # If greater than 1 Gbit/s
+            if bits >= 1000000000: # If greater than or equal to 1 Gbit/s
                 return "Gbit/s"
-            elif bits > 1000000: # If greater than 1 Mbit/s
+            elif bits >= 1000000: # If greater than or equal to 1 Mbit/s
                 return "Mbit/s"
             else:
                 return "Kbit/s"
         else:
-            if bandwidth_bytes > 1000000000: # If greater than 1 GB/s
+            if bandwidth_bytes >= 1000000000: # If greater than or equal to 1 GB/s
                 return "GB/s"
-            elif bandwidth_bytes > 1000000: # If greater than 1 MB/s
+            elif bandwidth_bytes >= 1000000: # If greater than or equal to 1 MB/s
                 return "MB/s"
             else:
                 return "KB/s"
@@ -333,10 +333,10 @@ class Relays:
     def _get_divisor_for_unit(self, unit):
         """Simple dictionary lookup for divisors"""
         divisors = {
-            # Bits
-            "Gbit/s": 8000000000,
-            "Mbit/s": 8000000,
-            "Kbit/s": 8000,
+            # Bits (convert bytes to bits, then to unit)
+            "Gbit/s": 125000000,   # 1000000000 / 8
+            "Mbit/s": 125000,      # 1000000 / 8  
+            "Kbit/s": 125,         # 1000 / 8
             # Bytes  
             "GB/s": 1000000000,
             "MB/s": 1000000,

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -194,6 +194,9 @@ class Relays:
             self.json["sorted"][k][v] = {
                 "relays": list(),
                 "bandwidth": 0,
+                "guard_bandwidth": 0,
+                "middle_bandwidth": 0,
+                "exit_bandwidth": 0,
                 "exit_count": 0,
                 "guard_count": 0,
                 "middle_count": 0,
@@ -207,10 +210,13 @@ class Relays:
 
         if "Exit" in relay["flags"]:
             self.json["sorted"][k][v]["exit_count"] += 1
+            self.json["sorted"][k][v]["exit_bandwidth"] += bw
         elif "Guard" in relay["flags"]:
             self.json["sorted"][k][v]["guard_count"] += 1
+            self.json["sorted"][k][v]["guard_bandwidth"] += bw
         else:
             self.json["sorted"][k][v]["middle_count"] += 1
+            self.json["sorted"][k][v]["middle_bandwidth"] += bw
 
         # Add consensus weight tracking
         if relay.get("consensus_weight"):
@@ -306,30 +312,44 @@ class Relays:
         with open(output, "w", encoding="utf8") as html:
             html.write(template_render)
 
-    def _format_bandwidth(self, bandwidth_bytes):
-        """
-        Format bandwidth according to the unit preference (bits or bytes)
-        
-        Args:
-            bandwidth_bytes: bandwidth value in bytes/second
-        Returns:
-            tuple of (value, unit)
-        """
+    def _determine_unit(self, bandwidth_bytes):
+        """Determine unit - simple threshold checking"""
         if self.use_bits:
-            bandwidth_bits = bandwidth_bytes * 8
-            if bandwidth_bits > 1000000000:  # If greater than 1 Gbit/s
-                return round(bandwidth_bits / 1000000000, 2), "Gbit/s"
-            elif bandwidth_bits > 1000000:  # If greater than 1 Mbit/s
-                return round(bandwidth_bits / 1000000, 2), "Mbit/s"
+            bits = bandwidth_bytes * 8
+            if bits > 1000000000: # If greater than 1 Gbit/s
+                return "Gbit/s"
+            elif bits > 1000000: # If greater than 1 Mbit/s
+                return "Mbit/s"
             else:
-                return round(bandwidth_bits / 1000, 2), "Kbit/s"
+                return "Kbit/s"
         else:
-            if bandwidth_bytes > 1000000000:  # If greater than 1 GB/s
-                return round(bandwidth_bytes / 1000000000, 2), "GB/s"
-            elif bandwidth_bytes > 1000000:  # If greater than 1 MB/s
-                return round(bandwidth_bytes / 1000000, 2), "MB/s"
+            if bandwidth_bytes > 1000000000: # If greater than 1 GB/s
+                return "GB/s"
+            elif bandwidth_bytes > 1000000: # If greater than 1 MB/s
+                return "MB/s"
             else:
-                return round(bandwidth_bytes / 1000, 2), "KB/s"
+                return "KB/s"
+
+    def _get_divisor_for_unit(self, unit):
+        """Simple dictionary lookup for divisors"""
+        divisors = {
+            # Bits
+            "Gbit/s": 8000000000,
+            "Mbit/s": 8000000,
+            "Kbit/s": 8000,
+            # Bytes  
+            "GB/s": 1000000000,
+            "MB/s": 1000000,
+            "KB/s": 1000
+        }
+        if unit in divisors:
+            return divisors[unit]
+        raise ValueError(f"Unknown unit: {unit}")
+
+    def _format_bandwidth_with_unit(self, bandwidth_bytes, unit):
+        """Format bandwidth using specified unit"""
+        divisor = self._get_divisor_for_unit(unit)
+        return round(bandwidth_bytes / divisor, 2)
 
     def write_pages_by_key(self, k):
         """
@@ -380,12 +400,20 @@ class Relays:
             os.makedirs(dir_path)
             self.json["relay_subset"] = members
             
-            bandwidth, bandwidth_unit = self._format_bandwidth(i["bandwidth"])
+            bandwidth_unit = self._determine_unit(i["bandwidth"])
+            # Format all bandwidth values using the same unit
+            bandwidth = self._format_bandwidth_with_unit(i["bandwidth"], bandwidth_unit)
+            guard_bandwidth = self._format_bandwidth_with_unit(i["guard_bandwidth"], bandwidth_unit)
+            middle_bandwidth = self._format_bandwidth_with_unit(i["middle_bandwidth"], bandwidth_unit)
+            exit_bandwidth = self._format_bandwidth_with_unit(i["exit_bandwidth"], bandwidth_unit)
                 
             rendered = template.render(
                 relays=self,
                 bandwidth=bandwidth,
                 bandwidth_unit=bandwidth_unit,
+                guard_bandwidth=guard_bandwidth,
+                middle_bandwidth=middle_bandwidth,
+                exit_bandwidth=exit_bandwidth,
                 exit_count=i["exit_count"],
                 guard_count=i["guard_count"],
                 middle_count=i["middle_count"],

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -195,6 +195,7 @@ class Relays:
                 "relays": list(),
                 "bandwidth": 0,
                 "exit_count": 0,
+                "guard_count": 0,
                 "middle_count": 0,
                 "consensus_weight": 0,
                 "consensus_weight_fraction": 0.0,
@@ -206,6 +207,8 @@ class Relays:
 
         if "Exit" in relay["flags"]:
             self.json["sorted"][k][v]["exit_count"] += 1
+        elif "Guard" in relay["flags"]:
+            self.json["sorted"][k][v]["guard_count"] += 1
         else:
             self.json["sorted"][k][v]["middle_count"] += 1
 
@@ -384,6 +387,7 @@ class Relays:
                 bandwidth=bandwidth,
                 bandwidth_unit=bandwidth_unit,
                 exit_count=i["exit_count"],
+                guard_count=i["guard_count"],
                 middle_count=i["middle_count"],
                 is_index=False,
                 path_prefix="../../",

--- a/allium/templates/as.html
+++ b/allium/templates/as.html
@@ -5,6 +5,11 @@
 {% block header %}<a href="../../">Home</a> :: {{ as_name }} ({{ as_number }}){% endblock %}
 {% block description %}{{ as_number }} is responsible for ~{{ bandwidth }} {{ bandwidth_unit }}
 of traffic, with
+{% if guard_count > 0 %}
+    {{ guard_count }} guard relay
+    {%- if guard_count > 1 -%}s{% endif %}
+    {% if middle_count > 0 or exit_count > 0 %},{% endif %}
+{% endif %}
 {% if middle_count > 0 %}
     {{ middle_count }} middle relay
     {%- if middle_count > 1 -%}s{% endif %}

--- a/allium/templates/as.html
+++ b/allium/templates/as.html
@@ -4,7 +4,21 @@
 {% block title %}Tor Relays :: {{ as_name }} ({{ as_number }}){% endblock %}
 {% block header %}<a href="../../">Home</a> :: {{ as_name }} ({{ as_number }}){% endblock %}
 {% block description %}{{ as_number }} is responsible for ~{{ bandwidth }} {{ bandwidth_unit }}
-of traffic, with
+of traffic
+{%- if guard_count > 0 or middle_count > 0 or exit_count > 0 %} (
+    {%- if guard_count > 0 -%}
+        {{ guard_bandwidth }} {{ bandwidth_unit }} guard
+        {%- if middle_count > 0 or exit_count > 0 %}, {% endif -%}
+    {%- endif -%}
+    {%- if middle_count > 0 -%}
+        {{ middle_bandwidth }} {{ bandwidth_unit }} middle
+        {%- if exit_count > 0 %}, {% endif -%}
+    {%- endif -%}
+    {%- if exit_count > 0 -%}
+        {{ exit_bandwidth }} {{ bandwidth_unit }} exit
+    {%- endif -%}
+)
+{%- endif %}, with
 {% if guard_count > 0 %}
     {{ guard_count }} guard relay
     {%- if guard_count > 1 -%}s{% endif %}

--- a/allium/templates/contact.html
+++ b/allium/templates/contact.html
@@ -11,6 +11,11 @@
     {% block description %}
         Relays with contact info <b>{{ contact }}</b> are
         responsible for ~{{ bandwidth }} {{ bandwidth_unit }} of traffic, with
+        {% if guard_count > 0 %}
+            {{ guard_count }} guard relay
+            {%- if guard_count > 1 -%}s{%- endif -%}
+            {% if middle_count > 0 or exit_count > 0 %},{% endif %}
+        {% endif %}
         {% if middle_count > 0 %}
             {{ middle_count }} middle relay
             {%- if middle_count > 1 -%}s{%- endif -%}

--- a/allium/templates/contact.html
+++ b/allium/templates/contact.html
@@ -10,7 +10,21 @@
     <a href="../../">Home</a> :: Contact {{ contact_hash }}{% endblock %}
     {% block description %}
         Relays with contact info <b>{{ contact }}</b> are
-        responsible for ~{{ bandwidth }} {{ bandwidth_unit }} of traffic, with
+        responsible for ~{{ bandwidth }} {{ bandwidth_unit }} of traffic
+        {%- if guard_count > 0 or middle_count > 0 or exit_count > 0 %} (
+            {%- if guard_count > 0 -%}
+                {{ guard_bandwidth }} {{ bandwidth_unit }} guard
+                {%- if middle_count > 0 or exit_count > 0 %}, {% endif -%}
+            {%- endif -%}
+            {%- if middle_count > 0 -%}
+                {{ middle_bandwidth }} {{ bandwidth_unit }} middle
+                {%- if exit_count > 0 %}, {% endif -%}
+            {%- endif -%}
+            {%- if exit_count > 0 -%}
+                {{ exit_bandwidth }} {{ bandwidth_unit }} exit
+            {%- endif -%}
+        )
+        {%- endif %}, with
         {% if guard_count > 0 %}
             {{ guard_count }} guard relay
             {%- if guard_count > 1 -%}s{%- endif -%}

--- a/allium/templates/country.html
+++ b/allium/templates/country.html
@@ -10,7 +10,21 @@
 {% block header %}<a href="../../">Home</a> :: {{ country_name }}{% endblock %}
 {% block description %}
     {{ country_name }} ({{ country_abbr }}) is responsible
-    for ~{{ bandwidth }} {{ bandwidth_unit }} of traffic, with
+    for ~{{ bandwidth }} {{ bandwidth_unit }} of traffic
+    {%- if guard_count > 0 or middle_count > 0 or exit_count > 0 %} (
+        {%- if guard_count > 0 -%}
+            {{ guard_bandwidth }} {{ bandwidth_unit }} guard
+            {%- if middle_count > 0 or exit_count > 0 %}, {% endif -%}
+        {%- endif -%}
+        {%- if middle_count > 0 -%}
+            {{ middle_bandwidth }} {{ bandwidth_unit }} middle
+            {%- if exit_count > 0 %}, {% endif -%}
+        {%- endif -%}
+        {%- if exit_count > 0 -%}
+            {{ exit_bandwidth }} {{ bandwidth_unit }} exit
+        {%- endif -%}
+    )
+    {%- endif %}, with
     {% if guard_count > 0 %}
         {{ guard_count }} guard relay
         {%- if guard_count > 1 -%}s{%- endif -%}

--- a/allium/templates/country.html
+++ b/allium/templates/country.html
@@ -11,6 +11,11 @@
 {% block description %}
     {{ country_name }} ({{ country_abbr }}) is responsible
     for ~{{ bandwidth }} {{ bandwidth_unit }} of traffic, with
+    {% if guard_count > 0 %}
+        {{ guard_count }} guard relay
+        {%- if guard_count > 1 -%}s{%- endif -%}
+        {% if middle_count > 0 or exit_count > 0 %},{% endif %}
+    {% endif %}
     {% if middle_count > 0 %}
         {{ middle_count }} middle relay
         {%- if middle_count > 1 -%}s{%- endif -%}

--- a/allium/templates/family.html
+++ b/allium/templates/family.html
@@ -7,6 +7,11 @@
     Relays with effective family member
     <code> {{ value|escape }}</code> are responsible for ~{{ bandwidth }} {{ bandwidth_unit }} of
     traffic, with
+    {% if guard_count > 0 %}
+        {{ guard_count }} guard relay
+        {%- if guard_count > 1 -%}s{% endif %}
+        {% if middle_count > 0 or exit_count > 0 %},{% endif %}
+    {% endif %}
     {% if middle_count > 0 %}
         {{ middle_count }} middle relay
         {%- if middle_count > 1 -%}s{% endif %}

--- a/allium/templates/family.html
+++ b/allium/templates/family.html
@@ -6,7 +6,21 @@
 {% block description %}
     Relays with effective family member
     <code> {{ value|escape }}</code> are responsible for ~{{ bandwidth }} {{ bandwidth_unit }} of
-    traffic, with
+    traffic
+    {%- if guard_count > 0 or middle_count > 0 or exit_count > 0 %} (
+        {%- if guard_count > 0 -%}
+            {{ guard_bandwidth }} {{ bandwidth_unit }} guard
+            {%- if middle_count > 0 or exit_count > 0 %}, {% endif -%}
+        {%- endif -%}
+        {%- if middle_count > 0 -%}
+            {{ middle_bandwidth }} {{ bandwidth_unit }} middle
+            {%- if exit_count > 0 %}, {% endif -%}
+        {%- endif -%}
+        {%- if exit_count > 0 -%}
+            {{ exit_bandwidth }} {{ bandwidth_unit }} exit
+        {%- endif -%}
+    )
+    {%- endif %}, with
     {% if guard_count > 0 %}
         {{ guard_count }} guard relay
         {%- if guard_count > 1 -%}s{% endif %}

--- a/allium/templates/first_seen.html
+++ b/allium/templates/first_seen.html
@@ -3,7 +3,26 @@
 {% block header %}<a href="../../">Home</a> :: {{ value }}{% endblock %}
 {% block description %}
     Relays started on {{ value }} are responsible for ~{{
-    bandwidth }} {{ bandwidth_unit }} of traffic, with
+    bandwidth }} {{ bandwidth_unit }} of traffic
+    {%- if guard_count > 0 or middle_count > 0 or exit_count > 0 %} (
+        {%- if guard_count > 0 -%}
+            {{ guard_bandwidth }} {{ bandwidth_unit }} guard
+            {%- if middle_count > 0 or exit_count > 0 %}, {% endif -%}
+        {%- endif -%}
+        {%- if middle_count > 0 -%}
+            {{ middle_bandwidth }} {{ bandwidth_unit }} middle
+            {%- if exit_count > 0 %}, {% endif -%}
+        {%- endif -%}
+        {%- if exit_count > 0 -%}
+            {{ exit_bandwidth }} {{ bandwidth_unit }} exit
+        {%- endif -%}
+    )
+    {%- endif %}, with
+    {% if guard_count > 0 %}
+        {{ guard_count }} guard relay
+        {%- if guard_count > 1 -%}s{%- endif %}
+        {% if middle_count > 0 or exit_count > 0 %},{% endif %}
+    {% endif %}
     {% if middle_count > 0 %}
         {{ middle_count }}
         middle relay

--- a/allium/templates/flag.html
+++ b/allium/templates/flag.html
@@ -5,7 +5,21 @@
     endblock %}
     {% block description %}
         Relays with the {{ value }} flag are responsible for ~{{
-        bandwidth }} {{ bandwidth_unit }} of traffic, with
+        bandwidth }} {{ bandwidth_unit }} of traffic
+        {%- if guard_count > 0 or middle_count > 0 or exit_count > 0 %} (
+            {%- if guard_count > 0 -%}
+                {{ guard_bandwidth }} {{ bandwidth_unit }} guard
+                {%- if middle_count > 0 or exit_count > 0 %}, {% endif -%}
+            {%- endif -%}
+            {%- if middle_count > 0 -%}
+                {{ middle_bandwidth }} {{ bandwidth_unit }} middle
+                {%- if exit_count > 0 %}, {% endif -%}
+            {%- endif -%}
+            {%- if exit_count > 0 -%}
+                {{ exit_bandwidth }} {{ bandwidth_unit }} exit
+            {%- endif -%}
+        )
+        {%- endif %}, with
         {% if guard_count > 0 %}
             {{ guard_count }} guard relay
             {%- if guard_count > 1 -%}s{%- endif %}

--- a/allium/templates/flag.html
+++ b/allium/templates/flag.html
@@ -6,6 +6,11 @@
     {% block description %}
         Relays with the {{ value }} flag are responsible for ~{{
         bandwidth }} {{ bandwidth_unit }} of traffic, with
+        {% if guard_count > 0 %}
+            {{ guard_count }} guard relay
+            {%- if guard_count > 1 -%}s{%- endif %}
+            {% if middle_count > 0 or exit_count > 0 %},{% endif %}
+        {% endif %}
         {% if middle_count > 0 %}
             {{ middle_count }}
             middle relay

--- a/allium/templates/misc-families.html
+++ b/allium/templates/misc-families.html
@@ -19,11 +19,15 @@
         <tr>
             <th>Family</th>
             {% if sorted_by_label == 'bandwidth' -%}
-                <th>Bandwidth</th>
+                <th>Overall / <a href="families-by-guard-bandwidth.html">Guard</a> / <a href="families-by-middle-bandwidth.html">Middle</a> / <a href="families-by-exit-bandwidth.html">Exit</a> Bandwidth</th>
+            {% elif sorted_by_label == 'guard_bandwidth' -%}
+                <th><a href="families-by-overall-bandwidth.html">Overall</a> / Guard / <a href="families-by-middle-bandwidth.html">Middle</a> / <a href="families-by-exit-bandwidth.html">Exit</a> Bandwidth</th>
+            {% elif sorted_by_label == 'middle_bandwidth' -%}
+                <th><a href="families-by-overall-bandwidth.html">Overall</a> / <a href="families-by-guard-bandwidth.html">Guard</a> / Middle / <a href="families-by-exit-bandwidth.html">Exit</a> Bandwidth</th>
+            {% elif sorted_by_label == 'exit_bandwidth' -%}
+                <th><a href="families-by-overall-bandwidth.html">Overall</a> / <a href="families-by-guard-bandwidth.html">Guard</a> / <a href="families-by-middle-bandwidth.html">Middle</a> / Exit Bandwidth</th>
             {% else -%}
-                <th>
-                    <a href="families-by-bandwidth.html">Bandwidth</a>
-                </th>
+                <th><a href="families-by-overall-bandwidth.html">Overall</a> / <a href="families-by-guard-bandwidth.html">Guard</a> / <a href="families-by-middle-bandwidth.html">Middle</a> / <a href="families-by-exit-bandwidth.html">Exit</a> Bandwidth</th>
             {% endif -%}
             {% if sorted_by_label == 'consensus_weight_fraction' -%}
                 <th>Consensus Weight</th>
@@ -39,7 +43,7 @@
                 </th>
             {% elif sorted_by_label == 'guard_count' -%}
                 <th>
-                    Guard / <a href="families-by-guard-count.html">Middle</a> / <a href="families-by-exit-count.html">Exit</a>
+                    Guard / <a href="families-by-middle-count.html">Middle</a> / <a href="families-by-exit-count.html">Exit</a>
                 </th>
             {% elif sorted_by_label == 'middle_count' -%}
                 <th>
@@ -47,7 +51,7 @@
                 </th>
             {% else -%}
                 <th>
-                    <a href="families-by-guard-count.html">Guard</a>  / <a href="families-by-guard-count.html">Middle</a> / <a href="families-by-exit-count.html">Exit</a>
+                    <a href="families-by-guard-count.html">Guard</a>  / <a href="families-by-middle-count.html">Middle</a> / <a href="families-by-exit-count.html">Exit</a>
                 </th>
             {% endif -%}
             {% if sorted_by_label == 'first_seen' -%}
@@ -64,13 +68,16 @@
                 reverse=True) -%}
                 {% if relays.json['relays'][v['relays'][0]]['fingerprint'] not in processed -%}
                     <tr>
-                        {% set obs_bandwidth, obs_unit = relays._format_bandwidth(v['bandwidth']) -%}
-                        {% set obs_bandwidth = '%s %s'|format(obs_bandwidth, obs_unit) -%}
+                        {% set obs_unit = relays._determine_unit(v['bandwidth']) -%}
+                        {% set obs_bandwidth = relays._format_bandwidth_with_unit(v['bandwidth'], obs_unit) -%}
+                        {% set guard_bw = relays._format_bandwidth_with_unit(v['guard_bandwidth'], obs_unit) -%}
+                        {% set middle_bw = relays._format_bandwidth_with_unit(v['middle_bandwidth'], obs_unit) -%}
+                        {% set exit_bw = relays._format_bandwidth_with_unit(v['exit_bandwidth'], obs_unit) -%}
                         <td>
                             <code><a href="{{ path_prefix }}family/{{ k|escape }}/">{{ k|escape
                             }}</a></code>
                         </td>
-                        <td>{{ obs_bandwidth }}</td>
+                        <td>{{ obs_bandwidth }} / {{ guard_bw }} / {{ middle_bw }} / {{ exit_bw }} {{ obs_unit }}</td>
                         <td>{{ "%.2f%%"|format(v['consensus_weight_fraction'] * 100)|default('N/A') }}</td>
                         {% if v['contact'] -%}
                             <td class="visible-md visible-lg">

--- a/allium/templates/misc-families.html
+++ b/allium/templates/misc-families.html
@@ -35,15 +35,19 @@
             <th class="visible-md visible-lg">Contact</th>
             {% if sorted_by_label == 'exit_count' -%}
                 <th>
-                    Exit / <a href="families-by-middle-count.html">Middle</a>
+                    <a href="families-by-guard-count.html">Guard</a> / <a href="families-by-middle-count.html">Middle</a> / Exit
+                </th>
+            {% elif sorted_by_label == 'guard_count' -%}
+                <th>
+                    Guard / <a href="families-by-guard-count.html">Middle</a> / <a href="families-by-exit-count.html">Exit</a>
                 </th>
             {% elif sorted_by_label == 'middle_count' -%}
                 <th>
-                    <a href="families-by-exit-count.html">Exit</a> / Middle
+                    <a href="families-by-guard-count.html">Guard</a> / Middle / <a href="families-by-exit-count.html">Exit</a>
                 </th>
             {% else -%}
                 <th>
-                    <a href="families-by-exit-count.html">Exit</a> / <a href="families-by-middle-count.html">Middle</a>
+                    <a href="families-by-guard-count.html">Guard</a>  / <a href="families-by-guard-count.html">Middle</a> / <a href="families-by-exit-count.html">Exit</a>
                 </th>
             {% endif -%}
             {% if sorted_by_label == 'first_seen' -%}
@@ -76,7 +80,7 @@
                         {% else -%}
                             <td class="visible-md visible-lg">none</td>
                         {% endif -%}
-                        <td>{{ v['exit_count'] }} / {{ v['middle_count'] }}</td>
+                        <td>{{ v['guard_count'] }} / {{ v['middle_count'] }} / {{ v['exit_count'] }}</td>
                         <td>
                             <a href="{{ path_prefix }}first_seen/{{ v['first_seen'].split(' ', 1)[0]|escape }}">{{ v['first_seen'].split(' ', 1)[0]|escape }}</a>
                         </td>

--- a/allium/templates/misc-networks.html
+++ b/allium/templates/misc-networks.html
@@ -30,15 +30,19 @@
             {% endif -%}
             {% if sorted_by_label == 'exit_count' -%}
                 <th>
-                    Exit / <a href="networks-by-middle-count.html">Middle</a>
+                    <a href="networks-by-guard-count.html">Guard</a> / <a href="networks-by-middle-count.html">Middle</a> / Exit
+                </th>
+            {% elif sorted_by_label == 'guard_count' -%}
+                <th>
+                    Guard / <a href="networks-by-middle-count.html">Middle</a> / <a href="networks-by-exit-count.html">Exit</a>
                 </th>
             {% elif sorted_by_label == 'middle_count' -%}
                 <th>
-                    <a href="networks-by-exit-count.html">Exit</a> / Middle
+                    <a href="networks-by-guard-count.html">Guard</a> / Middle / <a href="networks-by-exit-count.html">Exit</a>
                 </th>
             {% else -%}
                 <th>
-                    <a href="networks-by-exit-count.html">Exit</a> / <a href="networks-by-middle-count.html">Middle</a>
+                    <a href="networks-by-guard-count.html">Guard</a> / <a href="networks-by-middle-count.html">Middle</a> / <a href="networks-by-exit-count.html">Exit</a>
                 </th>
             {% endif -%}
         </tr>
@@ -70,7 +74,7 @@
                         <td>X</td>
                     {% endif -%}
                     <td>{{ obs_bandwidth }}</td>
-                    <td>{{ v['exit_count'] }} / {{ v['middle_count'] }}</td>
+                    <td>{{ v['guard_count'] }} / {{ v['middle_count'] }} / {{ v['exit_count'] }}</td>
                 </tr>
             {% endfor -%}
         </tbody>

--- a/allium/templates/misc-networks.html
+++ b/allium/templates/misc-networks.html
@@ -22,10 +22,21 @@
             <th>AS Name</th>
             <th>Country</th>
             {% if sorted_by_label == 'bandwidth' -%}
-                <th>Bandwidth</th>
+                <th>Overall / <a href="networks-by-guard-bandwidth.html">Guard</a> / <a href="networks-by-middle-bandwidth.html">Middle</a> / <a href="networks-by-exit-bandwidth.html">Exit</a> Bandwidth</th>
+            {% elif sorted_by_label == 'guard_bandwidth' -%}
+                <th><a href="networks-by-overall-bandwidth.html">Overall</a> / Guard / <a href="networks-by-middle-bandwidth.html">Middle</a> / <a href="networks-by-exit-bandwidth.html">Exit</a> Bandwidth</th>
+            {% elif sorted_by_label == 'middle_bandwidth' -%}
+                <th><a href="networks-by-overall-bandwidth.html">Overall</a> / <a href="networks-by-guard-bandwidth.html">Guard</a> / Middle / <a href="networks-by-exit-bandwidth.html">Exit</a> Bandwidth</th>
+            {% elif sorted_by_label == 'exit_bandwidth' -%}
+                <th><a href="networks-by-overall-bandwidth.html">Overall</a> / <a href="networks-by-guard-bandwidth.html">Guard</a> / <a href="networks-by-middle-bandwidth.html">Middle</a> / Exit Bandwidth</th>
+            {% else -%}
+                <th><a href="networks-by-overall-bandwidth.html">Overall</a> / <a href="networks-by-guard-bandwidth.html">Guard</a> / <a href="networks-by-middle-bandwidth.html">Middle</a> / <a href="networks-by-exit-bandwidth.html">Exit</a> Bandwidth</th>
+            {% endif -%}
+            {% if sorted_by_label == 'consensus_weight_fraction' -%}
+                <th>Consensus Weight</th>
             {% else -%}
                 <th>
-                    <a href="networks-by-bandwidth.html">Bandwidth</a>
+                    <a href="networks-by-consensus-weight.html">Consensus Weight</a>
                 </th>
             {% endif -%}
             {% if sorted_by_label == 'exit_count' -%}
@@ -50,8 +61,11 @@
             {% for k, v in relays.json['sorted']['as'].items()|sort(attribute=sorted_by,
                 reverse=True) -%}
                 <tr>
-                    {% set obs_bandwidth, obs_unit = relays._format_bandwidth(v['bandwidth']) -%}
-                    {% set obs_bandwidth = '%s %s'|format(obs_bandwidth, obs_unit) -%}
+                    {% set obs_unit = relays._determine_unit(v['bandwidth']) -%}
+                    {% set obs_bandwidth = relays._format_bandwidth_with_unit(v['bandwidth'], obs_unit) -%}
+                    {% set guard_bw = relays._format_bandwidth_with_unit(v['guard_bandwidth'], obs_unit) -%}
+                    {% set middle_bw = relays._format_bandwidth_with_unit(v['middle_bandwidth'], obs_unit) -%}
+                    {% set exit_bw = relays._format_bandwidth_with_unit(v['exit_bandwidth'], obs_unit) -%}
                     <td>
                         <a href="{{ path_prefix }}as/{{ k|escape }}/">{{ k|escape }}</a>
                     </td>
@@ -73,7 +87,12 @@
                     {% else -%}
                         <td>X</td>
                     {% endif -%}
-                    <td>{{ obs_bandwidth }}</td>
+                    {% if v['bandwidth'] == 0 -%}
+                        <td>0 / 0 / 0 / 0 {{ obs_unit }}</td>
+                    {% else -%}
+                        <td>{{ obs_bandwidth }} / {{ guard_bw }} / {{ middle_bw }} / {{ exit_bw }} {{ obs_unit }}</td>
+                    {% endif -%}
+                    <td>{{ "%.2f%%"|format(v['consensus_weight_fraction'] * 100)|default('N/A') }}</td>
                     <td>{{ v['guard_count'] }} / {{ v['middle_count'] }} / {{ v['exit_count'] }}</td>
                 </tr>
             {% endfor -%}

--- a/allium/templates/platform.html
+++ b/allium/templates/platform.html
@@ -4,7 +4,21 @@
 {% block header %}<a href="../../">Home</a> :: {{ platform }}{% endblock %}
 {% block description %}
     {{ platform }} systems are responsible for ~{{ bandwidth
-    }} {{ bandwidth_unit }} of traffic, with
+    }} {{ bandwidth_unit }} of traffic
+    {%- if guard_count > 0 or middle_count > 0 or exit_count > 0 %} (
+        {%- if guard_count > 0 -%}
+            {{ guard_bandwidth }} {{ bandwidth_unit }} guard
+            {%- if middle_count > 0 or exit_count > 0 %}, {% endif -%}
+        {%- endif -%}
+        {%- if middle_count > 0 -%}
+            {{ middle_bandwidth }} {{ bandwidth_unit }} middle
+            {%- if exit_count > 0 %}, {% endif -%}
+        {%- endif -%}
+        {%- if exit_count > 0 -%}
+            {{ exit_bandwidth }} {{ bandwidth_unit }} exit
+        {%- endif -%}
+    )
+    {%- endif %}, with
     {% if guard_count > 0 %}
         {{ guard_count }} guard relay
         {%- if guard_count > 1 -%}s{%- endif %}

--- a/allium/templates/platform.html
+++ b/allium/templates/platform.html
@@ -5,6 +5,11 @@
 {% block description %}
     {{ platform }} systems are responsible for ~{{ bandwidth
     }} {{ bandwidth_unit }} of traffic, with
+    {% if guard_count > 0 %}
+        {{ guard_count }} guard relay
+        {%- if guard_count > 1 -%}s{%- endif %}
+        {% if middle_count > 0 or exit_count > 0 %},{% endif %}
+    {% endif %}
     {% if middle_count > 0 %}
         {{ middle_count }} middle
         relay

--- a/allium/templates/relay-info.html
+++ b/allium/templates/relay-info.html
@@ -67,10 +67,10 @@ none
 <dt>
 Observed Bandwidth
 </dt>
-{% set obs_bandwidth, obs_unit = relays._format_bandwidth(relay['observed_bandwidth']) -%}
-{% set obs_bandwidth = '%s %s'|format(obs_bandwidth, obs_unit) -%}
+{% set obs_unit = relays._determine_unit(relay['observed_bandwidth']) -%}
+{% set obs_bandwidth = relays._format_bandwidth_with_unit(relay['observed_bandwidth'], obs_unit) -%}
 <dd>
-{{ obs_bandwidth }}
+{{ obs_bandwidth }} {{ obs_unit }}
 </dd>
 <dt>
 IPv4 Exit Policy Summary

--- a/allium/templates/relay-list.html
+++ b/allium/templates/relay-list.html
@@ -34,8 +34,8 @@ Last fetch was at {{ relays.timestamp }}.
     {% endif -%}
     {% for relay in relay_list -%}
 	<tr>
-	    {% set obs_bandwidth, obs_unit = relays._format_bandwidth(relay['observed_bandwidth']) -%}
-	    {% set obs_bandwidth = '%s %s'|format(obs_bandwidth, obs_unit) -%}
+	    {% set obs_unit = relays._determine_unit(relay['observed_bandwidth']) -%}
+	    {% set obs_bandwidth = relays._format_bandwidth_with_unit(relay['observed_bandwidth'], obs_unit) -%}
 	    {% if relay['running'] -%}
 		<td>
 		    <span class="circle circle-online" title="This relay is online"></span>
@@ -73,7 +73,7 @@ Last fetch was at {{ relays.timestamp }}.
 			<span class="contact-text">{{ relay['contact_aroi_display']|escape }}</span>
 		    </td>
 		{% endif -%}
-		<td>{{ obs_bandwidth }}</td>
+		<td>{{ obs_bandwidth }} {{ obs_unit }}</td>
 		<td class="visible-md visible-lg">
 		    <a href="https://bgp.tools/prefix/{{ relay['or_addresses'][0].split(':', 1)[0]|escape }}">{{
 		    relay['or_addresses'][0].split(':', 1)[0]|escape }}</a>


### PR DESCRIPTION
## Summary
Adds comprehensive bandwidth tracking and sorting functionality with separate tracking for guard, middle, and exit relay bandwidth.

## Changes (4 commits)
- **Part 1/3**: Backend bandwidth tracking + sorting configuration  
- **Part 2/3**: Interactive bandwidth column headers with sorting links
- **Part 3/3**: Complete template updates and conditional bandwidth display
- **Fix**: Bandwidth unit calculation and boundary conditions

## Features Added
- ✅ Track guard/middle/exit bandwidth separately 
- ✅ Sort by overall/guard/middle/exit bandwidth
- ✅ Interactive column headers with sorting links
- ✅ Conditional bandwidth display (only show relevant breakdowns)
- ✅ Clean bandwidth formatting functions
- ✅ Support for both bits/second and bytes/second modes

## Testing
- [x] Bandwidth calculations verified for both bits and bytes modes
- [x] All templates updated with new formatting functions
- [x] Sorting links work correctly
- [x] Conditional display shows only relevant bandwidth types