### PR TITLE
Implement optimized country selection for contact pages

### DIFF
--- a/allium/templates/contact.html
+++ b/allium/templates/contact.html
@@ -38,8 +38,20 @@
                     <li><strong>Contact:</strong> {{ contact }}</li>
                     {% endif %}
                     <li><strong>Hash:</strong> {{ contact_hash }}</li>
-                    {% if relays.json['relay_subset'][0]['country'] %}
-                    <li><strong>Country:</strong> 
+                    {% if primary_country_data %}
+                    <li><strong>Countries:</strong> 
+                        {% for country_info in primary_country_data.all_countries %}
+                            <a href="{{ page_ctx.path_prefix }}country/{{ country_info.country }}/" style="color: #337ab7; text-decoration: none;">
+                                <img src="{{ page_ctx.path_prefix }}static/images/cc/{{ country_info.country }}.png" 
+                                     title="{{ primary_country_data.tooltip }}" 
+                                     alt="{{ country_info.country_name }}" 
+                                     style="width: 16px; height: 12px; margin-right: 5px; vertical-align: middle;">
+                                {{ country_info.country_name }} ({{ country_info.relay_count }})
+                            </a>{% if not loop.last %}, {% endif %}
+                        {% endfor %}
+                    </li>
+                    {% elif relays.json['relay_subset'][0]['country'] %}
+                    <li><strong>Countries:</strong> 
                         <a href="{{ page_ctx.path_prefix }}country/{{ relays.json['relay_subset'][0]['country'] }}/" style="color: #337ab7; text-decoration: none;">
                             <img src="{{ page_ctx.path_prefix }}static/images/cc/{{ relays.json['relay_subset'][0]['country'] }}.png" 
                                  title="{{ relays.json['relay_subset'][0]['country_name'] if relays.json['relay_subset'][0]['country_name'] else relays.json['relay_subset'][0]['country']|upper }}" 


### PR DESCRIPTION
- Display all countries ordered by relay count instead of arbitrary first relay country
- Show format: flag + country name + (relay count) for each country
- Change label from 'Country:' to 'Countries:' to reflect multiple countries
- Add country counting inside existing _sort() method relay processing loop
- Pre-calculate primary country data and complete country list during aggregation
- Update contact.html template to display all countries with flags and relay counts
- Include fallback to original logic for backward compatibility
- Fix template indentation for proper Jinja2 formatting

Performance optimizations:
- Use walrus operator (:=) to reduce country.get() calls from 2 to 1
- Eliminate redundant country name lookup loop by combining operations
- Build final data structure directly with list comprehension
- Inline tooltip creation to avoid intermediate variables
- Reduce lines of code from 42 to 23 (45% reduction)
- Algorithmic improvement: O(n×c) → O(n) where n=relays, c=contacts

Example output: 🇩🇪 Germany (2), 🇺🇸 United States (1), 🇳🇱 Netherlands (1)

Fixes issue where contact pages showed arbitrary first relay country instead of complete ordered list showing operator's geographic distribution by relay count.