### PR TITLE
fix: static sync must compare file content, not only mtime+size

### DIFF
--- a/allium/lib/site_generator.py
+++ b/allium/lib/site_generator.py
@@ -12,6 +12,7 @@ To add a new sorted-by variant (e.g., "by-latency"):
   - Add an entry to SORTED_BY_VARIANTS
 """
 
+import filecmp
 import os
 from shutil import copy2
 
@@ -202,7 +203,9 @@ def _sync_static_files(src_dir, dst_dir):
     """Copy only new or changed files from src_dir to dst_dir.
 
     A file is copied when the destination is missing, the size differs,
-    or the source mtime is newer.  Returns (copied, skipped) counts.
+    the source mtime is newer, or byte content differs (same size/mtime
+    can still diverge after checkout or archive extraction).  Returns
+    (copied, skipped) counts.
     """
     copied = skipped = 0
     for dirpath, _dirnames, filenames in os.walk(src_dir):
@@ -214,11 +217,12 @@ def _sync_static_files(src_dir, dst_dir):
             src_file = os.path.join(dirpath, fname)
             dst_file = os.path.join(dst_subdir, fname)
 
-            if os.path.exists(dst_file):
+            if os.path.isfile(dst_file):
                 src_stat = os.stat(src_file)
                 dst_stat = os.stat(dst_file)
                 if (src_stat.st_size == dst_stat.st_size
-                        and src_stat.st_mtime <= dst_stat.st_mtime):
+                        and src_stat.st_mtime <= dst_stat.st_mtime
+                        and filecmp.cmp(src_file, dst_file, shallow=False)):
                     skipped += 1
                     continue
 

--- a/tests/unit/test_site_generator_static_sync.py
+++ b/tests/unit/test_site_generator_static_sync.py
@@ -1,0 +1,53 @@
+"""Regression tests for static file sync in site_generator."""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from allium.lib.site_generator import _sync_static_files
+
+
+class TestSyncStaticFiles(unittest.TestCase):
+    def test_same_size_same_mtime_different_content_is_copied(self):
+        """mtime+size alone are not enough; content must match to skip."""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src")
+            dst = os.path.join(tmp, "dst")
+            os.makedirs(src)
+            os.makedirs(dst, exist_ok=True)
+            src_f = os.path.join(src, "a.css")
+            dst_f = os.path.join(dst, "a.css")
+            with open(src_f, "w") as f:
+                f.write("AAAAA")
+            shutil.copy2(src_f, dst_f)
+            st = os.stat(dst_f)
+            with open(src_f, "w") as f:
+                f.write("BBBBB")
+            os.utime(src_f, (st.st_atime, st.st_mtime))
+
+            copied, skipped = _sync_static_files(src, dst)
+            self.assertEqual(copied, 1)
+            self.assertEqual(skipped, 0)
+            with open(dst_f) as f:
+                self.assertEqual(f.read(), "BBBBB")
+
+    def test_identical_files_are_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src")
+            dst = os.path.join(tmp, "dst")
+            os.makedirs(src)
+            os.makedirs(dst, exist_ok=True)
+            src_f = os.path.join(src, "x.css")
+            dst_f = os.path.join(dst, "x.css")
+            with open(src_f, "w") as f:
+                f.write("unchanged")
+            shutil.copy2(src_f, dst_f)
+
+            copied, skipped = _sync_static_files(src, dst)
+            self.assertEqual(copied, 0)
+            self.assertEqual(skipped, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_site_generator_static_sync.py
+++ b/tests/unit/test_site_generator_static_sync.py
@@ -2,52 +2,44 @@
 
 import os
 import shutil
-import tempfile
-import unittest
 
 from allium.lib.site_generator import _sync_static_files
 
 
-class TestSyncStaticFiles(unittest.TestCase):
-    def test_same_size_same_mtime_different_content_is_copied(self):
-        """mtime+size alone are not enough; content must match to skip."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = os.path.join(tmp, "src")
-            dst = os.path.join(tmp, "dst")
-            os.makedirs(src)
-            os.makedirs(dst, exist_ok=True)
-            src_f = os.path.join(src, "a.css")
-            dst_f = os.path.join(dst, "a.css")
-            with open(src_f, "w") as f:
-                f.write("AAAAA")
-            shutil.copy2(src_f, dst_f)
-            st = os.stat(dst_f)
-            with open(src_f, "w") as f:
-                f.write("BBBBB")
-            os.utime(src_f, (st.st_atime, st.st_mtime))
+def test_same_size_same_mtime_different_content_is_copied(temp_dir):
+    """mtime+size alone are not enough; content must match to skip."""
+    src = os.path.join(temp_dir, "src")
+    dst = os.path.join(temp_dir, "dst")
+    os.makedirs(src)
+    os.makedirs(dst, exist_ok=True)
+    src_f = os.path.join(src, "a.css")
+    dst_f = os.path.join(dst, "a.css")
+    with open(src_f, "w") as f:
+        f.write("AAAAA")
+    shutil.copy2(src_f, dst_f)
+    st = os.stat(dst_f)
+    with open(src_f, "w") as f:
+        f.write("BBBBB")
+    os.utime(src_f, (st.st_atime, st.st_mtime))
 
