### PR TITLE
docs: Update documentation with recent major features

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ cd www && python3 -m http.server 8000
 - **Optimized contact pages** with efficient two-column layout (50% space reduction)
 - **Enhanced operator profiles** with streamlined reliability metrics and network uptime percentiles
 - **Network uptime percentile analysis** showing operator positioning within network performance distribution
+- **Enhanced family pages** with AROI and Contact bullets for better navigation
+- **Country display improvements** with full country names and tooltips
 - **Improved information density** while preserving all analytical data
 - **Responsive design** with mobile-friendly layouts
 - **JavaScript-free pagination** for AROI leaderboards with independent category navigation
 
 ### AROI Leaderboard System 🏆
-- **12 specialized leaderboards** for authenticated relay operators
+- **15 specialized leaderboards** for authenticated relay operators (includes Guard/Exit Authority, IPv4/IPv6 unique address categories)
 - **Paginated rankings** with 1-10, 11-20, 21-25 views per category for improved navigation
 - **Independent pagination** - each category manages its own page state
 - **CSS-only navigation** using `:target` selectors for maximum security and performance
@@ -49,6 +51,7 @@ cd www && python3 -m http.server 8000
 - **Operator achievement tracking** across multiple dimensions
 - **Geographic diversity scoring** with frontier country recognition
 - **Platform diversity metrics** highlighting technical leadership
+- **Network address diversity** with IPv4/IPv6 unique address leaderboards
 
 ### Security & Performance 🔒
 - **XSS-hardened templates** with comprehensive input sanitization
@@ -109,6 +112,12 @@ allium integrates with multiple Tor Project APIs:
 - **Memory Usage**: ~2GB during processing (large historical dataset)
 - **Usage**: Enhanced relay reliability metrics and performance analysis
 
+### Onionoo Bandwidth API
+- **URL**: `https://onionoo.torproject.org/bandwidth`
+- **Purpose**: Historical bandwidth statistics for trend analysis and optimization
+- **Cache**: Configurable cache time (default: 12 hours)
+- **Usage**: Historical bandwidth data for performance tracking and analysis
+
 **Sample Data**:
 ```json
 {
@@ -138,6 +147,8 @@ allium integrates with multiple Tor Project APIs:
 |--------|---------|-------------|
 | `--out` | `./www` | Output directory for generated files |
 | `--onionoo-url` | `https://onionoo.torproject.org/details` | Onionoo API endpoint |
+| `--onionoo-bandwidth-url` | `https://onionoo.torproject.org/bandwidth` | Historical bandwidth API endpoint |
+| `--bandwidth-cache-hours` | `12` | Cache time for historical bandwidth data (hours) |
 | `--display-bandwidth-units` | `bits` | Units for bandwidth display (`bits` or `bytes`) |
 | `--progress` | `false` | Show detailed progress with memory usage |
 
@@ -174,20 +185,23 @@ allium integrates with multiple Tor Project APIs:
 
 ## 🌍 AROI Leaderboards
 
-Twelve specialized categories tracking authenticated operator achievements:
+Fifteen specialized categories tracking authenticated operator achievements:
 
 1. **Bandwidth Champions** - Total bandwidth contributed
 2. **Consensus Weight Leaders** - Network authority holders
 3. **Exit Authority Champions** - Exit traffic facilitators
-4. **Exit Gate Keepers** - Number of exit relays operated
-5. **Guard Champions** - Number of guard relays operated
-6. **Most Diverse Operators** - Geographic, platform, and network diversity
-7. **Platform Diversity Heroes** - Non-Linux champions promoting OS diversity
-8. **Non-EU Leaders** - Geographic champions expanding Tor outside EU
-9. **Frontier Builders** - Operators in rare/underrepresented countries
-10. **Network Veterans** - Longest-serving operators
-11. **Reliability Masters** - 6-month average uptime champions (25+ relays)
-12. **Legacy Titans** - 5-year average uptime champions (25+ relays)
+4. **Guard Authority Champions** - Guard traffic facilitators
+5. **Exit Gate Keepers** - Number of exit relays operated
+6. **Guard Champions** - Number of guard relays operated
+7. **Most Diverse Operators** - Geographic, platform, and network diversity
+8. **Platform Diversity Heroes** - Non-Linux champions promoting OS diversity
+9. **Non-EU Leaders** - Geographic champions expanding Tor outside EU
+10. **Frontier Builders** - Operators in rare/underrepresented countries
+11. **Network Veterans** - Longest-serving operators
+12. **Reliability Masters** - 6-month average uptime champions (25+ relays)
+13. **Legacy Titans** - 5-year average uptime champions (25+ relays)
+14. **IPv4 Address Diversity** - Unique IPv4 address distribution leaders
+15. **IPv6 Address Diversity** - Unique IPv6 address distribution leaders
 
 ## 🔒 Security & Performance
 

--- a/docs/features/RELIABILITY_SYSTEM_UPDATES.md
+++ b/docs/features/RELIABILITY_SYSTEM_UPDATES.md
@@ -178,7 +178,7 @@ User Understanding: Simplified
 - Simplified reliability scoring with no weighting
 - 25+ relay eligibility requirement
 - Focus on statistical significance and clarity
-- Maintains 12-category AROI leaderboard system
+- Maintains 15-category AROI leaderboard system
 
 ## Future Considerations
 

--- a/docs/features/contact_pages.md
+++ b/docs/features/contact_pages.md
@@ -81,7 +81,7 @@ The contact page uses an efficient two-column layout that maximizes information 
 - **Achievement descriptions**: Brief explanation of each accomplishment
 
 #### Ranking Categories
