### PR TITLE
Fix family page title to show meaningful family identifiers

### DIFF
--- a/allium/templates/family.html
+++ b/allium/templates/family.html
@@ -1,8 +1,8 @@
 {% extends "contact-relay-list.html" %}
 {% from "macros.html" import navigation, detail_summary %}
-{% set family_hash = key %}
+{% set family_hash = value %}
 {% set family_aroi = family_aroi_domain if family_aroi_domain else '' %}
-{% block title %}Tor Relays :: Family {{ family_hash }}{% endblock %}
+{% block title %}Tor Relays :: Family {% if family_aroi and family_aroi != 'none' and family_aroi != '' %}{{ family_aroi }}{% elif family_contact and family_contact.strip() %}{{ family_contact|truncate(30) }}{% else %}{{ family_hash[:8] }}{% endif %}{% endblock %}
 {% block header %}
     {% if family_aroi and family_aroi != 'none' and family_aroi != '' -%}
         View Family {{ family_aroi }} Details


### PR DESCRIPTION
Updated family page title to use three-level priority logic:
1. AROI domain (when available and not 'none' or empty)
2. Contact field truncated to 30 characters (when available and not empty)
3. First 8 characters of family hash (fallback)

This replaces the generic 'family' text with actual family identifiers. Matches truncation patterns used elsewhere in the codebase.

Example: https://1aeo.com/metrics/family/0040E1791755D340BA8109F4C1849666582CF56C/
will now show 'Tor Relays :: Family 1aeo' in the page title.