-            copied, skipped = _sync_static_files(src, dst)
-            self.assertEqual(copied, 1)
-            self.assertEqual(skipped, 0)
-            with open(dst_f) as f:
-                self.assertEqual(f.read(), "BBBBB")
-
-    def test_identical_files_are_skipped(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            src = os.path.join(tmp, "src")
-            dst = os.path.join(tmp, "dst")
-            os.makedirs(src)
-            os.makedirs(dst, exist_ok=True)
-            src_f = os.path.join(src, "x.css")
-            dst_f = os.path.join(dst, "x.css")
-            with open(src_f, "w") as f:
-                f.write("unchanged")
-            shutil.copy2(src_f, dst_f)
-
-            copied, skipped = _sync_static_files(src, dst)
-            self.assertEqual(copied, 0)
-            self.assertEqual(skipped, 1)
+    copied, skipped = _sync_static_files(src, dst)
+    assert copied == 1
+    assert skipped == 0
+    with open(dst_f) as f:
+        assert f.read() == "BBBBB"
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_identical_files_are_skipped(temp_dir):
+    src = os.path.join(temp_dir, "src")
+    dst = os.path.join(temp_dir, "dst")
+    os.makedirs(src)
+    os.makedirs(dst, exist_ok=True)
+    src_f = os.path.join(src, "x.css")
+    dst_f = os.path.join(dst, "x.css")
+    with open(src_f, "w") as f:
+        f.write("unchanged")
+    shutil.copy2(src_f, dst_f)
+
+    copied, skipped = _sync_static_files(src, dst)
+    assert copied == 0
+    assert skipped == 1

--- a/tests/unit/test_site_generator_static_sync.py
+++ b/tests/unit/test_site_generator_static_sync.py
@@ -30,6 +30,7 @@ def test_same_size_same_mtime_different_content_is_copied(temp_dir):
 
 
 def test_identical_files_are_skipped(temp_dir):
+    """Ensure identical files in src and dst are skipped by _sync_static_files."""
     src = os.path.join(temp_dir, "src")
     dst = os.path.join(temp_dir, "dst")
     os.makedirs(src)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #53378 (incremental static sync) fixed the “never update CSS after first run” problem by copying when mtime/size differ. A remaining edge case: **same length and same (or older) mtime with different bytes** still skipped the copy, so the output directory could keep stale CSS.

## Reproduction

1. Copy `AAAAA` from src to dst and note dst’s mtime.
2. Overwrite src with `BBBBB` (same size) and `os.utime` src to match dst’s mtime.
3. Run `_sync_static_files`: before this change it reported `skipped=1` and left `AAAAA` in dst.

## Fix

Before treating a file as unchanged, require `filecmp.cmp(..., shallow=False)` in addition to matching size and `src_mtime <= dst_mtime`. Use `os.path.isfile` for the destination so we do not skip when the path is a directory.

## Tests

- `tests/unit/test_site_generator_static_sync.py`: regression for the mtime+size collision; pytest functions with `temp_dir` from `conftest.py`; docstrings on both tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7845713c-1f6b-4e00-93c1-f7d20fbc1e31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7845713c-1f6b-4e00-93c1-f7d20fbc1e31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Static file sync now treats truly identical files as skipped and correctly recopies files whose content changed despite matching size/mtime; comparisons are restricted to regular files.
* **Tests**
  * Added regression tests verifying recopy for same-size/same-mtime with different content and skip behavior for identical files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->