### PR TITLE
Update AROI Leaderboard documentation for category consistency

### DIFF
--- a/docs/features/aroi-leaderboard/README.md
+++ b/docs/features/aroi-leaderboard/README.md
@@ -13,7 +13,7 @@
 - **Size**: ~19KB, comprehensive specification with examples
 
 **Key Features:**
-- 🏆 **12 Ranking Categories**: Bandwidth, consensus weight, exit/guard operators, diversity, efficiency
+- 🏆 **10 Ranking Categories**: Bandwidth, consensus weight, exit/guard operators, diversity, efficiency
 - 📊 **Live Dashboard**: Real-time leaderboard with champion badges and achievements
 - 🌍 **Geographic Analysis**: Global diversity tracking and frontier country pioneers
 - ⚡ **Performance Metrics**: Efficiency ratios, uptime tracking, and technical excellence
@@ -28,10 +28,9 @@
 - **Size**: ~7.7KB, technical analysis with implementation roadmap
 
 **Key Analysis:**
-- ✅ **Ready Categories**: 7/12 categories implementable immediately with existing data
-- ⚠️ **Calculation Required**: 3/12 categories need new algorithms but data is available
-- ❌ **New Data Needed**: 2/12 categories require additional data sources
-- 🎯 **Implementation Priority**: Tiered approach with 58% immediate deployment capability
+- ✅ **Ready Categories**: 7/10 categories implementable immediately with existing data
+- ⚠️ **Calculation Required**: 3/10 categories need new algorithms but data is available
+- 🎯 **Implementation Priority**: Tiered approach with 70% immediate deployment capability
 
 ## 🎯 System Overview
 
@@ -43,7 +42,7 @@ The AROI Leaderboard System provides:
 - **Duplicate Prevention**: Accurate operator representation without double-counting
 
 ### **Performance Ranking**
-- **Multi-Category Analysis**: 12 distinct ranking categories covering all aspects of relay operation
+- **Multi-Category Analysis**: 10 distinct ranking categories covering all aspects of relay operation
 - **Real-Time Updates**: Live ranking updates based on current network status
 - **Achievement System**: Champion badges and recognition for top performers
 
@@ -56,18 +55,16 @@ The AROI Leaderboard System provides:
 
 | Category | Status | Data Available | Implementation |
 |----------|--------|----------------|----------------|
-| **Bandwidth Leaders** | ✅ Ready | Yes | Immediate |
+| **Bandwidth Contributed** | ✅ Ready | Yes | Immediate |
 | **Consensus Weight** | ✅ Ready | Yes | Immediate |
+| **Exit Authority Champions** | ✅ Ready | Yes | Immediate |
 | **Exit Operators** | ✅ Ready | Yes | Immediate |
 | **Guard Operators** | ✅ Ready | Yes | Immediate |
+| **Most Diverse Operators** | ✅ Ready | Yes | Immediate |
 | **Platform Diversity** | ✅ Ready | Yes | Immediate |
 | **Geographic Champions** | ✅ Ready | Yes | Immediate |
-| **BSD Technical Leaders** | ✅ Ready | Yes | Immediate |
-| **Efficiency Champions** | ⚠️ Calculation | Yes | Simple Ratio |
 | **Frontier Builders** | ⚠️ Calculation | Yes | Rarity Analysis |
-| **Diversity Leaders** | ⚠️ Calculation | Yes | Multi-Factor |
-| **Network Veterans** | ❌ New Data | Partial | Uptime History |
-| **Stability Champions** | ❌ New Data | Limited | Historical Data |
+| **Network Veterans** | ⚠️ Calculation | Yes | Veteran Scoring |
 
 ## 🏁 Frontier Builders Rarity Scoring System
 

--- a/docs/proposals/aroi_leaderboard_data_analysis.md
+++ b/docs/proposals/aroi_leaderboard_data_analysis.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-This document analyzes the data requirements for implementing the Top 10 AROI Operator Leaderboard by comparing the proposed categories against available Onionoo API data and current allium processing capabilities.
+This document analyzes the data requirements for implementing the Top 10 AROI Operator Leaderboard by comparing the implemented categories against available Onionoo API data and current allium processing capabilities.
 
 ## Methodology
 
