### PR TITLE
Investigate network diversity display for operator

### DIFF
--- a/allium/lib/intelligence_engine.py
+++ b/allium/lib/intelligence_engine.py
@@ -529,11 +529,30 @@ class IntelligenceEngine:
                 
                 # Determine network diversity rating
                 if unique_as_count == 1:
-                    # Special case: Check if this contact is the only operator in their AS
+                                        # Special case: Check if this contact is the only operator in their AS
                     first_relay_as = contact_relays[0].get('as') if contact_relays else None
-                    if (first_relay_as and 'as' in self.sorted_data and 
-                        first_relay_as in self.sorted_data['as'] and
-                        self.sorted_data['as'][first_relay_as].get('unique_contact_count', 0) == 1):
+                    
+
+                    
+                    # Robust AS format handling: try multiple format variations
+                    as_data = None
+                    if first_relay_as and 'as' in self.sorted_data:
+                        # Try original format first
+                        as_data = self.sorted_data['as'].get(first_relay_as)
+                        
+                        # If not found, try alternative formats
+                        if not as_data:
+                            # If relay AS has "AS" prefix, try without it
+                            if first_relay_as.startswith('AS'):
+                                normalized_as = first_relay_as[2:]  # Remove "AS" prefix
+                                as_data = self.sorted_data['as'].get(normalized_as)
+                            # If relay AS doesn't have "AS" prefix, try with it
+                            else:
+                                prefixed_as = f"AS{first_relay_as}"
+                                as_data = self.sorted_data['as'].get(prefixed_as)
+                    
+                    # Check if this contact is the only operator in their AS
+                    if as_data and as_data.get('unique_contact_count', 0) == 1:
                         network_rating = "Great"
                         portfolio_diversity = f"{network_rating}, 1 AS with 1 operator"
                     else:

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -1257,9 +1257,9 @@ class Relays:
                     self.json["sorted"][k][v]["unique_family_set"] = set()
                 
                 # Add this relay's contact hash to the country/platform/network's unique contacts
-                c_str = relay.get("contact", "").encode("utf-8")
-                c_hash = hashlib.md5(c_str).hexdigest()
-                self.json["sorted"][k][v]["unique_contact_set"].add(c_hash)
+                c_hash = relay.get("contact_md5", "")
+                if c_hash:  # Only add if contact_md5 exists
+                    self.json["sorted"][k][v]["unique_contact_set"].add(c_hash)
                 
                 # Add this relay's family to the country/platform/network's unique families
                 if relay.get("effective_family") and len(relay["effective_family"]) > 1:


### PR DESCRIPTION
Fix network diversity display for single AS operators by correcting AS format handling and unique contact counting.

The "Network diversity: Poor, 1 network" message was incorrectly shown for operators who were the sole operator in their Autonomous System. This was due to two underlying bugs:
1.  Inconsistent AS number formatting (e.g., 'AS12345' vs '12345') prevented correct lookup in `intelligence_engine.py`.
2.  The `unique_contact_count` in `relays.py` was flawed, as it re-hashed raw contact strings. Minor variations (like different relay numbers in an email address) led to the same operator being counted multiple times, falsely indicating multiple operators in an AS.

---

[Open in Web](https://www.cursor.com/agents?id=bc-22e16765-813f-4caf-892c-13f58e29bea4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-22e16765-813f-4caf-892c-13f58e29bea4)