### PR TITLE
Add full country names with 32-char truncation and full names in tool…

### DIFF
--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -1000,8 +1000,15 @@ class Relays:
 
         if k == "as":
             self.json["sorted"][k][v]["country"] = relay.get("country")
-            self.json["sorted"][k][v]["country_name"] = relay.get("country")
+            self.json["sorted"][k][v]["country_name"] = relay.get("country_name") or relay.get("country", "").upper()
             self.json["sorted"][k][v]["as_name"] = relay.get("as_name")
+        
+        if k == "country":
+            # Set country name for countries - truncate to 32 characters as requested
+            full_country_name = relay.get("country_name") or relay.get("country", "").upper()
+            truncated_country_name = full_country_name[:32] if len(full_country_name) > 32 else full_country_name
+            self.json["sorted"][k][v]["country_name"] = truncated_country_name
+            self.json["sorted"][k][v]["country_name_full"] = full_country_name
 
         if k == "family" or k == "contact" or k == "country" or k == "platform" or k == "as":
             # Families, contacts, countries, platforms, and networks benefit from additional tracking data:

--- a/allium/templates/misc-countries.html
+++ b/allium/templates/misc-countries.html
@@ -130,7 +130,7 @@
                     <td>
                         <a href="{{ page_ctx.path_prefix }}country/{{ k|escape }}/">
                             <img src="{{ page_ctx.path_prefix }}static/images/cc/{{ k|escape }}.png"
-                                 title="{{ v['country_name']|escape }}"
+                                 title="{{ v['country_name_full']|escape }}"
                                  alt="{{ v['country_name']|escape }}">
                             {{ v['country_name']|escape }}
                         </a>


### PR DESCRIPTION
…tips

- Fix bug: country_name was incorrectly set to country code instead of full name
- Add country name truncation logic (max 32 characters) in Python
- Add full country names in tooltips for better user experience
- Template already supports both flag and country name as clickable links
- All logic implemented in Python as requested, not in Jinja2
- Minimal code changes: 8 new lines total