@@ -45,53 +45,37 @@ Analysis based on:
 - **AROI Grouping**: Can group by contact and count non-Linux platforms
 - **Implementation**: Count relays per AROI where `platform != "Linux"`
 
-#### 6. **Technical Leaders (BSD Operators)** ✅
-- **Data Available**: `platform` field with BSD variant detection
-- **Aggregation**: BSD platform detection already implemented (FreeBSD, OpenBSD, NetBSD)
-- **AROI Grouping**: Can group by contact and count BSD platforms
-- **Implementation**: Count relays per AROI where `platform` contains BSD variants
+#### 6. **Exit Authority Champions** ✅
+- **Data Available**: Exit consensus weight calculation via `exit_consensus_weight_fraction`
+- **Aggregation**: Exit authority weight already implemented in contact aggregations
+- **AROI Grouping**: Functional via contact hash grouping
+- **Implementation**: Sum exit consensus weight for all relays per AROI contact
 
-#### 7. **Geographic Champions (Non-EU Leaders)** ✅
-- **Data Available**: `country` and `country_name` fields from Onionoo
-- **Aggregation**: Country-based grouping already implemented
-- **AROI Grouping**: Can group by contact and identify primary countries
-- **Implementation**: Group by AROI contact, identify non-EU countries per operator
+#### 7. **Most Diverse Operators** ✅
+- **Data Available**: `country`, `platform`, `as` (AS number) fields available
+- **Aggregation**: Multi-factor diversity scoring already implemented
+- **AROI Grouping**: Functional via contact hash grouping
+- **Implementation**: Multi-factor diversity calculation per AROI operator
 
 ### **PARTIALLY SUPPORTED (Requires New Calculations)**
 
-#### 8. **Efficiency Champions (High CW/Bandwidth Ratio)** ⚠️
-- **Data Available**: Both `consensus_weight_fraction` and `observed_bandwidth` available
-- **Calculation Needed**: New ratio calculation (CW/BW ratio per AROI)
-- **AROI Grouping**: Functional via contact hash grouping
-- **Implementation**: Calculate efficiency ratio = total_consensus_weight / total_bandwidth per AROI
-
-#### 9. **Frontier Builders (Rare Countries)** ⚠️
+#### 8. **Frontier Builders (Rare Countries)** ⚠️
 - **Data Available**: `country` field available from Onionoo
 - **Calculation Needed**: "Rarity scoring" algorithm for countries (frequency analysis)
 - **AROI Grouping**: Functional via contact hash grouping
 - **Implementation**: Analyze country frequency across all relays, score operators in rare countries
 
-#### 10. **Most Diverse Operators** ⚠️
-- **Data Available**: `country`, `platform`, `as` (AS number) fields available
-- **Calculation Needed**: Complex diversity scoring algorithm (30% geo, 25% platform, 20% ASN, 25% underrepresented)
+#### 9. **Geographic Champions (Non-EU Leaders)** ⚠️
+- **Data Available**: `country` and `country_name` fields from Onionoo
+- **Calculation Needed**: Non-EU country identification and counting
 - **AROI Grouping**: Functional via contact hash grouping
-- **Implementation**: Multi-factor diversity calculation per AROI operator
+- **Implementation**: Group by AROI contact, identify and count non-EU countries per operator
 
-### **REQUIRES NEW DATA/CALCULATIONS**
-
-#### 11. **Network Veterans (Longest Operating)** ❌
+#### 10. **Network Veterans (Longest Operating)** ⚠️
 - **Data Available**: `first_seen` field available from Onionoo
-- **Current Issue**: Need historical data analysis or "longest operating" definition
+- **Calculation Needed**: Earliest first seen time calculation with relay scale weighting
 - **AROI Grouping**: Functional via contact hash grouping
