### PR TITLE
feat: Add AROI and Contact bullets to family detail summary

### DIFF
--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -1722,6 +1722,15 @@ class Relays:
                 # Get primary country data for this contact
                 primary_country_data = i.get("primary_country_data")
             
+            # Add family-specific data for family templates (used by detail_summary macro)
+            family_aroi_domain = None
+            family_contact = None
+            family_contact_md5 = None
+            if k == "family":
+                family_aroi_domain = i.get("aroi_domain", "")
+                family_contact = i.get("contact", "")
+                family_contact_md5 = i.get("contact_md5", "")
+            
             # Time the template rendering
             render_start = time.time()
             rendered = template.render(
@@ -1748,6 +1757,10 @@ class Relays:
                 operator_reliability=operator_reliability,  # Operator reliability statistics for contact pages
                 contact_display_data=contact_display_data,  # Pre-computed contact-specific display data
                 primary_country_data=primary_country_data,  # Primary country data for contact pages
+                # Family-specific data for detail_summary macro in family templates
+                family_aroi_domain=family_aroi_domain,  # AROI domain for family pages
+                family_contact=family_contact,  # Contact string for family pages
+                family_contact_md5=family_contact_md5,  # Contact MD5 hash for family pages
                 # Template optimizations - pre-computed values to avoid expensive Jinja2 operations for all page types
                 consensus_weight_percentage=f"{i['consensus_weight_fraction'] * 100:.2f}%",
                 guard_consensus_weight_percentage=f"{i['guard_consensus_weight_fraction'] * 100:.2f}%",

--- a/allium/templates/family.html
+++ b/allium/templates/family.html
@@ -1,7 +1,7 @@
-{% extends "relay-list.html" %}
+{% extends "contact-relay-list.html" %}
 {% from "macros.html" import navigation, detail_summary %}
 {% set family_hash = key %}
-{% set family_aroi = relays.json['relay_subset'][0]['aroi_domain'] if relays.json['relay_subset'] and relays.json['relay_subset'][0].get('aroi_domain') else '' %}
+{% set family_aroi = family_aroi_domain if family_aroi_domain else '' %}
 {% block title %}Tor Relays :: Family {{ family_hash }}{% endblock %}
 {% block header %}
     {% if family_aroi and family_aroi != 'none' and family_aroi != '' -%}
@@ -14,4 +14,4 @@
 {{ navigation('families', page_ctx) }}
 {% endblock -%}
 {% block description %}Relays with effective family member <code>{{ value|escape }}</code> summary:
-{{ detail_summary(bandwidth, bandwidth_unit, guard_bandwidth, middle_bandwidth, exit_bandwidth, consensus_weight_fraction, guard_consensus_weight_fraction, middle_consensus_weight_fraction, exit_consensus_weight_fraction, guard_count, middle_count, exit_count, relays.json['relay_subset']|length, network_position) }}{% endblock %}
+{{ detail_summary(bandwidth, bandwidth_unit, guard_bandwidth, middle_bandwidth, exit_bandwidth, consensus_weight_fraction, guard_consensus_weight_fraction, middle_consensus_weight_fraction, exit_consensus_weight_fraction, guard_count, middle_count, exit_count, relays.json['relay_subset']|length, network_position, family_aroi_domain, family_contact, family_contact_md5, page_ctx) }}{% endblock %}

--- a/allium/templates/macros.html
+++ b/allium/templates/macros.html
@@ -95,7 +95,7 @@
     </nav>
 {%- endmacro %}
 
-{% macro detail_summary(bandwidth, bandwidth_unit, guard_bandwidth, middle_bandwidth, exit_bandwidth, consensus_weight_fraction, guard_consensus_weight_fraction, middle_consensus_weight_fraction, exit_consensus_weight_fraction, guard_count, middle_count, exit_count, total_relays, network_position) -%}
+{% macro detail_summary(bandwidth, bandwidth_unit, guard_bandwidth, middle_bandwidth, exit_bandwidth, consensus_weight_fraction, guard_consensus_weight_fraction, middle_consensus_weight_fraction, exit_consensus_weight_fraction, guard_count, middle_count, exit_count, total_relays, network_position, aroi_domain=none, contact=none, contact_md5=none, page_ctx=none) -%}
 <ul style="list-style-type: disc; padding-left: 20px; margin-bottom: 15px;">
     <li><strong><span title="Observed bandwidth represents the estimated capacity this group can handle, combining total, guard, middle, and exit bandwidth contributions">Bandwidth</span>:</strong> ~{{ bandwidth }} {{ bandwidth_unit }}
         {%- if guard_count > 0 or middle_count > 0 or exit_count > 0 %} 
@@ -112,5 +112,11 @@
         )
         {%- endif %}</li>
     <li><strong><span title="Network position indicates the strategic role distribution of relays. Labels: Guard-focused (>60% guard), Exit-focused (>40% exit), Multi-role (both guard and exit >20%), Balanced (mixed roles), Guard-only (100% guard), Exit-only (100% exit), Middle-only (100% middle)">Network Position</span>:</strong> {{ network_position.formatted_string }}</li>
+    {%- if aroi_domain and aroi_domain != 'none' and aroi_domain != '' %}
+    <li><strong><span title="Autonomous Relay Operator Identifier - unverified">AROI</span>:</strong> <a href="{{ page_ctx.path_prefix if page_ctx else '../../' }}contact/{{ contact_md5|escape }}/">{{ aroi_domain|escape }}</a></li>
+    {%- endif %}
+    {%- if contact_md5 %}
+    <li><strong>Contact:</strong> <a href="{{ page_ctx.path_prefix if page_ctx else '../../' }}contact/{{ contact_md5|escape }}/">{% if contact and contact.strip() %}{{ contact|escape }}{% else %}none{% endif %}</a></li>
+    {%- endif %}
 </ul>
 {%- endmacro %} 


### PR DESCRIPTION
- Updated detail_summary macro to accept optional AROI and contact parameters
- Changed family.html to extend contact-relay-list.html instead of relay-list.html
- Added AROI and Contact bullets to family detail summary with hyperlinks
- Modified write_pages_by_key to pass family AROI/contact data to templates
- All calculations done in Python, not Jinja2 as requested
- AROI bullet only shows when AROI is available
- Contact bullet always shows with link to contact page
- Existing templates continue to work with optional parameters

Changes implement the requested family detail page improvements:
1. Use contact-relay-list.html template for better relay listing
2. Add AROI bullet (only when available)
3. Add Contact bullet with hyperlink
4. All data processing done in Python for efficiency