### PR TITLE
Fix network position display

### DIFF
--- a/allium/templates/contact.html
+++ b/allium/templates/contact.html
@@ -68,7 +68,7 @@
                         {% endif %}
                     </li>
                     
-                    <li><strong><span title="Network position indicates the strategic role distribution of relays. Labels: Guard-focused (>60% guard), Exit-focused (>40% exit), Multi-role (both guard and exit >20%), Balanced (mixed roles), Guard-only (100% guard), Exit-only (100% exit), Middle-only (100% middle)">Network Position</span>:</strong> {{ network_position }}</li>
+                    <li><strong><span title="Network position indicates the strategic role distribution of relays. Labels: Guard-focused (>60% guard), Exit-focused (>40% exit), Multi-role (both guard and exit >20%), Balanced (mixed roles), Guard-only (100% guard), Exit-only (100% exit), Middle-only (100% middle)">Network Position</span>:</strong> {{ network_position.formatted_string }}</li>
                 </ul>
             </div>
         </div>

--- a/tests/test_integration_contact_template.py
+++ b/tests/test_integration_contact_template.py
@@ -39,7 +39,14 @@ class TestContactTemplateIntegration(unittest.TestCase):
             'bandwidth': '150.0',
             'bandwidth_unit': 'MB/s',
             'consensus_weight_fraction': 0.025,  # 2.5%
-            'network_position': 'Mixed (5 total relays, 2 guards, 1 middle, 2 exits)',
+            'network_position': {
+                'label': 'mixed',
+                'percentage_breakdown': '40% guard, 20% middle, 40% exit',
+                'formatted_string': 'Mixed (5 total relays, 2 guards, 1 middle, 2 exits)',
+                'guard_percentage': 40,
+                'middle_percentage': 20,
+                'exit_percentage': 40
+            },
             'relays': {
                 'json': {
                     'relay_subset': [{

--- a/tests/test_uptime_utils.py
+++ b/tests/test_uptime_utils.py
@@ -340,8 +340,13 @@ class TestConsolidatedProcessing(unittest.TestCase):
             consolidated_uptime = consolidated_result['relay_uptime_data'].get(fingerprint, {}).get('1_month')
             if consolidated_uptime is not None:
                 self.assertAlmostEqual(
-                    individual_uptime, consolidated_uptime, places=2,
-                    f"Mismatch for {fingerprint}: individual={individual_uptime}, consolidated={consolidated_uptime}"
+                    individual_uptime,
+                    consolidated_uptime,
+                    places=2,
+                    msg=(
+                        f"Mismatch for {fingerprint}: individual={individual_uptime},"
+                        f" consolidated={consolidated_uptime}"
+                    )
                 )
     
     def test_consolidated_processing_with_flag_analysis(self):


### PR DESCRIPTION
## Summary
- show network position text instead of dict on operator pages
- adjust integration test context
- fix unit test assertion syntax

## Testing
- `pytest -q` *(fails: ModuleNotFoundError, network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6853c6ed3fa8832fb9cbebab49ea8542