### PR TITLE
Add historical bandwidth API endpoint integration with configurable c…

### DIFF
--- a/allium/allium.py
+++ b/allium/allium.py
@@ -123,6 +123,25 @@ if __name__ == "__main__":
         required=False,
     )
     parser.add_argument(
+        "--onionoo-bandwidth-url",
+        dest="onionoo_bandwidth_url",
+        type=str,
+        default="https://onionoo.torproject.org/bandwidth",
+        help=(
+            "onionoo historical bandwidth API HTTP URL (default "
+            '"https://onionoo.torproject.org/bandwidth")'
+        ),
+        required=False,
+    )
+    parser.add_argument(
+        "--bandwidth-cache-hours",
+        dest="bandwidth_cache_hours",
+        type=int,
+        default=12,
+        help="hours to cache historical bandwidth data before refreshing (default: 12)",
+        required=False,
+    )
+    parser.add_argument(
         "--apis",
         dest="enabled_apis",
         type=str,
@@ -177,7 +196,7 @@ if __name__ == "__main__":
     progress_logger.log("Initializing relay data from onionoo (using coordinator)...")
     
     try:
-        RELAY_SET = create_relay_set_with_coordinator(args.output_dir, args.onionoo_details_url, args.onionoo_uptime_url, args.bandwidth_units == 'bits', args.progress, start_time, progress_logger.get_current_step(), total_steps, args.enabled_apis, args.filter_downtime_days)
+        RELAY_SET = create_relay_set_with_coordinator(args.output_dir, args.onionoo_details_url, args.onionoo_uptime_url, args.onionoo_bandwidth_url, args.bandwidth_cache_hours, args.bandwidth_units == 'bits', args.progress, start_time, progress_logger.get_current_step(), total_steps, args.enabled_apis, args.filter_downtime_days)
         if RELAY_SET is None or RELAY_SET.json == None:
             # Progress-style error context message (conditional on progress flag)
             progress_logger.log("No onionoo data available, exiting gracefully")


### PR DESCRIPTION
…ache refresh

- Add --onionoo-bandwidth-url command line argument for historical bandwidth endpoint
- Add --bandwidth-cache-hours argument for configurable cache time (default: 12)
- Implement fetch_onionoo_bandwidth() worker with @handle_http_errors decorator
- Configurable cache refresh logic - only fetches when cache older than specified hours
- Integrate historical bandwidth API into coordinator system for 'all' APIs mode
- Store historical bandwidth data on disk in JSON format with proper caching
- Attach bandwidth_data to relay set for future processing
- Maintain consistency with existing worker patterns and error handling

Technical details:
- Uses existing cache management infrastructure
- Implements HTTP conditional requests with If-Modified-Since headers
- Provides graceful fallback to stale cache on API failures
- Supports progress logging and threaded execution
- Dynamic progress messages show actual cache time used
- Data includes comprehensive historical bandwidth (1_month to 5_years)
- Backward compatible with 12-hour default cache time
- Clear terminology: adds historical bandwidth data, not just bandwidth
- Fixed coordinator argument passing for proper parameter order