### PR TITLE
Fix CI/CD issue: Handle uptime_data=None in directory authorities gen…

### DIFF
--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -1527,7 +1527,7 @@ class Relays:
                 'problem_uptime': problem_uptime
             },
             'authority_network_stats': authority_network_stats,  # Include for template access
-            'uptime_metadata': getattr(self, 'uptime_data', {}).get('relays_published', 'Unknown')
+            'uptime_metadata': (getattr(self, 'uptime_data', {}) or {}).get('relays_published', 'Unknown')
         }
 
     def _determine_unit(self, bandwidth_bytes):


### PR DESCRIPTION
…eration

- Fixed AttributeError in _get_directory_authorities_data when uptime_data is None
- Directory authority pages now populate with 'Unknown' metadata when running with --apis details
- Ensures compatibility with command line option to run without uptime API data
- Added defensive handling: (getattr(self, 'uptime_data', {}) or {}).get('relays_published', 'Unknown')
- Validated fix with unit tests - authorities tests still pass

Fixes the CI/CD failure where directory authorities generation crashed when uptime API doesn't return data, now honors the --apis details command line option properly.