### PR TITLE
Fix StaleDesc flag counting typo

### DIFF
--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -3205,7 +3205,7 @@ class Relays:
             is_stable = 'Stable' in flags
             is_v2dir = 'V2Dir' in flags
             is_hsdir = 'HSDir' in flags
-            is_stabledesc = 'StableDesc' in flags
+            is_stabledesc = 'StaleDesc' in flags
             is_sybil = 'Sybil' in flags
             is_running = relay.get('running', True)
             # REMOVED: is_hibernating


### PR DESCRIPTION
- Fixed typo in _calculate_network_health_metrics where 'StableDesc' was checked instead of 'StaleDesc'
- This bug caused StaleDesc relays to always show as 0 in the network health dashboard
- The correct flag name is 'StaleDesc' (with 'd') as seen in consensus files
- Now properly displays count and percentage of relays with stale descriptors (18+ hours old)

Fixes issue where 16+ StaleDesc relays from consensus were not showing in network health dashboard