-Operators may appear in up to 12 specialized leaderboards:
+Operators may appear in up to 15 specialized leaderboards:
 - Bandwidth Champions, Consensus Weight Leaders
 - Exit Authority Champions, Guard Champions
 - Network Diversity Leaders, Platform Diversity Heroes

--- a/docs/features/pagination-system.md
+++ b/docs/features/pagination-system.md
@@ -4,7 +4,7 @@
 
 ## 📋 Overview
 
-The AROI Leaderboard pagination system transforms the traditional single-page leaderboard view into an optimized, multi-page experience that improves readability, performance, and user navigation across all 12 leaderboard categories.
+The AROI Leaderboard pagination system transforms the traditional single-page leaderboard view into an optimized, multi-page experience that improves readability, performance, and user navigation across all 15 leaderboard categories.
 
 ### **🎯 Key Benefits**
 - **Enhanced Performance**: Reduced initial page load with paginated data
@@ -85,7 +85,7 @@ The system integrates seamlessly with existing Jinja2 macros:
 
 ## 🌟 Supported Categories
 
-All 12 AROI leaderboard categories include full pagination support:
+All 15 AROI leaderboard categories include full pagination support:
 
 | Category | URL Pattern | Description |
 |----------|-------------|-------------|

--- a/docs/implementation/merge_plan_top10page.md
+++ b/docs/implementation/merge_plan_top10page.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-The `top10page` branch introduces a comprehensive pagination system for AROI leaderboards, allowing users to view "Top 25" rankings across 12 categories with JavaScript-free CSS navigation. This merge plan outlines the strategy to safely integrate these changes into master.
+The `top10page` branch introduces a comprehensive pagination system for AROI leaderboards, allowing users to view "Top 25" rankings across 15 categories with JavaScript-free CSS navigation. This merge plan outlines the strategy to safely integrate these changes into master.
 
 ## Branch Analysis
 
@@ -21,7 +21,7 @@ The `top10page` branch introduces a comprehensive pagination system for AROI lea
 ## Key Features in top10page Branch
 
 ### 1. Comprehensive Pagination System
-- **Scope**: All 12 AROI leaderboard categories
+- **Scope**: All 15 AROI leaderboard categories
 - **Implementation**: JavaScript-free CSS navigation using `:target` selectors
 - **Pages**: 1-10, 11-20, 21-25 for each category
 - **Independence**: Each category manages its own pagination state
@@ -134,7 +134,7 @@ The `top10page` branch introduces a comprehensive pagination system for AROI lea
    git commit -m "Merge branch 'top10page': Comprehensive AROI pagination system
 
    Features:
-   - JavaScript-free pagination for all 12 AROI categories
+   - JavaScript-free pagination for all 15 AROI categories
    - Independent category pagination states
    - Enhanced macro system for template efficiency
    - Fixed emoji duplication in Reliability Masters and Legacy Titans
@@ -152,7 +152,7 @@ The `top10page` branch introduces a comprehensive pagination system for AROI lea
 ## Testing Checklist
 
 ### Functional Testing
-- [ ] All 12 AROI categories display correctly
+- [ ] All 15 AROI categories display correctly
 - [ ] Pagination works: 1-10 → 11-20 → 21-25 for each category
 - [ ] Category independence: pagination doesn't cross-affect categories
 - [ ] Emoji display fixed for reliability_masters and legacy_titans

--- a/docs/implementation/readme-review-report.md
+++ b/docs/implementation/readme-review-report.md
@@ -21,7 +21,7 @@ The current `README` file is quite minimal (41 lines) and appears to be signific
 - **Template escaping standardized** throughout the application
 
 ### 2. AROI Leaderboard System 🏆
-- **12 distinct leaderboard categories** for operator rankings
+- **15 distinct leaderboard categories** for operator rankings
 - **Sophisticated operator analytics** including geographic and platform diversity
 - **Dynamic scoring algorithms** for rare countries and network contributions
 - **Professional dashboard interface** for viewing operator achievements
@@ -60,7 +60,7 @@ A powerful, security-hardened static site generator that creates comprehensive T
 - **Bandwidth and consensus weight analytics** with multiple viewing modes
 
 ### AROI Leaderboard System 🏆
-- **12 specialized leaderboards** for authenticated relay operators
+- **15 specialized leaderboards** for authenticated relay operators
 - **Operator achievement tracking** across multiple dimensions
 - **Geographic diversity scoring** with frontier country recognition
 - **Platform diversity metrics** highlighting technical leadership
@@ -133,7 +133,7 @@ cd www && python -m http.server 8000
 ### Main Pages
 - **Index page** with top 500 relays by consensus weight
 - **Complete relay listing** with all active relays
-- **AROI leaderboards** with 12 specialized categories
+- **AROI leaderboards** with 15 specialized categories
 - **Geographic analysis** with rare country intelligence
 
 ### Categorized Views
@@ -272,7 +272,7 @@ Rarity Score = (Relay Count Factor × 4) +
 5. **Add proper installation guide** with requirements
 6. **Include examples** of different usage scenarios
 7. **Highlight performance features** like progress tracking
-8. **Document the 12 AROI leaderboard categories**
+8. **Document the 15 AROI leaderboard categories**
 9. **Explain the rare country classification system**
 10. **Add contributing guidelines** for the expanded project
 


### PR DESCRIPTION
- Add historical bandwidth API integration with configurable cache
- Update AROI leaderboards from 12 to 15 categories (Guard Authority + IPv4/IPv6 address diversity)
- Document enhanced family pages with AROI and Contact bullets
- Add country display improvements with full names and tooltips
- Update command line arguments for new bandwidth API options
- Update all documentation references to reflect 15 leaderboard categories