-- **Gap**: Need to define "longest operating" vs "earliest first_seen" vs "consistent operation"
-- **Implementation**: Use `first_seen` dates per AROI, but may need uptime consistency analysis
-
-#### 12. **Diamond Stability (Highest Uptime)** ❌
-- **Data Limited**: Onionoo provides `running` status but no historical uptime percentage
-- **Missing Data**: No access to uptime history documents in current implementation
-- **AROI Grouping**: Functional via contact hash grouping
-- **Gap**: Would need Onionoo uptime documents (`/uptime` endpoint) integration
-- **Implementation**: Requires new data source or approximation using `running` status
+- **Implementation**: Use `first_seen` dates per AROI with veteran scoring algorithm
 
 ## AROI Processing Status ✅
 
@@ -109,17 +93,13 @@ Analysis based on:
 3. **Exit Operators** - Direct data available
 4. **Guard Operators** - Direct data available
 5. **Platform Diversity (Non-Linux Heroes)** - Direct data available
-6. **Technical Leaders (BSD Operators)** - Direct data available
-7. **Geographic Champions (Non-EU Leaders)** - Direct data available
+6. **Exit Authority Champions** - Direct data available
+7. **Most Diverse Operators** - Direct data available
 
 ### **Tier 2: Quick Implementation (Simple Calculations)**
-8. **Efficiency Champions** - Simple ratio calculation
-9. **Frontier Builders** - Country frequency analysis required
-10. **Most Diverse Operators** - Complex multi-factor scoring required
-
-### **Tier 3: Requires New Data Integration**
-11. **Network Veterans** - May work with `first_seen` approximation
-12. **Diamond Stability** - Requires Onionoo uptime documents integration
+8. **Frontier Builders** - Country frequency analysis required
+9. **Geographic Champions (Non-EU Leaders)** - Geographic analysis required
+10. **Network Veterans** - Veteran scoring algorithm required
 
 ## Recommendations
 
@@ -140,12 +120,11 @@ Analysis based on:
 
 ## Data Confidence Assessment
 
-- **High Confidence (Tier 1)**: 7/12 categories ready for immediate deployment
-- **Medium Confidence (Tier 2)**: 3/12 categories require calculations but data available  
-- **Low Confidence (Tier 3)**: 2/12 categories may require new data sources
+- **High Confidence (Tier 1)**: 7/10 categories ready for immediate deployment
+- **Medium Confidence (Tier 2)**: 3/10 categories require calculations but data is available
 
 ## Conclusion
 
-**58% of leaderboard categories (7/12)** can be implemented immediately with existing data and processing capabilities. The AROI operator grouping system is fully functional and ready for leaderboard implementation.
+**70% of leaderboard categories (7/10)** can be implemented immediately with existing data and processing capabilities. The AROI operator grouping system is fully functional and ready for leaderboard implementation.
 
-Priority should focus on deploying the 7 ready categories first, then iteratively adding the calculation-required categories, and finally investigating uptime data integration for completeness. 
+Priority should focus on deploying the 7 ready categories first, then iteratively adding the calculation-required categories for full implementation. 


### PR DESCRIPTION
Documentation was updated to resolve inconsistencies regarding the number of AROI leaderboard categories. Previously, `docs/features/aroi-leaderboard/README.md` and `docs/proposals/aroi_leaderboard_data_analysis.md` stated 12 categories, while the actual implementation contained 10.

Changes made to align documentation with the 10 implemented categories:

*   In `docs/features/aroi-leaderboard/README.md`:
    *   References to "12 Ranking Categories" were changed to "10 Ranking Categories".
    *   The "Multi-Category Analysis" count was updated from 12 to 10.
    *   The implementation status table was revised to list the 10 actual categories, removing "BSD Technical Leaders", "Efficiency Champions", and "Stability Champions".
    *   Data availability and deployment capability percentages were adjusted from "7/12" to "7/10" and "58%" to "70%".

*   In `docs/proposals/aroi_leaderboard_data_analysis.md`:
    *   All mentions of 12 categories were updated to 10.
    *   Analysis sections were re-aligned to reflect the 10 implemented categories, including "Exit Authority Champions" and "Most Diverse Operators", and reclassifying "Network Veterans" as "⚠️ Calculation".
    *   Confidence assessments and conclusion percentages were updated to reflect the 10-category count.

This ensures documentation accurately reflects the current system.