### PR TITLE
Prometheus support review

### DIFF
--- a/allium/lib/prometheus_metrics.py
+++ b/allium/lib/prometheus_metrics.py
@@ -3,10 +3,10 @@ Prometheus metrics generator for allium.
 
 Generates a static Prometheus exposition format file containing:
   - Section 1: Exit DNS Health (per-relay + aggregates)
-  - Section 2: AROI Monitoring (per-relay + aggregates)
+  - Section 2: AROI Monitoring (state-based schema v2)
   - Meta: build info, generation timestamp, source availability
 
-Schema v1. Metric names and frozen label keys are the public API contract.
+Schema v2. Metric names and frozen label keys are the public API contract.
 See docs/prometheus/README.md for the full schema reference.
 """
 
@@ -18,11 +18,19 @@ from typing import Callable, Dict, List, Optional, Set
 from .aroi_validation import _check_aroi_fields
 
 # Schema version — bump on breaking changes (metric renames, label key changes)
-SCHEMA_VERSION = "1"
+SCHEMA_VERSION = "2"
 GENERATOR = "allium"
 
-# Allowed status values (frozen in schema v1)
-_DNS_STATUS_VALUES = ("success", "dns_fail", "timeout", "relay_unreachable")
+# Allowed status values (frozen in schema v2)
+_DNS_STATUS_VALUES = ("success", "dns_fail", "timeout", "relay_unreachable", "untested")
+
+# AROI state values (frozen in schema v2)
+_AROI_STATE_VALUES = (
+    "not_configured",
+    "configured_unchecked",
+    "configured_checked_invalid",
+    "configured_checked_valid",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -122,6 +130,19 @@ def _build_aroi_map(relay_set) -> Dict[str, dict]:
                 "proof_type": entry.get("proof_type") or "",
             }
     return result_map
+
+
+def _get_aroi_state(relay: dict, aroi_map: Dict[str, dict]) -> str:
+    """Classify a relay into one of the schema-v2 AROI states."""
+    if not _is_aroi_configured(relay):
+        return "not_configured"
+
+    fp = relay.get("fingerprint", "").upper()
+    entry = aroi_map.get(fp)
+    if not entry:
+        return "configured_unchecked"
+
+    return "configured_checked_valid" if entry.get("valid") else "configured_checked_invalid"
 
 
 def _get_verified_aroi(relay: dict, aroi_map: Dict[str, dict],
@@ -311,7 +332,7 @@ def _write_dns_health_section(lines: List[str], relay_set,
     for relay in exit_relays:
         fp = relay.get("fingerprint", "")
         detail = relay.get("exit_dns_health_detail", "untested")
-        failed = 0 if detail == "success" else 1
+        failed = 0 if detail in ("success", "untested") else 1
         # Map detail to allowed status values
         if detail in _DNS_STATUS_VALUES:
             status = detail
@@ -371,60 +392,44 @@ def _write_dns_health_section(lines: List[str], relay_set,
 def _write_aroi_section(lines: List[str], relay_set,
                         fp_to_family: Callable[[str], str],
                         aroi_map: Dict[str, dict]) -> int:
-    """Emit AROI aggregates and per-relay metrics. Returns configured relay count."""
+    """Emit AROI state metrics (schema v2). Returns configured relay count."""
     aroi_data = getattr(relay_set, "aroi_validation_data", None)
     if not aroi_data or not isinstance(aroi_data, dict):
         return 0
 
     metadata = aroi_data.get("metadata", {})
-    statistics = aroi_data.get("statistics", {})
 
     lines.append("")
     lines.append("# =========================================================================")
-    lines.append("# SECTION 2: AROI MONITORING (only AROI-configured relays)")
+    lines.append("# SECTION 2: AROI MONITORING (state model)")
     lines.append("# =========================================================================")
     lines.append("")
 
-    # --- Aggregates ---
-    total_relays = metadata.get("total_relays", 0)
-    valid_relays = metadata.get("valid_relays", 0)
-
-    _emit_help_type(lines, "aeo1_aroi_network_relays_count",
-                    "Total relays observed in network snapshot")
-    _emit(lines, "aeo1_aroi_network_relays_count", {}, total_relays)
-    lines.append("")
-
-    # Count configured relays from the relay data (relays passing _is_aroi_configured)
+    # --- Relay-state classification ---
     all_relays = relay_set.json.get("relays", [])
-    configured_relays = [r for r in all_relays if _is_aroi_configured(r)]
-    configured_count = len(configured_relays)
+    relays_sorted = sorted(all_relays, key=lambda r: r.get("fingerprint", ""))
+    state_counts = {state: 0 for state in _AROI_STATE_VALUES}
+    configured_count = 0
 
-    _emit_help_type(lines, "aeo1_aroi_configured_relays_count",
-                    "Relays with all required AROI fields configured")
-    _emit(lines, "aeo1_aroi_configured_relays_count", {}, configured_count)
+    _emit_help_type(lines, "aeo1_aroi_relay_state",
+                    "Canonical AROI relay state in schema v2 (always 1 for emitted state)")
+    for relay in relays_sorted:
+        state = _get_aroi_state(relay, aroi_map)
+        state_counts[state] += 1
+        if state != "not_configured":
+            configured_count += 1
+        fp = relay.get("fingerprint", "")
+        _emit(lines, "aeo1_aroi_relay_state", {
+            "fingerprint": fp,
+            "familyid": fp_to_family(fp),
+            "state": state,
+        }, 1)
     lines.append("")
 
-    _emit_help_type(lines, "aeo1_aroi_valid_relays_count",
-                    "AROI-configured relays that validated successfully")
-    _emit(lines, "aeo1_aroi_valid_relays_count", {}, valid_relays)
-    lines.append("")
-
-    success_ratio = round(valid_relays / configured_count, 4) if configured_count > 0 else 0
-    _emit_help_type(lines, "aeo1_aroi_success_ratio",
-                    "Fraction of AROI-configured relays that validated (0..1)")
-    _emit(lines, "aeo1_aroi_success_ratio", {}, success_ratio)
-    lines.append("")
-
-    # Proof type breakdown
-    proof_types = statistics.get("proof_types", {})
-    _emit_help_type(lines, "aeo1_aroi_proof_type_count",
-                    "Snapshot relay counts by proof_type and result")
-    for pt_key, prom_pt in [("uri_rsa", "uri-rsa"), ("dns_rsa", "dns-rsa")]:
-        pt_data = proof_types.get(pt_key, {})
-        _emit(lines, "aeo1_aroi_proof_type_count",
-              {"proof_type": prom_pt, "result": "valid"}, pt_data.get("valid", 0))
-        _emit(lines, "aeo1_aroi_proof_type_count",
-              {"proof_type": prom_pt, "result": "total"}, pt_data.get("total", 0))
+    _emit_help_type(lines, "aeo1_aroi_relays_count",
+                    "Relay count by canonical AROI state in schema v2")
+    for state in _AROI_STATE_VALUES:
+        _emit(lines, "aeo1_aroi_relays_count", {"state": state}, state_counts[state])
     lines.append("")
 
     # Scan timestamp
@@ -434,36 +439,26 @@ def _write_aroi_section(lines: List[str], relay_set,
     _emit(lines, "aeo1_aroi_scan_timestamp_seconds", {}, int(aroi_ts))
     lines.append("")
 
-    # --- Per-relay ---
-    configured_sorted = sorted(configured_relays, key=lambda r: r.get("fingerprint", ""))
-
-    _emit_help_type(lines, "aeo1_aroi_valid",
-                    "Whether relay AROI validation passed (1=valid, 0=failing)")
-    for relay in configured_sorted:
-        fp = relay.get("fingerprint", "").upper()
-        aroi_entry = aroi_map.get(fp, {})
-        valid_val = 1 if aroi_entry.get("valid") else 0
-        _emit(lines, "aeo1_aroi_valid", {
-            "fingerprint": relay.get("fingerprint", ""),
-            "familyid": fp_to_family(relay.get("fingerprint", "")),
-        }, valid_val)
-    lines.append("")
-
     # aeo1_aroi_relay_info (non-ABI, mutable labels)
     _emit_help_type(lines, "aeo1_aroi_relay_info",
-                    "Human-readable AROI relay metadata (always 1)")
-    for relay in configured_sorted:
+                    "Human-readable AROI relay metadata for configured relays (always 1)")
+    for relay in relays_sorted:
+        if not _is_aroi_configured(relay):
+            continue
         fp = relay.get("fingerprint", "").upper()
         aroi_entry = aroi_map.get(fp, {})
+        relay_domain = relay.get("aroi_domain", "")
+        if relay_domain in ("none", None):
+            relay_domain = ""
         _emit(lines, "aeo1_aroi_relay_info", {
             "fingerprint": relay.get("fingerprint", ""),
             "familyid": fp_to_family(relay.get("fingerprint", "")),
             "nick": relay.get("nickname", ""),
-            "domain": aroi_entry.get("domain", ""),
+            "domain": aroi_entry.get("domain", "") or relay_domain,
             "proof_type": aroi_entry.get("proof_type", ""),
         }, 1)
 
-    return len(configured_sorted)
+    return configured_count
 
 
 # ---------------------------------------------------------------------------

--- a/allium/lib/prometheus_metrics.py
+++ b/allium/lib/prometheus_metrics.py
@@ -13,7 +13,7 @@ See docs/prometheus/README.md for the full schema reference.
 import math
 import os
 import time
-from typing import Callable, Dict, List, Set
+from typing import Callable, Dict, List, Protocol, Set
 
 from .aroi_validation import _check_aroi_fields
 
@@ -31,6 +31,26 @@ _AROI_STATE_VALUES = (
     "configured_checked_invalid",
     "configured_checked_valid",
 )
+
+
+class _LineAppender(Protocol):
+    """Protocol for line sinks used by metric emitters."""
+
+    def append(self, value: str) -> None:
+        """Append one line (without trailing newline)."""
+
+
+class _StreamingLineSink:
+    """Stream line-based output directly to a file handle."""
+
+    def __init__(self, file_handle):
+        self._file_handle = file_handle
+        self.bytes_written = 0
+
+    def append(self, value: str) -> None:
+        line = f"{value}\n"
+        self._file_handle.write(line)
+        self.bytes_written += len(line.encode("utf-8"))
 
 
 # ---------------------------------------------------------------------------
@@ -79,12 +99,12 @@ def _safe_numeric(value) -> str:
     return str(f)
 
 
-def _emit(lines: List[str], name: str, labels: Dict[str, str], value) -> None:
+def _emit(lines: _LineAppender, name: str, labels: Dict[str, str], value) -> None:
     """Append a single metric line."""
     lines.append(f"{name}{_format_labels(labels)} {_safe_numeric(value)}")
 
 
-def _emit_help_type(lines: List[str], name: str, help_text: str, type_name: str = "gauge") -> None:
+def _emit_help_type(lines: _LineAppender, name: str, help_text: str, type_name: str = "gauge") -> None:
     """Append HELP and TYPE header lines for a metric."""
     lines.append(f"# HELP {name} {help_text}")
     lines.append(f"# TYPE {name} {type_name}")
@@ -110,6 +130,10 @@ def _is_aroi_configured(relay: dict) -> bool:
 
     Uses the canonical ``_check_aroi_fields`` predicate from aroi_validation.
     """
+    cached = relay.get("aroi_configured")
+    if isinstance(cached, bool):
+        return cached
+
     contact = relay.get("contact", "") or ""
     fields = _check_aroi_fields(contact)
     return fields.get("complete", False)
@@ -228,7 +252,7 @@ def _parse_timestamp_epoch(ts_str) -> float:
 # Meta section (always emitted)
 # ---------------------------------------------------------------------------
 
-def _write_meta_section(lines: List[str], relay_set) -> None:
+def _write_meta_section(lines: _LineAppender, relay_set) -> None:
     """Emit build info, generation timestamp, and source-availability metrics."""
     lines.append("# =========================================================================")
     lines.append("# META (always emitted)")
@@ -281,7 +305,38 @@ def _write_meta_section(lines: List[str], relay_set) -> None:
 # DNS Health section
 # ---------------------------------------------------------------------------
 
-def _write_dns_health_section(lines: List[str], relay_set,
+def _build_exit_dns_rows(relays: List[dict],
+                         fp_to_family: Callable[[str], str],
+                         aroi_map: Dict[str, dict],
+                         validated_domains: Set[str]):
+    """Build precomputed DNS metric rows for exit relays."""
+    rows = []
+    exit_relays = sorted(
+        [r for r in relays if "Exit" in r.get("flags", [])],
+        key=lambda r: r.get("fingerprint", "")
+    )
+    for relay in exit_relays:
+        fp = relay.get("fingerprint", "")
+        detail = relay.get("exit_dns_health_detail", "untested")
+        failed = 0 if detail in ("success", "untested") else 1
+        if detail in _DNS_STATUS_VALUES:
+            status = detail
+        else:
+            status = "dns_fail" if failed else "success"
+        rows.append({
+            "fingerprint": fp,
+            "familyid": fp_to_family(fp),
+            "status": status,
+            "failed": failed,
+            "latency": relay.get("exit_dns_health_timing_ms"),
+            "consecutive_failures": relay.get("exit_dns_health_consecutive_failures", 0),
+            "nick": relay.get("nickname", ""),
+            "verifiedaroi": _get_verified_aroi(relay, aroi_map, validated_domains),
+        })
+    return rows
+
+
+def _write_dns_health_section(lines: _LineAppender, relay_set,
                               fp_to_family: Callable[[str], str],
                               aroi_map: Dict[str, dict],
                               validated_domains: Set[str]) -> int:
@@ -362,75 +417,60 @@ def _write_dns_health_section(lines: List[str], relay_set,
 
     # --- Per-relay metrics ---
     relays = relay_set.json.get("relays", [])
-    exit_relays = sorted(
-        [r for r in relays if "Exit" in r.get("flags", [])],
-        key=lambda r: r.get("fingerprint", "")
-    )
+    dns_rows = _build_exit_dns_rows(relays, fp_to_family, aroi_map, validated_domains)
 
     # aeo1_exit_dns_failed
     _emit_help_type(lines, "aeo1_exit_dns_failed",
                     "Whether exit relay DNS health check failed (1=failed, 0=healthy)")
-    for relay in exit_relays:
-        fp = relay.get("fingerprint", "")
-        detail = relay.get("exit_dns_health_detail", "untested")
-        failed = 0 if detail in ("success", "untested") else 1
-        # Map detail to allowed status values
-        if detail in _DNS_STATUS_VALUES:
-            status = detail
-        else:
-            status = "dns_fail" if failed else "success"
+    for row in dns_rows:
         _emit(lines, "aeo1_exit_dns_failed", {
-            "fingerprint": fp,
-            "familyid": fp_to_family(fp),
-            "status": status,
-        }, failed)
+            "fingerprint": row["fingerprint"],
+            "familyid": row["familyid"],
+            "status": row["status"],
+        }, row["failed"])
     lines.append("")
 
     # aeo1_exit_dns_latency_ms
     _emit_help_type(lines, "aeo1_exit_dns_latency_ms",
                     "DNS resolution latency in milliseconds for the relay in latest scan")
-    for relay in exit_relays:
-        latency = relay.get("exit_dns_health_timing_ms")
+    for row in dns_rows:
+        latency = row["latency"]
         if latency is not None:
-            fp = relay.get("fingerprint", "")
             _emit(lines, "aeo1_exit_dns_latency_ms", {
-                "fingerprint": fp,
-                "familyid": fp_to_family(fp),
+                "fingerprint": row["fingerprint"],
+                "familyid": row["familyid"],
             }, latency)
     lines.append("")
 
     # aeo1_exit_dns_consecutive_failures
     _emit_help_type(lines, "aeo1_exit_dns_consecutive_failures",
                     "Consecutive DNS scan failures for this relay")
-    for relay in exit_relays:
-        fp = relay.get("fingerprint", "")
-        cf = relay.get("exit_dns_health_consecutive_failures", 0)
+    for row in dns_rows:
         _emit(lines, "aeo1_exit_dns_consecutive_failures", {
-            "fingerprint": fp,
-            "familyid": fp_to_family(fp),
-        }, cf)
+            "fingerprint": row["fingerprint"],
+            "familyid": row["familyid"],
+        }, row["consecutive_failures"])
     lines.append("")
 
     # aeo1_exit_relay_info (non-ABI, mutable labels)
     _emit_help_type(lines, "aeo1_exit_relay_info",
                     "Human-readable exit relay metadata (always 1)")
-    for relay in exit_relays:
-        fp = relay.get("fingerprint", "")
+    for row in dns_rows:
         _emit(lines, "aeo1_exit_relay_info", {
-            "fingerprint": fp,
-            "familyid": fp_to_family(fp),
-            "nick": relay.get("nickname", ""),
-            "verifiedaroi": _get_verified_aroi(relay, aroi_map, validated_domains),
+            "fingerprint": row["fingerprint"],
+            "familyid": row["familyid"],
+            "nick": row["nick"],
+            "verifiedaroi": row["verifiedaroi"],
         }, 1)
 
-    return len(exit_relays)
+    return len(dns_rows)
 
 
 # ---------------------------------------------------------------------------
 # AROI section
 # ---------------------------------------------------------------------------
 
-def _write_aroi_section(lines: List[str], relay_set,
+def _write_aroi_section(lines: _LineAppender, relay_set,
                         fp_to_family: Callable[[str], str],
                         aroi_map: Dict[str, dict]) -> int:
     """Emit AROI state metrics (schema v2). Returns configured relay count."""
@@ -505,8 +545,6 @@ def generate_prometheus_metrics(relay_set, output_dir: str) -> dict:
     Returns:
         dict with generation statistics.
     """
-    lines: List[str] = []
-
     # Build shared lookups once
     aroi_map = _build_aroi_map(relay_set)
     validated_domains = getattr(relay_set, "validated_aroi_domains", set()) or set()
@@ -514,33 +552,31 @@ def generate_prometheus_metrics(relay_set, output_dir: str) -> dict:
     def fp_to_family(fingerprint: str) -> str:
         return _get_family_id(relay_set, fingerprint)
 
-    # Meta — always emitted
-    _write_meta_section(lines, relay_set)
-
-    # DNS Health — conditional
-    exit_count = _write_dns_health_section(
-        lines, relay_set, fp_to_family, aroi_map, validated_domains)
-    dns_available = bool(getattr(relay_set, "exit_dns_health_data", None))
-
-    # AROI — conditional
-    aroi_count = _write_aroi_section(lines, relay_set, fp_to_family, aroi_map)
-    aroi_available = bool(getattr(relay_set, "aroi_validation_data", None))
-
-    # Trailing newline + EOF
-    lines.append("# EOF")
-    lines.append("")
-
-    content = "\n".join(lines)
-
     # Atomic write: tmp file then rename
     os.makedirs(output_dir, exist_ok=True)
     tmp_path = os.path.join(output_dir, "metrics.tmp")
     final_path = os.path.join(output_dir, "metrics")
     with open(tmp_path, "w", encoding="utf-8") as f:
-        f.write(content)
-    os.replace(tmp_path, final_path)
+        lines = _StreamingLineSink(f)
 
-    file_size_kb = round(len(content.encode("utf-8")) / 1024, 1)
+        # Meta — always emitted
+        _write_meta_section(lines, relay_set)
+
+        # DNS Health — conditional
+        exit_count = _write_dns_health_section(
+            lines, relay_set, fp_to_family, aroi_map, validated_domains)
+        dns_available = bool(getattr(relay_set, "exit_dns_health_data", None))
+
+        # AROI — conditional
+        aroi_count = _write_aroi_section(lines, relay_set, fp_to_family, aroi_map)
+        aroi_available = bool(getattr(relay_set, "aroi_validation_data", None))
+
+        # Trailing newline + EOF
+        lines.append("# EOF")
+        lines.append("")
+
+        file_size_kb = round(lines.bytes_written / 1024, 1)
+    os.replace(tmp_path, final_path)
 
     return {
         "exit_relays": exit_count,

--- a/allium/lib/prometheus_metrics.py
+++ b/allium/lib/prometheus_metrics.py
@@ -13,7 +13,7 @@ See docs/prometheus/README.md for the full schema reference.
 import math
 import os
 import time
-from typing import Callable, Dict, List, Optional, Set
+from typing import Callable, Dict, List, Set
 
 from .aroi_validation import _check_aroi_fields
 
@@ -132,17 +132,58 @@ def _build_aroi_map(relay_set) -> Dict[str, dict]:
     return result_map
 
 
-def _get_aroi_state(relay: dict, aroi_map: Dict[str, dict]) -> str:
-    """Classify a relay into one of the schema-v2 AROI states."""
-    if not _is_aroi_configured(relay):
-        return "not_configured"
+def _build_aroi_relay_rows(relays: List[dict], fp_to_family: Callable[[str], str],
+                           aroi_map: Dict[str, dict]):
+    """Build canonical relay rows and aggregate state counts in one pass.
 
-    fp = relay.get("fingerprint", "").upper()
-    entry = aroi_map.get(fp)
-    if not entry:
-        return "configured_unchecked"
+    Returns:
+        tuple(rows, state_counts, configured_count)
+        - rows: list of dicts with precomputed labels/state for emission
+        - state_counts: dict[state] -> count
+        - configured_count: number of configured relays
+    """
+    rows = []
+    state_counts = {state: 0 for state in _AROI_STATE_VALUES}
+    configured_count = 0
 
-    return "configured_checked_valid" if entry.get("valid") else "configured_checked_invalid"
+    for relay in sorted(relays, key=lambda r: r.get("fingerprint", "")):
+        fp = relay.get("fingerprint", "")
+        fp_upper = fp.upper()
+        familyid = fp_to_family(fp)
+
+        configured = _is_aroi_configured(relay)
+        aroi_entry = aroi_map.get(fp_upper, {}) if configured else {}
+
+        if not configured:
+            state = "not_configured"
+            domain = ""
+            proof_type = ""
+        else:
+            configured_count += 1
+            relay_domain = relay.get("aroi_domain", "")
+            if relay_domain in ("none", None):
+                relay_domain = ""
+
+            if not aroi_entry:
+                state = "configured_unchecked"
+            else:
+                state = "configured_checked_valid" if aroi_entry.get("valid") else "configured_checked_invalid"
+
+            domain = aroi_entry.get("domain", "") or relay_domain
+            proof_type = aroi_entry.get("proof_type", "")
+
+        state_counts[state] += 1
+        rows.append({
+            "fingerprint": fp,
+            "familyid": familyid,
+            "nick": relay.get("nickname", ""),
+            "state": state,
+            "configured": configured,
+            "domain": domain,
+            "proof_type": proof_type,
+        })
+
+    return rows, state_counts, configured_count
 
 
 def _get_verified_aroi(relay: dict, aroi_map: Dict[str, dict],
@@ -405,24 +446,18 @@ def _write_aroi_section(lines: List[str], relay_set,
     lines.append("# =========================================================================")
     lines.append("")
 
-    # --- Relay-state classification ---
+    # --- Relay-state classification (single pass precompute) ---
     all_relays = relay_set.json.get("relays", [])
-    relays_sorted = sorted(all_relays, key=lambda r: r.get("fingerprint", ""))
-    state_counts = {state: 0 for state in _AROI_STATE_VALUES}
-    configured_count = 0
+    relay_rows, state_counts, configured_count = _build_aroi_relay_rows(
+        all_relays, fp_to_family, aroi_map)
 
     _emit_help_type(lines, "aeo1_aroi_relay_state",
                     "Canonical AROI relay state in schema v2 (always 1 for emitted state)")
-    for relay in relays_sorted:
-        state = _get_aroi_state(relay, aroi_map)
-        state_counts[state] += 1
-        if state != "not_configured":
-            configured_count += 1
-        fp = relay.get("fingerprint", "")
+    for row in relay_rows:
         _emit(lines, "aeo1_aroi_relay_state", {
-            "fingerprint": fp,
-            "familyid": fp_to_family(fp),
-            "state": state,
+            "fingerprint": row["fingerprint"],
+            "familyid": row["familyid"],
+            "state": row["state"],
         }, 1)
     lines.append("")
 
@@ -442,20 +477,15 @@ def _write_aroi_section(lines: List[str], relay_set,
     # aeo1_aroi_relay_info (non-ABI, mutable labels)
     _emit_help_type(lines, "aeo1_aroi_relay_info",
                     "Human-readable AROI relay metadata for configured relays (always 1)")
-    for relay in relays_sorted:
-        if not _is_aroi_configured(relay):
+    for row in relay_rows:
+        if not row["configured"]:
             continue
-        fp = relay.get("fingerprint", "").upper()
-        aroi_entry = aroi_map.get(fp, {})
-        relay_domain = relay.get("aroi_domain", "")
-        if relay_domain in ("none", None):
-            relay_domain = ""
         _emit(lines, "aeo1_aroi_relay_info", {
-            "fingerprint": relay.get("fingerprint", ""),
-            "familyid": fp_to_family(relay.get("fingerprint", "")),
-            "nick": relay.get("nickname", ""),
-            "domain": aroi_entry.get("domain", "") or relay_domain,
-            "proof_type": aroi_entry.get("proof_type", ""),
+            "fingerprint": row["fingerprint"],
+            "familyid": row["familyid"],
+            "nick": row["nick"],
+            "domain": row["domain"],
+            "proof_type": row["proof_type"],
         }, 1)
 
     return configured_count

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -322,6 +322,7 @@ class Relays:
             
             # Store AROI domain on relay (extracted during contact hashing for efficiency)
             relay["aroi_domain"] = aroi_domain
+            relay["aroi_configured"] = aroi_domain not in ("none", "", None)
             
             # Use AROI domain as key if available, otherwise use contact hash as key
             if aroi_domain and aroi_domain != "none" and contact.strip():

--- a/docs/prometheus/PRODUCTION_CHECKLIST.md
+++ b/docs/prometheus/PRODUCTION_CHECKLIST.md
@@ -1,0 +1,72 @@
+# Prometheus v2 Production Go/No-Go Checklist
+
+Use this checklist before promoting schema v2 changes to production.
+
+## Go/No-Go Gates
+
+| Gate | Validation | Pass Criteria | Status |
+|---|---|---|---|
+| 1. Unit + contract tests | `python3 -m unittest -v tests.unit.test_prometheus_metrics tests.unit.test_prometheus_schema_contract` | All tests pass | ☐ |
+| 2. Prometheus rules syntax | `promtool check rules docs/prometheus/alerts_aroi.yml docs/prometheus/alerts_dns_health.yml docs/prometheus/recording_rules.yml` | `SUCCESS: ...` for all rule files | ☐ |
+| 3. Rule/metric contract | `python3 -m unittest -v tests.unit.test_prometheus_schema_contract` | No unknown `aeo1_` references in alerts/rules | ☐ |
+| 4. Full site generation parity | Generate before/after outputs with all APIs + compare | Diffs reviewed; no unexpected static changes | ☐ |
+| 5. Static asset integrity | SHA256 manifest diff of `www_*/static` | Zero hash diffs | ☐ |
+| 6. Dashboard/query migration | Review all dashboards and alerts using old metric names | No live references to removed v1 AROI metrics | ☐ |
+| 7. Staging scrape health | Deploy to staging Prometheus target | No scrape parse errors, no series churn anomalies | ☐ |
+| 8. Alert dry run | Evaluate key alert expressions in staging | Alerts evaluate as expected for valid/invalid/unchecked states | ☐ |
+| 9. Cardinality budget | Inspect series count and scrape size in staging | Within retention/storage budget | ☐ |
+| 10. Rollback readiness | Document rollback commit + operational steps | Rollback tested or clearly rehearsed | ☐ |
+
+---
+
+## Mandatory command bundle (local)
+
+Run from repo root:
+
+```bash
+python3 -m unittest -v tests.unit.test_prometheus_metrics tests.unit.test_prometheus_schema_contract
+promtool check rules docs/prometheus/alerts_aroi.yml docs/prometheus/alerts_dns_health.yml docs/prometheus/recording_rules.yml
+```
+
+If you changed generation/templating/metrics behavior:
+
+```bash
+# BEFORE
+python3 allium/allium.py --out allium/www_prodcheck_before --apis all --progress
+
+# AFTER
+python3 allium/allium.py --out allium/www_prodcheck_after --apis all --progress
+
+# Compare output
+python3 compare_outputs.py --baseline allium/www_prodcheck_before --after allium/www_prodcheck_after --quiet
+
+# Static-only integrity check
+(cd allium/www_prodcheck_before/static && rg --files | sort | xargs sha256sum) > /tmp/prodcheck_static_before.sha256
+(cd allium/www_prodcheck_after/static && rg --files | sort | xargs sha256sum) > /tmp/prodcheck_static_after.sha256
+diff -u /tmp/prodcheck_static_before.sha256 /tmp/prodcheck_static_after.sha256
+```
+
+---
+
+## Staging validation (required before production)
+
+1. Confirm `up{job="aeo1_tor_metrics"} == 1`.
+2. Confirm freshness:
+   - `time() - aeo1_generation_timestamp_seconds`
+   - `time() - aeo1_exit_scan_timestamp_seconds`
+   - `time() - aeo1_aroi_scan_timestamp_seconds`
+3. Confirm source availability:
+   - `aeo1_source_up{source="exitdnshealth"}`
+   - `aeo1_source_up{source="aroi"}`
+4. Confirm canonical AROI states appear and sum as expected:
+   - `aeo1_aroi_relays_count`
+5. Spot-check joins:
+   - `aeo1_aroi_relay_state{state="configured_checked_invalid"} == 1 and on(fingerprint) aeo1_aroi_relay_info`
+
+---
+
+## Rollout recommendation
+
+1. Canary deploy (single environment/instance).
+2. Observe at least 2 scrape intervals and one full allium regeneration cycle.
+3. Promote to full production only if all gates are green.

--- a/docs/prometheus/README.md
+++ b/docs/prometheus/README.md
@@ -226,6 +226,12 @@ kill -HUP $(pidof prometheus)
 
 See `docs/prometheus/recording_rules.yml` for ready-to-use examples.
 
+## Production Go/No-Go Checklist
+
+Before deploying schema updates to production, run the explicit gate checklist in:
+
+- `docs/prometheus/PRODUCTION_CHECKLIST.md`
+
 ---
 
 ## Schema Policy

--- a/docs/prometheus/README.md
+++ b/docs/prometheus/README.md
@@ -153,6 +153,15 @@ up{job="aeo1_tor_metrics"}
 - Removed legacy per-relay `aeo1_aroi_valid` (ambiguous for unchecked relays).
 - Removed emitted `aeo1_aroi_success_ratio`; compute via `aeo1_aroi_relays_count{state=...}`.
 - Canonical relay state now encoded in `aeo1_aroi_relay_state{state=...}`.
+- DNS behavior update: `status="untested"` now emits `aeo1_exit_dns_failed ... 0` (not failed).
+
+### Migration checklist (recommended)
+
+1. Update all alerts/queries that reference `aeo1_aroi_valid`.
+2. Replace family/domain failure checks with `state="configured_checked_invalid"`.
+3. Add explicit monitoring for `state="configured_unchecked"` to detect validator coverage gaps.
+4. Replace direct `aeo1_aroi_success_ratio` usage with derived expressions from `aeo1_aroi_relays_count`.
+5. Validate rule outputs in a staging Prometheus before production rollout.
 
 ### Side-by-side query mapping (including domain/family joins)
 
@@ -163,6 +172,59 @@ up{job="aeo1_tor_metrics"}
 | Domain failures | `aeo1_aroi_valid == 0 and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}` | `aeo1_aroi_relay_state{state="configured_checked_invalid"} == 1 and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}` |
 | Domain valid | `aeo1_aroi_valid == 1 and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}` | `aeo1_aroi_relay_state{state="configured_checked_valid"} == 1 and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}` |
 | Domain unchecked | not expressible cleanly | `aeo1_aroi_relay_state{state="configured_unchecked"} == 1 and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}` |
+
+---
+
+## Operator Runbook (quick triage)
+
+When an AROI alert fires:
+
+1. **Check source freshness**
+   - `aeo1_source_up{source="aroi"}`
+   - `time() - aeo1_aroi_scan_timestamp_seconds`
+2. **Identify state**
+   - `configured_checked_invalid` => validator checked and failed
+   - `configured_unchecked` => validator had no result for relay fingerprint
+3. **Drill down per relay**
+   - `aeo1_aroi_relay_state{state="configured_checked_invalid"} == 1 and on(fingerprint) aeo1_aroi_relay_info`
+4. **Assess blast radius**
+   - `aeo1_aroi_relays_count{state="configured_checked_invalid"}`
+   - `aeo1_aroi_relays_count{state="configured_unchecked"}`
+
+## Aggregate-only dashboard mode (low cardinality)
+
+If you do not need per-relay visuals, build dashboards from `aeo1_aroi_relays_count` only:
+
+```promql
+# State distribution (4-series panel)
+aeo1_aroi_relays_count
+
+# Checked coverage over configured relays
+(aeo1_aroi_relays_count{state="configured_checked_invalid"}
+ + aeo1_aroi_relays_count{state="configured_checked_valid"})
+/
+(aeo1_aroi_relays_count{state="configured_unchecked"}
+ + aeo1_aroi_relays_count{state="configured_checked_invalid"}
+ + aeo1_aroi_relays_count{state="configured_checked_valid"})
+
+# Success over configured relays
+aeo1_aroi_relays_count{state="configured_checked_valid"}
+/
+(aeo1_aroi_relays_count{state="configured_unchecked"}
+ + aeo1_aroi_relays_count{state="configured_checked_invalid"}
+ + aeo1_aroi_relays_count{state="configured_checked_valid"})
+```
+
+## Recording rules (optional)
+
+If you want stable precomputed ratio series, use recording rules:
+
+```bash
+cp recording_rules.yml /etc/prometheus/rules/
+kill -HUP $(pidof prometheus)
+```
+
+See `docs/prometheus/recording_rules.yml` for ready-to-use examples.
 
 ---
 

--- a/docs/prometheus/README.md
+++ b/docs/prometheus/README.md
@@ -3,7 +3,7 @@
 Prometheus endpoint for monitoring Tor exit relay DNS health and AROI validation status.
 
 **Endpoint:** `https://metrics.1aeo.com/metrics`  
-**Schema:** v1  
+**Schema:** v2  
 **Update frequency:** Every 30 minutes (allium regeneration cycle)  
 **Format:** Prometheus text exposition format 0.0.4
 
@@ -16,9 +16,6 @@ Prometheus endpoint for monitoring Tor exit relay DNS health and AROI validation
 ```yaml
 scrape_configs:
   - job_name: 'aeo1_tor_metrics'
-    # 1m recommended. Data updates every 30 min but Prometheus needs
-    # sub-5m scrapes for reliable alerting (default lookback is 5m).
-    # Endpoint is ~220KB gzipped — 1m scraping is fine.
     scrape_interval: 1m
     scrape_timeout: 30s
     static_configs:
@@ -29,15 +26,8 @@ scrape_configs:
 ### Install Alert Rules
 
 ```bash
-# Copy alert rules to your Prometheus rules directory
 cp alerts_dns_health.yml /etc/prometheus/rules/
 cp alerts_aroi.yml /etc/prometheus/rules/
-
-# Edit: replace YOUR_FAMILY_ID and YOUR_DOMAIN with your values
-vim /etc/prometheus/rules/alerts_dns_health.yml
-vim /etc/prometheus/rules/alerts_aroi.yml
-
-# Reload Prometheus
 kill -HUP $(pidof prometheus)
 ```
 
@@ -49,10 +39,10 @@ kill -HUP $(pidof prometheus)
 
 | Metric | Labels | Description |
 |--------|--------|-------------|
-| `aeo1_build_info` | `schema`, `generator` | Schema version (always 1) |
-| `aeo1_generation_timestamp_seconds` | — | When this file was generated |
-| `aeo1_source_up` | `source` | 1=data available, 0=unavailable |
-| `aeo1_source_last_success_timestamp_seconds` | `source` | Last successful ingest, 0 if never |
+| `aeo1_build_info` | `schema`, `generator` | Schema version/build info (v2) |
+| `aeo1_generation_timestamp_seconds` | — | Metrics file generation time |
+| `aeo1_source_up` | `source` | 1=data source available, 0=unavailable |
+| `aeo1_source_last_success_timestamp_seconds` | `source` | Last successful ingest timestamp, 0 if never |
 
 `source` values: `exitdnshealth`, `aroi`
 
@@ -62,128 +52,123 @@ kill -HUP $(pidof prometheus)
 |--------|--------|-------------|
 | `aeo1_exit_consensus_relays_count` | — | Total exit relays in consensus |
 | `aeo1_exit_tested_relays_count` | — | Relays with DNS test results |
-| `aeo1_exit_unreachable_relays_count` | — | Relays with circuit failures |
+| `aeo1_exit_unreachable_relays_count` | — | Relays unreachable during latest scan |
 | `aeo1_exit_dns_success_ratio` | — | Success fraction (0..1) |
 | `aeo1_exit_reachability_ratio` | — | Reachability fraction (0..1) |
 | `aeo1_exit_dns_errors_count` | `error_type` | Error count by type |
 | `aeo1_exit_dns_latency_ms_stat` | `stat` | Latency statistics (ms) |
-| `aeo1_exit_scan_timestamp_seconds` | — | When DNS scan ran |
+| `aeo1_exit_scan_timestamp_seconds` | — | Exit DNS scan timestamp |
 
-`error_type` values: `fail`, `timeout`, `wrong_ip`, `socks_error`, `network_error`, `exception`  
+`error_type` values: `fail`, `timeout`, `wrong_ip`, `socks_error`, `network_error`, `error`, `exception`, `unknown`  
 `stat` values: `p50`, `p95`, `p99`, `avg`, `min`, `max`
 
-### Exit DNS Health — Per-Relay (exit relays only)
+### Exit DNS Health — Per Relay (exit relays only)
 
 | Metric | Frozen Labels | Description |
 |--------|---------------|-------------|
-| `aeo1_exit_dns_failed` | `fingerprint`, `familyid`, `status` | 1=failed, 0=healthy |
-| `aeo1_exit_dns_latency_ms` | `fingerprint`, `familyid` | Latency (ms), omitted if untested |
+| `aeo1_exit_dns_failed` | `fingerprint`, `familyid`, `status` | 1=failed, 0=healthy/untested |
+| `aeo1_exit_dns_latency_ms` | `fingerprint`, `familyid` | Latency (ms), omitted when unavailable |
 | `aeo1_exit_dns_consecutive_failures` | `fingerprint`, `familyid` | Consecutive failure streak |
 | `aeo1_exit_relay_info` | `fingerprint`, `familyid`, `nick`, `verifiedaroi` | Relay metadata (always 1, non-ABI) |
 
-`status` values: `success`, `dns_fail`, `timeout`, `relay_unreachable`
+`status` values: `success`, `dns_fail`, `timeout`, `relay_unreachable`, `untested`
 
-### AROI Monitoring — Aggregates
+### AROI Monitoring — Relay State Model (schema v2)
+
+AROI status is represented by a single canonical relay state enum.
 
 | Metric | Labels | Description |
 |--------|--------|-------------|
-| `aeo1_aroi_network_relays_count` | — | Total relays in network |
-| `aeo1_aroi_configured_relays_count` | — | Relays with all 3 AROI fields |
-| `aeo1_aroi_valid_relays_count` | — | Configured + validated |
-| `aeo1_aroi_success_ratio` | — | Validation fraction (0..1) |
-| `aeo1_aroi_proof_type_count` | `proof_type`, `result` | Count by proof type |
-| `aeo1_aroi_scan_timestamp_seconds` | — | When AROI scan ran |
+| `aeo1_aroi_relay_state` | `fingerprint`, `familyid`, `state` | Per-relay AROI state (always 1 for emitted state) |
+| `aeo1_aroi_relays_count` | `state` | Aggregate relay count by state |
+| `aeo1_aroi_scan_timestamp_seconds` | — | AROI scan timestamp |
+| `aeo1_aroi_relay_info` | `fingerprint`, `familyid`, `nick`, `domain`, `proof_type` | Configured relay metadata (always 1, non-ABI) |
 
-`proof_type` values: `uri-rsa`, `dns-rsa`  
-`result` values: `valid`, `total`
+Frozen `state` label values:
+- `not_configured`
+- `configured_unchecked`
+- `configured_checked_invalid`
+- `configured_checked_valid`
 
-### AROI Monitoring — Per-Relay (configured relays only)
-
-| Metric | Frozen Labels | Description |
-|--------|---------------|-------------|
-| `aeo1_aroi_valid` | `fingerprint`, `familyid` | 1=valid, 0=failing |
-| `aeo1_aroi_relay_info` | `fingerprint`, `familyid`, `nick`, `domain`, `proof_type` | Relay metadata (always 1, non-ABI) |
+Interpretation:
+- `configured_checked_invalid` = validation was attempted and failed
+- `configured_unchecked` = relay is configured, but validator had no result for its fingerprint
 
 ---
 
-## PromQL Cheatsheet
+## PromQL Cheatsheet (v2)
 
-### DNS Health — Filter by Family
+### AROI State Queries
 
 ```promql
-# All relays in my family:
-aeo1_exit_dns_failed{familyid="YOUR_FAMILY_ID"}
+# Family: checked + invalid relays
+aeo1_aroi_relay_state{familyid="YOUR_FAMILY_ID",state="configured_checked_invalid"} == 1
 
-# Failing relays in my family:
-aeo1_exit_dns_failed{familyid="YOUR_FAMILY_ID"} == 1
+# Family: checked + valid relays
+aeo1_aroi_relay_state{familyid="YOUR_FAMILY_ID",state="configured_checked_valid"} == 1
 
-# Count of healthy vs failing:
-count(aeo1_exit_dns_failed{familyid="YOUR_FAMILY_ID"} == 0)  # healthy
-count(aeo1_exit_dns_failed{familyid="YOUR_FAMILY_ID"} == 1)  # failing
+# Domain: checked + invalid relays
+aeo1_aroi_relay_state{state="configured_checked_invalid"} == 1
+  and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}
 
-# Average latency for my family:
-avg(aeo1_exit_dns_latency_ms{familyid="YOUR_FAMILY_ID"})
-
-# Relays with escalating failures:
-aeo1_exit_dns_consecutive_failures{familyid="YOUR_FAMILY_ID"} > 2
+# Domain: configured but unchecked relays
+aeo1_aroi_relay_state{state="configured_unchecked"} == 1
+  and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}
 ```
 
-### DNS Health — Filter by AROI Domain
+### Derived Ratios (from canonical counts)
 
 ```promql
-# All relays for my AROI domain (join with info metric):
-aeo1_exit_dns_failed == 1
-  and on(fingerprint) aeo1_exit_relay_info{verifiedaroi="www.1aeo.com"}
+# Success ratio over configured relays
+aeo1_aroi_relays_count{state="configured_checked_valid"}
+/
+(aeo1_aroi_relays_count{state="configured_unchecked"}
+ + aeo1_aroi_relays_count{state="configured_checked_invalid"}
+ + aeo1_aroi_relays_count{state="configured_checked_valid"})
 
-# Nicknames of my failing relays:
-aeo1_exit_relay_info
-  and on(fingerprint) (aeo1_exit_dns_failed{familyid="YOUR_FAMILY_ID"} == 1)
-```
-
-### AROI Monitoring
-
-```promql
-# My relays with broken AROI:
-aeo1_aroi_valid{familyid="YOUR_FAMILY_ID"} == 0
-
-# AROI failing for a specific domain:
-aeo1_aroi_valid == 0
-  and on(fingerprint) aeo1_aroi_relay_info{domain="www.1aeo.com"}
-
-# Network AROI adoption rate:
-aeo1_aroi_success_ratio
+# Checked coverage ratio over configured relays
+(aeo1_aroi_relays_count{state="configured_checked_invalid"}
+ + aeo1_aroi_relays_count{state="configured_checked_valid"})
+/
+(aeo1_aroi_relays_count{state="configured_unchecked"}
+ + aeo1_aroi_relays_count{state="configured_checked_invalid"}
+ + aeo1_aroi_relays_count{state="configured_checked_valid"})
 ```
 
 ### Freshness
 
 ```promql
-# How old is the metrics file:
 time() - aeo1_generation_timestamp_seconds
-
-# How old is the DNS scan data:
 time() - aeo1_exit_scan_timestamp_seconds
-
-# Is the endpoint reachable:
+time() - aeo1_aroi_scan_timestamp_seconds
 up{job="aeo1_tor_metrics"}
 ```
 
 ---
 
-## Schema Policy
+## Migration: v1 → v2
 
-- **v1 is frozen**: metric names, types, and frozen label keys will not change
-- **Non-ABI metrics** (`_info` metrics): label keys may evolve without schema bump
-- **New metrics** may be added without schema bump
-- **Breaking changes** (renames, type changes, frozen label changes): require schema version bump in `aeo1_build_info`
-- **`familyid` encoding**: currently 64-char uppercase hex (CollecTor Ed25519 key). Will change to base64 when onionoo adds `family_ids` support — this will require a schema bump
+### Breaking changes
+
+- Removed legacy per-relay `aeo1_aroi_valid` (ambiguous for unchecked relays).
+- Removed emitted `aeo1_aroi_success_ratio`; compute via `aeo1_aroi_relays_count{state=...}`.
+- Canonical relay state now encoded in `aeo1_aroi_relay_state{state=...}`.
+
+### Side-by-side query mapping (including domain/family joins)
+
+| Intent | v1 | v2 |
+|---|---|---|
+| Family failures | `aeo1_aroi_valid{familyid="YOUR_FAMILY_ID"} == 0` | `aeo1_aroi_relay_state{familyid="YOUR_FAMILY_ID",state="configured_checked_invalid"} == 1` |
+| Family valid | `aeo1_aroi_valid{familyid="YOUR_FAMILY_ID"} == 1` | `aeo1_aroi_relay_state{familyid="YOUR_FAMILY_ID",state="configured_checked_valid"} == 1` |
+| Domain failures | `aeo1_aroi_valid == 0 and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}` | `aeo1_aroi_relay_state{state="configured_checked_invalid"} == 1 and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}` |
+| Domain valid | `aeo1_aroi_valid == 1 and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}` | `aeo1_aroi_relay_state{state="configured_checked_valid"} == 1 and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}` |
+| Domain unchecked | not expressible cleanly | `aeo1_aroi_relay_state{state="configured_unchecked"} == 1 and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}` |
 
 ---
 
-## Data Freshness
+## Schema Policy
 
-| Source | Update Frequency | Metric |
-|--------|-----------------|--------|
-| Allium generation | Every 30 min | `aeo1_generation_timestamp_seconds` |
-| Exit DNS health scan | Every 6-12 hours | `aeo1_exit_scan_timestamp_seconds` |
-| AROI validation | Every few hours | `aeo1_aroi_scan_timestamp_seconds` |
-| CollecTor family keys | Hourly incremental | (embedded in `familyid` labels) |
+- **v2 state labels are frozen** for `aeo1_aroi_relay_state` and `aeo1_aroi_relays_count`.
+- **Non-ABI `_info` metrics** may evolve label keys without schema bump.
+- **New additive metrics** may be added without schema bump.
+- **Breaking changes** require schema bump in `aeo1_build_info`.

--- a/docs/prometheus/alerts_aroi.yml
+++ b/docs/prometheus/alerts_aroi.yml
@@ -6,6 +6,7 @@
 #
 # Source: https://github.com/1aeo/allium/docs/prometheus/
 # Metrics endpoint: https://metrics.1aeo.com/metrics
+# Optional recording rules: docs/prometheus/recording_rules.yml
 
 groups:
   - name: aeo1_aroi_monitoring
@@ -47,6 +48,15 @@ groups:
           severity: warning
         annotations:
           summary: "{{ $value }} configured relay(s) missing validator result"
+
+      # Optional if you install recording_rules.yml:
+      # - alert: AroiCheckedCoverageLow
+      #   expr: aeo1_aroi_checked_ratio_derived < 0.95
+      #   for: 1h
+      #   labels:
+      #     severity: warning
+      #   annotations:
+      #     summary: "AROI checked coverage is low ({{ $value | humanizePercentage }})"
 
   - name: aeo1_freshness
     interval: 1m

--- a/docs/prometheus/alerts_aroi.yml
+++ b/docs/prometheus/alerts_aroi.yml
@@ -1,5 +1,5 @@
 # 1AEO AROI Monitoring + Freshness Alerts
-# Schema: v1
+# Schema: v2
 # Install: copy to /etc/prometheus/rules/ and reload Prometheus
 # Customize: replace YOUR_FAMILY_ID with your Ed25519 family key (64-char hex)
 #            replace YOUR_DOMAIN with your AROI domain (e.g., www.1aeo.com)
@@ -12,24 +12,24 @@ groups:
     interval: 1m
     rules:
 
-      # AROI configured but validation failing (proof file removed? DNS changed?)
+      # AROI configured and checked, but validation failing
       - alert: AroiValidationLost
         expr: >
-          aeo1_aroi_valid{familyid="YOUR_FAMILY_ID"} == 0
+          aeo1_aroi_relay_state{familyid="YOUR_FAMILY_ID",state="configured_checked_invalid"} == 1
           and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}
         for: 1h
         labels:
           severity: critical
         annotations:
           summary: "AROI validation FAILED for {{ $labels.nick }}"
-          description: "Check proof file at {{ $labels.domain }}"
+          description: "Check proof file for {{ $labels.domain }}"
           dashboard: "https://metrics.1aeo.com/relay/{{ $labels.fingerprint }}/"
 
       # Multiple relays failing for same domain (proof server or DNS down)
       - alert: AroiDomainOutage
         expr: >
           count(
-            aeo1_aroi_valid == 0
+            aeo1_aroi_relay_state{state="configured_checked_invalid"} == 1
             and on(fingerprint) aeo1_aroi_relay_info{domain="YOUR_DOMAIN"}
           ) > 5
         for: 30m
@@ -37,6 +37,16 @@ groups:
           severity: critical
         annotations:
           summary: "{{ $value }} relays failing AROI validation for YOUR_DOMAIN"
+
+      # Configured relays are not being checked (validator coverage gap)
+      - alert: AroiUncheckedRelaysPresent
+        expr: >
+          aeo1_aroi_relays_count{state="configured_unchecked"} > 0
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $value }} configured relay(s) missing validator result"
 
   - name: aeo1_freshness
     interval: 1m

--- a/docs/prometheus/alerts_dns_health.yml
+++ b/docs/prometheus/alerts_dns_health.yml
@@ -1,5 +1,5 @@
 # 1AEO Exit DNS Health Alerts
-# Schema: v1
+# Schema: v2
 # Install: copy to /etc/prometheus/rules/ and reload Prometheus
 # Customize: replace YOUR_FAMILY_ID with your Ed25519 family key (64-char hex)
 #            or use verifiedaroi label via info metric joins

--- a/docs/prometheus/recording_rules.yml
+++ b/docs/prometheus/recording_rules.yml
@@ -30,19 +30,11 @@ groups:
             + aeo1_aroi_relays_count{state="configured_checked_valid"}
           )
           /
-          (
-            aeo1_aroi_relays_count{state="configured_unchecked"}
-            + aeo1_aroi_relays_count{state="configured_checked_invalid"}
-            + aeo1_aroi_relays_count{state="configured_checked_valid"}
-          )
+          clamp_min(aeo1_aroi_configured_relays_count_derived, 1)
 
       # Success ratio over configured relays
       - record: aeo1_aroi_success_ratio_derived
         expr: >
           aeo1_aroi_relays_count{state="configured_checked_valid"}
           /
-          (
-            aeo1_aroi_relays_count{state="configured_unchecked"}
-            + aeo1_aroi_relays_count{state="configured_checked_invalid"}
-            + aeo1_aroi_relays_count{state="configured_checked_valid"}
-          )
+          clamp_min(aeo1_aroi_configured_relays_count_derived, 1)

--- a/docs/prometheus/recording_rules.yml
+++ b/docs/prometheus/recording_rules.yml
@@ -1,0 +1,48 @@
+# 1AEO Prometheus Recording Rules (Schema v2)
+# Optional: precompute common AROI ratios for simpler dashboards/alerts.
+#
+# Install:
+#   cp recording_rules.yml /etc/prometheus/rules/
+#   kill -HUP $(pidof prometheus)
+
+groups:
+  - name: aeo1_aroi_recording
+    interval: 1m
+    rules:
+      # Configured relay denominator: unchecked + checked-invalid + checked-valid
+      - record: aeo1_aroi_configured_relays_count_derived
+        expr: >
+          aeo1_aroi_relays_count{state="configured_unchecked"}
+          + aeo1_aroi_relays_count{state="configured_checked_invalid"}
+          + aeo1_aroi_relays_count{state="configured_checked_valid"}
+
+      # Checked relay numerator: checked-invalid + checked-valid
+      - record: aeo1_aroi_checked_relays_count_derived
+        expr: >
+          aeo1_aroi_relays_count{state="configured_checked_invalid"}
+          + aeo1_aroi_relays_count{state="configured_checked_valid"}
+
+      # Checked coverage ratio over configured relays
+      - record: aeo1_aroi_checked_ratio_derived
+        expr: >
+          (
+            aeo1_aroi_relays_count{state="configured_checked_invalid"}
+            + aeo1_aroi_relays_count{state="configured_checked_valid"}
+          )
+          /
+          (
+            aeo1_aroi_relays_count{state="configured_unchecked"}
+            + aeo1_aroi_relays_count{state="configured_checked_invalid"}
+            + aeo1_aroi_relays_count{state="configured_checked_valid"}
+          )
+
+      # Success ratio over configured relays
+      - record: aeo1_aroi_success_ratio_derived
+        expr: >
+          aeo1_aroi_relays_count{state="configured_checked_valid"}
+          /
+          (
+            aeo1_aroi_relays_count{state="configured_unchecked"}
+            + aeo1_aroi_relays_count{state="configured_checked_invalid"}
+            + aeo1_aroi_relays_count{state="configured_checked_valid"}
+          )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package namespace."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,12 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+from tests.unit.prometheus_fixtures import (
+    make_relay as _make_relay,
+    make_relay_set as _make_relay_set,
+    sample_aroi_data as _sample_aroi_data,
+    sample_dns_metadata as _sample_dns_metadata,
+)
 
 # ============================================================================
 # PATH SETUP
@@ -76,6 +82,31 @@ def temp_dir():
     """Fixture that provides a temporary directory that's cleaned up after the test."""
     with tempfile.TemporaryDirectory() as tmpdir:
         yield tmpdir
+
+
+@pytest.fixture
+def make_relay():
+    return _make_relay
+
+
+@pytest.fixture
+def make_relay_set():
+    return _make_relay_set
+
+
+@pytest.fixture
+def sample_aroi_data():
+    return _sample_aroi_data
+
+
+@pytest.fixture
+def sample_aroi_metadata():
+    return _sample_aroi_data
+
+
+@pytest.fixture
+def sample_dns_metadata():
+    return _sample_dns_metadata
 
 
 @pytest.fixture

--- a/tests/unit/prometheus_fixtures.py
+++ b/tests/unit/prometheus_fixtures.py
@@ -1,0 +1,96 @@
+"""
+Shared fixtures for Prometheus metrics unit tests.
+"""
+
+
+def make_relay(
+    fingerprint,
+    nickname="TestRelay",
+    flags=None,
+    contact="",
+    dns_status="success",
+    dns_timing=1000,
+    dns_consecutive=0,
+    aroi_domain="none",
+):
+    return {
+        "fingerprint": fingerprint,
+        "nickname": nickname,
+        "flags": flags or ["Exit", "Fast", "Guard", "Running", "Stable", "Valid"],
+        "contact": contact,
+        "aroi_domain": aroi_domain,
+        "exit_dns_health_status": "success" if dns_status == "success" else "fail",
+        "exit_dns_health_detail": dns_status,
+        "exit_dns_health_timing_ms": dns_timing,
+        "exit_dns_health_consecutive_failures": dns_consecutive,
+    }
+
+
+def make_relay_set(
+    relays,
+    exit_dns_health_data=None,
+    aroi_validation_data=None,
+    fp_to_family_key=None,
+    validated_aroi_domains=None,
+):
+    class MockRelaySet:
+        pass
+
+    rs = MockRelaySet()
+    rs.json = {"relays": relays}
+    rs.exit_dns_health_data = exit_dns_health_data
+    rs.aroi_validation_data = aroi_validation_data
+    rs._fp_to_family_key = fp_to_family_key or {}
+    rs.validated_aroi_domains = validated_aroi_domains or set()
+    return rs
+
+
+def sample_dns_metadata():
+    return {
+        "metadata": {
+            "timestamp": "2026-03-08T08:00:00Z",
+            "consensus_relays": 100,
+            "tested_relays": 95,
+            "unreachable_relays": 5,
+            "dns_success": 90,
+            "dns_fail": 3,
+            "dns_timeout": 1,
+            "dns_wrong_ip": 1,
+            "dns_socks_error": 0,
+            "dns_network_error": 0,
+            "dns_error": 0,
+            "dns_exception": 0,
+            "dns_unknown": 0,
+            "timing": {
+                "total": {
+                    "avg_ms": 15000,
+                    "min_ms": 200,
+                    "max_ms": 30000,
+                    "p50_ms": 14000,
+                    "p95_ms": 25000,
+                    "p99_ms": 28000,
+                }
+            },
+        }
+    }
+
+
+def sample_aroi_data():
+    return {
+        "metadata": {
+            "timestamp": "2026-03-08T10:00:00Z",
+            "total_relays": 200,
+            "valid_relays": 50,
+            "invalid_relays": 150,
+        },
+        "statistics": {
+            "proof_types": {
+                "uri_rsa": {"total": 40, "valid": 38},
+                "dns_rsa": {"total": 10, "valid": 8},
+            }
+        },
+        "results": [
+            {"fingerprint": "AAAA", "valid": True, "domain": "example.com", "proof_type": "uri-rsa"},
+            {"fingerprint": "BBBB", "valid": False, "domain": "broken.org", "proof_type": "dns-rsa"},
+        ],
+    }

--- a/tests/unit/prometheus_fixtures.py
+++ b/tests/unit/prometheus_fixtures.py
@@ -13,13 +13,20 @@ def make_relay(
     dns_consecutive=0,
     aroi_domain="none",
 ):
+    if dns_status == "success":
+        health_status = "success"
+    elif dns_status == "untested":
+        health_status = "untested"
+    else:
+        health_status = "fail"
+
     return {
         "fingerprint": fingerprint,
         "nickname": nickname,
         "flags": flags or ["Exit", "Fast", "Guard", "Running", "Stable", "Valid"],
         "contact": contact,
         "aroi_domain": aroi_domain,
-        "exit_dns_health_status": "success" if dns_status == "success" else "fail",
+        "exit_dns_health_status": health_status,
         "exit_dns_health_detail": dns_status,
         "exit_dns_health_timing_ms": dns_timing,
         "exit_dns_health_consecutive_failures": dns_consecutive,

--- a/tests/unit/test_prometheus_metrics.py
+++ b/tests/unit/test_prometheus_metrics.py
@@ -19,40 +19,13 @@ from allium.lib.prometheus_metrics import (
     _sanitize_prom_label,
     generate_prometheus_metrics,
 )
-from tests.unit.prometheus_fixtures import (
-    make_relay as _make_relay,
-    make_relay_set as _make_relay_set,
-    sample_aroi_data as _sample_aroi_data,
-    sample_dns_metadata as _sample_dns_metadata,
-)
-
 _USE_DEFAULT = object()
-
-
-@pytest.fixture
-def make_relay():
-    return _make_relay
-
-
-@pytest.fixture
-def make_relay_set():
-    return _make_relay_set
-
-
-@pytest.fixture
-def sample_aroi_data():
-    return _sample_aroi_data
-
-
-@pytest.fixture
-def sample_dns_metadata():
-    return _sample_dns_metadata
-
 
 def _generate(
     tmp_path: Path,
     make_relay_set,
     sample_dns_metadata,
+    sample_aroi_metadata,
     relays,
     dns_data=_USE_DEFAULT,
     aroi_data=_USE_DEFAULT,
@@ -60,7 +33,7 @@ def _generate(
     validated_domains=None,
 ) -> tuple[str, dict]:
     selected_dns = sample_dns_metadata() if dns_data is _USE_DEFAULT else dns_data
-    selected_aroi = _sample_aroi_data() if aroi_data is _USE_DEFAULT else aroi_data
+    selected_aroi = sample_aroi_metadata() if aroi_data is _USE_DEFAULT else aroi_data
     rs = make_relay_set(
         relays,
         exit_dns_health_data=selected_dns,
@@ -173,54 +146,59 @@ def test_build_aroi_map_uppercase(make_relay_set, sample_aroi_data):
     assert amap["BBBB"]["valid"] is False
 
 
-def test_dns_metrics_healthy(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
-    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, [make_relay("AAAA", dns_status="success")])
+def test_dns_metrics_healthy(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_metadata):
+    content, _ = _generate(
+        tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, [make_relay("AAAA", dns_status="success")]
+    )
     assert 'aeo1_exit_dns_failed{fingerprint="AAAA",familyid="",status="success"} 0' in content
 
 
-def test_dns_metrics_failure(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
+def test_dns_metrics_failure(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_metadata):
     relays = [make_relay("BBBB", dns_status="dns_fail", dns_timing=5000, dns_consecutive=3)]
-    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays)
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, relays)
     assert 'aeo1_exit_dns_failed{fingerprint="BBBB",familyid="",status="dns_fail"} 1' in content
     assert 'aeo1_exit_dns_latency_ms{fingerprint="BBBB",familyid=""} 5000' in content
     assert 'aeo1_exit_dns_consecutive_failures{fingerprint="BBBB",familyid=""} 3' in content
 
 
-def test_dns_unreachable_no_latency(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
+def test_dns_unreachable_no_latency(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_metadata):
     relays = [make_relay("CCCC", dns_status="relay_unreachable", dns_timing=None)]
-    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays)
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, relays)
     assert 'aeo1_exit_dns_failed{fingerprint="CCCC",familyid="",status="relay_unreachable"} 1' in content
     assert 'aeo1_exit_dns_latency_ms{fingerprint="CCCC"' not in content
 
 
-def test_dns_untested_not_failed(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
+def test_dns_untested_not_failed(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_metadata):
     relays = [make_relay("DDDD", dns_status="untested", dns_timing=None)]
-    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays)
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, relays)
     assert 'aeo1_exit_dns_failed{fingerprint="DDDD",familyid="",status="untested"} 0' in content
     assert 'aeo1_exit_dns_latency_ms{fingerprint="DDDD"' not in content
 
 
-def test_dns_non_exit_excluded(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+def test_dns_non_exit_excluded(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data,
+                               sample_aroi_metadata):
     relays = [make_relay("AAAA", flags=["Guard", "Running"]), make_relay("BBBB", flags=["Exit", "Running"])]
     content, stats = _generate(
-        tmp_path, make_relay_set, sample_dns_metadata, relays, aroi_data=sample_aroi_data()
+        tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, relays, aroi_data=sample_aroi_data()
     )
     assert stats["exit_relays"] == 1
     assert 'aeo1_exit_dns_failed{fingerprint="AAAA"' not in content
 
 
-def test_dns_familyid_populated(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
+def test_dns_familyid_populated(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_metadata):
     content, _ = _generate(
         tmp_path,
         make_relay_set,
         sample_dns_metadata,
+        sample_aroi_metadata,
         [make_relay("AAAA")],
         fp_to_family={"AAAA": "MYFAMKEY"},
     )
     assert 'familyid="MYFAMKEY"' in content
 
 
-def test_dns_verifiedaroi_info(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+def test_dns_verifiedaroi_info(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data,
+                               sample_aroi_metadata):
     relays = [make_relay("AAAA", aroi_domain="example.com", contact="url:https://example.com proof:uri-rsa ciissversion:2")]
     aroi_data = sample_aroi_data()
     aroi_data["results"] = [{"fingerprint": "AAAA", "valid": True, "domain": "example.com", "proof_type": "uri-rsa"}]
@@ -228,6 +206,7 @@ def test_dns_verifiedaroi_info(tmp_path, make_relay, make_relay_set, sample_dns_
         tmp_path,
         make_relay_set,
         sample_dns_metadata,
+        sample_aroi_metadata,
         relays,
         aroi_data=aroi_data,
         validated_domains={"example.com"},
@@ -235,21 +214,27 @@ def test_dns_verifiedaroi_info(tmp_path, make_relay, make_relay_set, sample_dns_
     assert 'verifiedaroi="example.com"' in content
 
 
-def test_dns_metrics_sorted_by_fingerprint(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+def test_dns_metrics_sorted_by_fingerprint(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data,
+                                           sample_aroi_metadata):
     relays = [make_relay("CCCC"), make_relay("AAAA"), make_relay("BBBB")]
-    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays, aroi_data=sample_aroi_data())
+    content, _ = _generate(
+        tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, relays, aroi_data=sample_aroi_data()
+    )
     fps = re.findall(r'aeo1_exit_dns_failed\{fingerprint="(\w+)"', content)
     assert fps == sorted(fps)
 
 
-def test_aroi_state_and_counts(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+def test_aroi_state_and_counts(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data,
+                               sample_aroi_metadata):
     relays = [
         make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com"),
         make_relay("BBBB", contact="url:https://broken.org proof:dns-rsa ciissversion:2", aroi_domain="broken.org"),
         make_relay("CCCC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org"),
         make_relay("DDDD", contact="plain"),
     ]
-    content, stats = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays, aroi_data=sample_aroi_data())
+    content, stats = _generate(
+        tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, relays, aroi_data=sample_aroi_data()
+    )
     assert stats["aroi_relays"] == 3
     assert 'state="configured_checked_valid"} 1' in content
     assert 'state="configured_checked_invalid"} 1' in content
@@ -261,14 +246,17 @@ def test_aroi_state_and_counts(tmp_path, make_relay, make_relay_set, sample_dns_
     assert 'aeo1_aroi_relays_count{state="configured_checked_valid"} 1' in content
 
 
-def test_aroi_exactly_one_state_per_relay(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+def test_aroi_exactly_one_state_per_relay(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data,
+                                          sample_aroi_metadata):
     relays = [
         make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com"),
         make_relay("BBBB", contact="url:https://broken.org proof:dns-rsa ciissversion:2", aroi_domain="broken.org"),
         make_relay("CCCC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org"),
         make_relay("DDDD", contact="plain"),
     ]
-    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays, aroi_data=sample_aroi_data())
+    content, _ = _generate(
+        tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, relays, aroi_data=sample_aroi_data()
+    )
     for fp in ("AAAA", "BBBB", "CCCC", "DDDD"):
         matches = re.findall(
             rf'^aeo1_aroi_relay_state\{{fingerprint="{fp}",familyid="",state="[^"]+"\}} 1$',
@@ -278,51 +266,63 @@ def test_aroi_exactly_one_state_per_relay(tmp_path, make_relay, make_relay_set, 
         assert len(matches) == 1, f"expected exactly one state for {fp}"
 
 
-def test_aroi_legacy_metrics_removed(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+def test_aroi_legacy_metrics_removed(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data,
+                                     sample_aroi_metadata):
     relays = [make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")]
-    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays, aroi_data=sample_aroi_data())
+    content, _ = _generate(
+        tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, relays, aroi_data=sample_aroi_data()
+    )
     assert "aeo1_aroi_valid{" not in content
     assert "aeo1_aroi_success_ratio" not in content
 
 
-def test_aroi_unchecked_relay_info_uses_claimed_domain(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+def test_aroi_unchecked_relay_info_uses_claimed_domain(tmp_path, make_relay, make_relay_set, sample_dns_metadata,
+                                                       sample_aroi_data, sample_aroi_metadata):
     relays = [make_relay("CCCC", nickname="RelayC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org")]
-    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays, aroi_data=sample_aroi_data())
+    content, _ = _generate(
+        tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, relays, aroi_data=sample_aroi_data()
+    )
     line = next((ln for ln in content.split("\n") if ln.startswith('aeo1_aroi_relay_info{fingerprint="CCCC"')), "")
     assert 'domain="missing.org"' in line
 
 
-def test_source_availability_permutations(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+def test_source_availability_permutations(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data,
+                                          sample_aroi_metadata):
     relay = make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
     # both up
     content, _ = _generate(
-        tmp_path, make_relay_set, sample_dns_metadata, [relay], aroi_data=sample_aroi_data()
+        tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, [relay], aroi_data=sample_aroi_data()
     )
     assert 'aeo1_source_up{source="exitdnshealth"} 1' in content
     assert 'aeo1_source_up{source="aroi"} 1' in content
 
 
-def test_source_dns_down(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+def test_source_dns_down(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data,
+                         sample_aroi_metadata):
     relay = make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
     content, _ = _generate(
-        tmp_path, make_relay_set, sample_dns_metadata, [relay], dns_data=None, aroi_data=sample_aroi_data()
+        tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, [relay], dns_data=None,
+        aroi_data=sample_aroi_data()
     )
     assert 'aeo1_source_up{source="exitdnshealth"} 0' in content
     assert 'aeo1_source_up{source="aroi"} 1' in content
     assert "aeo1_exit_dns_failed" not in content
 
 
-def test_source_aroi_down(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
+def test_source_aroi_down(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_metadata):
     relay = make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
-    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, [relay], aroi_data=None)
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, [relay], aroi_data=None)
     assert 'aeo1_source_up{source="exitdnshealth"} 1' in content
     assert 'aeo1_source_up{source="aroi"} 0' in content
     assert "aeo1_aroi_relay_state" not in content
     assert "aeo1_aroi_relays_count" not in content
 
 
-def test_source_both_down(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
-    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, [make_relay("AAAA")], dns_data=None, aroi_data=None)
+def test_source_both_down(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_metadata):
+    content, _ = _generate(
+        tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, [make_relay("AAAA")], dns_data=None,
+        aroi_data=None
+    )
     assert 'aeo1_source_up{source="exitdnshealth"} 0' in content
     assert 'aeo1_source_up{source="aroi"} 0' in content
     assert "aeo1_build_info" in content

--- a/tests/unit/test_prometheus_metrics.py
+++ b/tests/unit/test_prometheus_metrics.py
@@ -1,7 +1,5 @@
 """
-Unit tests for allium.lib.prometheus_metrics
-
-Tests the Prometheus exposition format generator for schema v1.
+Unit tests for allium.lib.prometheus_metrics (schema v2).
 """
 
 import os
@@ -12,18 +10,18 @@ import time
 import unittest
 
 # Add the allium package to the path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'allium'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "allium"))
 
-from lib.prometheus_metrics import (
-    _sanitize_prom_label,
-    _safe_numeric,
+from lib.prometheus_metrics import (  # noqa: E402
+    SCHEMA_VERSION,
+    _build_aroi_map,
     _format_labels,
     _get_family_id,
     _is_aroi_configured,
-    _build_aroi_map,
     _parse_timestamp_epoch,
+    _safe_numeric,
+    _sanitize_prom_label,
     generate_prometheus_metrics,
-    SCHEMA_VERSION,
 )
 
 
@@ -31,10 +29,16 @@ from lib.prometheus_metrics import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_relay(fingerprint, nickname="TestRelay", flags=None, contact="",
-                dns_status="success", dns_timing=1000, dns_consecutive=0,
-                aroi_domain="none"):
-    """Create a minimal relay dict matching allium's enriched relay structure."""
+def _make_relay(
+    fingerprint,
+    nickname="TestRelay",
+    flags=None,
+    contact="",
+    dns_status="success",
+    dns_timing=1000,
+    dns_consecutive=0,
+    aroi_domain="none",
+):
     return {
         "fingerprint": fingerprint,
         "nickname": nickname,
@@ -48,10 +52,13 @@ def _make_relay(fingerprint, nickname="TestRelay", flags=None, contact="",
     }
 
 
-def _make_relay_set(relays, exit_dns_health_data=None, aroi_validation_data=None,
-                    fp_to_family_key=None, validated_aroi_domains=None):
-    """Create a mock relay_set object with the attributes prometheus_metrics needs."""
-
+def _make_relay_set(
+    relays,
+    exit_dns_health_data=None,
+    aroi_validation_data=None,
+    fp_to_family_key=None,
+    validated_aroi_domains=None,
+):
     class MockRelaySet:
         pass
 
@@ -77,7 +84,9 @@ def _sample_dns_metadata():
             "dns_wrong_ip": 1,
             "dns_socks_error": 0,
             "dns_network_error": 0,
+            "dns_error": 0,
             "dns_exception": 0,
+            "dns_unknown": 0,
             "timing": {
                 "total": {
                     "avg_ms": 15000,
@@ -118,7 +127,6 @@ def _sample_aroi_data():
 # ---------------------------------------------------------------------------
 
 class TestSanitizeLabel(unittest.TestCase):
-
     def test_normal_string(self):
         self.assertEqual(_sanitize_prom_label("hello"), "hello")
 
@@ -137,13 +145,8 @@ class TestSanitizeLabel(unittest.TestCase):
     def test_empty(self):
         self.assertEqual(_sanitize_prom_label(""), "")
 
-    def test_combined(self):
-        self.assertEqual(_sanitize_prom_label('a\\b"c\nd'),
-                         'a\\\\b\\"c\\nd')
-
 
 class TestFormatLabels(unittest.TestCase):
-
     def test_empty(self):
         self.assertEqual(_format_labels({}), "")
 
@@ -164,7 +167,6 @@ class TestFormatLabels(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestSafeNumeric(unittest.TestCase):
-
     def test_int(self):
         self.assertEqual(_safe_numeric(42), "42")
 
@@ -203,15 +205,14 @@ class TestSafeNumeric(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Tests: safe accessors
+# Tests: helpers
 # ---------------------------------------------------------------------------
 
 class TestGetFamilyId(unittest.TestCase):
-
     def test_found(self):
         rs = _make_relay_set([], fp_to_family_key={"AAAA": "FAMKEY1"})
         self.assertEqual(_get_family_id(rs, "AAAA"), "FAMKEY1")
-        self.assertEqual(_get_family_id(rs, "aaaa"), "FAMKEY1")  # case-insensitive
+        self.assertEqual(_get_family_id(rs, "aaaa"), "FAMKEY1")
 
     def test_not_found(self):
         rs = _make_relay_set([], fp_to_family_key={"AAAA": "FAMKEY1"})
@@ -224,7 +225,6 @@ class TestGetFamilyId(unittest.TestCase):
 
 
 class TestIsAroiConfigured(unittest.TestCase):
-
     def test_all_fields(self):
         relay = {"contact": "email:a@b.com url:https://b.com proof:uri-rsa ciissversion:2"}
         self.assertTrue(_is_aroi_configured(relay))
@@ -242,14 +242,22 @@ class TestIsAroiConfigured(unittest.TestCase):
         self.assertFalse(_is_aroi_configured(relay))
 
 
+class TestBuildAroiMap(unittest.TestCase):
+    def test_map_uses_uppercase_fingerprints(self):
+        rs = _make_relay_set([], aroi_validation_data=_sample_aroi_data())
+        amap = _build_aroi_map(rs)
+        self.assertIn("AAAA", amap)
+        self.assertIn("BBBB", amap)
+        self.assertTrue(amap["AAAA"]["valid"])
+        self.assertFalse(amap["BBBB"]["valid"])
+
+
 # ---------------------------------------------------------------------------
 # Tests: DNS health section
 # ---------------------------------------------------------------------------
 
 class TestDnsHealthMetrics(unittest.TestCase):
-
-    def _generate(self, relays, dns_data=None, aroi_data=None,
-                  fp_to_family=None, validated_domains=None):
+    def _generate(self, relays, dns_data=None, aroi_data=None, fp_to_family=None, validated_domains=None):
         rs = _make_relay_set(
             relays,
             exit_dns_health_data=dns_data or _sample_dns_metadata(),
@@ -259,7 +267,7 @@ class TestDnsHealthMetrics(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as td:
             stats = generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics")) as f:
+            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
                 content = f.read()
         return content, stats
 
@@ -279,17 +287,22 @@ class TestDnsHealthMetrics(unittest.TestCase):
         relays = [_make_relay("CCCC", dns_status="relay_unreachable", dns_timing=None)]
         content, _ = self._generate(relays)
         self.assertIn('aeo1_exit_dns_failed{fingerprint="CCCC",familyid="",status="relay_unreachable"} 1', content)
-        # No latency line for unreachable relays
         self.assertNotIn('aeo1_exit_dns_latency_ms{fingerprint="CCCC"', content)
+
+    def test_untested_relay_not_marked_failed(self):
+        relays = [_make_relay("DDDD", dns_status="untested", dns_timing=None)]
+        content, _ = self._generate(relays)
+        self.assertIn('aeo1_exit_dns_failed{fingerprint="DDDD",familyid="",status="untested"} 0', content)
+        self.assertNotIn('aeo1_exit_dns_latency_ms{fingerprint="DDDD"', content)
 
     def test_non_exit_excluded(self):
         relays = [
-            _make_relay("AAAA", flags=["Guard", "Running"]),  # not exit
-            _make_relay("BBBB", flags=["Exit", "Running"]),   # exit
+            _make_relay("AAAA", flags=["Guard", "Running"]),
+            _make_relay("BBBB", flags=["Exit", "Running"]),
         ]
-        content, stats = self._generate(relays)
+        content, stats = self._generate(relays, aroi_data=_sample_aroi_data())
         self.assertEqual(stats["exit_relays"], 1)
-        self.assertNotIn('fingerprint="AAAA"', content.split("SECTION 2")[0])  # not in DNS section
+        self.assertNotIn('aeo1_exit_dns_failed{fingerprint="AAAA"', content)
 
     def test_familyid_populated(self):
         relays = [_make_relay("AAAA")]
@@ -303,112 +316,95 @@ class TestDnsHealthMetrics(unittest.TestCase):
         aroi_data["results"] = [
             {"fingerprint": "AAAA", "valid": True, "domain": "example.com", "proof_type": "uri-rsa"}
         ]
-        content, _ = self._generate(relays, aroi_data=aroi_data,
-                                     validated_domains={"example.com"})
+        content, _ = self._generate(relays, aroi_data=aroi_data, validated_domains={"example.com"})
         self.assertIn('verifiedaroi="example.com"', content)
-
-    def test_verifiedaroi_not_inherited_from_other_relay(self):
-        """Relay claiming a domain validated by a *different* relay must not inherit the label."""
-        relays = [
-            _make_relay("AAAA", aroi_domain="example.com"),
-            _make_relay("BBBB", aroi_domain="example.com"),
-        ]
-        aroi_data = _sample_aroi_data()
-        aroi_data["results"] = [
-            {"fingerprint": "AAAA", "valid": True, "domain": "example.com", "proof_type": "uri-rsa"},
-            {"fingerprint": "BBBB", "valid": False, "domain": "example.com", "proof_type": "uri-rsa"},
-        ]
-        content, _ = self._generate(relays, aroi_data=aroi_data,
-                                     validated_domains={"example.com"})
-        # AAAA is valid — should have the label
-        self.assertIn('aeo1_exit_relay_info{fingerprint="AAAA"', content)
-        aaaa_line = next((line for line in content.split("\n")
-                          if line.startswith('aeo1_exit_relay_info{fingerprint="AAAA"')), None)
-        self.assertIsNotNone(aaaa_line, "Expected aeo1_exit_relay_info line for AAAA")
-        self.assertIn('verifiedaroi="example.com"', aaaa_line)
-        # BBBB is invalid — must NOT inherit
-        bbbb_line = next((line for line in content.split("\n")
-                          if line.startswith('aeo1_exit_relay_info{fingerprint="BBBB"')), None)
-        self.assertIsNotNone(bbbb_line, "Expected aeo1_exit_relay_info line for BBBB")
-        self.assertIn('verifiedaroi=""', bbbb_line)
-
-    def test_aggregates_ratio_format(self):
-        relays = [_make_relay("AAAA")]
-        content, _ = self._generate(relays)
-        # Ratios should be 0..1, not percentages
-        self.assertIn("aeo1_exit_dns_success_ratio", content)
-        # Match the metric line (not HELP/TYPE lines) — must start at line beginning
-        match = re.search(r'^aeo1_exit_dns_success_ratio (\S+)', content, re.MULTILINE)
-        self.assertIsNotNone(match, "Could not find aeo1_exit_dns_success_ratio metric line")
-        ratio = float(match.group(1))
-        self.assertLessEqual(ratio, 1.0)
-
-    def test_count_suffix_not_total(self):
-        relays = [_make_relay("AAAA")]
-        content, _ = self._generate(relays)
-        # No _total suffix on any gauge
-        for line in content.split("\n"):
-            if line.startswith("aeo1_") and "_total" in line.split("{")[0]:
-                self.fail(f"Found _total suffix on gauge: {line}")
 
     def test_sorted_by_fingerprint(self):
         relays = [_make_relay("CCCC"), _make_relay("AAAA"), _make_relay("BBBB")]
-        content, _ = self._generate(relays)
-        # Extract fingerprints in order from aeo1_exit_dns_failed lines
+        content, _ = self._generate(relays, aroi_data=_sample_aroi_data())
         fps = re.findall(r'aeo1_exit_dns_failed\{fingerprint="(\w+)"', content)
         self.assertEqual(fps, sorted(fps))
 
 
 # ---------------------------------------------------------------------------
-# Tests: AROI section
+# Tests: AROI section (schema v2)
 # ---------------------------------------------------------------------------
 
-class TestAroiMetrics(unittest.TestCase):
-
-    def _generate(self, relays, aroi_data=None):
+class TestAroiStateMetrics(unittest.TestCase):
+    def _generate(self, relays, aroi_data=None, fp_to_family=None):
         rs = _make_relay_set(
             relays,
             exit_dns_health_data=_sample_dns_metadata(),
             aroi_validation_data=aroi_data or _sample_aroi_data(),
+            fp_to_family_key=fp_to_family or {},
         )
         with tempfile.TemporaryDirectory() as td:
             stats = generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics")) as f:
+            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
                 content = f.read()
         return content, stats
 
-    def test_configured_relay_included(self):
-        relay = _make_relay("AAAA",
-                            contact="url:https://example.com proof:uri-rsa ciissversion:2",
-                            aroi_domain="example.com")
-        content, stats = self._generate([relay])
-        self.assertEqual(stats["aroi_relays"], 1)
-        self.assertIn('aeo1_aroi_valid{fingerprint="AAAA"', content)
+    def test_state_configured_checked_valid(self):
+        relay = _make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
+        content, _ = self._generate([relay], aroi_data=_sample_aroi_data())
+        self.assertIn('aeo1_aroi_relay_state{fingerprint="AAAA",familyid="",state="configured_checked_valid"} 1', content)
 
-    def test_unconfigured_relay_excluded(self):
-        relay = _make_relay("AAAA", contact="just a name", aroi_domain="none")
-        content, stats = self._generate([relay])
-        self.assertEqual(stats["aroi_relays"], 0)
+    def test_state_configured_checked_invalid(self):
+        relay = _make_relay("BBBB", contact="url:https://broken.org proof:dns-rsa ciissversion:2", aroi_domain="broken.org")
+        content, _ = self._generate([relay], aroi_data=_sample_aroi_data())
+        self.assertIn('aeo1_aroi_relay_state{fingerprint="BBBB",familyid="",state="configured_checked_invalid"} 1', content)
 
-    def test_valid_relay(self):
-        relay = _make_relay("AAAA",
-                            contact="url:https://example.com proof:uri-rsa ciissversion:2")
-        content, _ = self._generate([relay])
-        self.assertIn('aeo1_aroi_valid{fingerprint="AAAA",familyid=""} 1', content)
+    def test_state_configured_unchecked(self):
+        relay = _make_relay("CCCC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org")
+        content, _ = self._generate([relay], aroi_data=_sample_aroi_data())
+        self.assertIn('aeo1_aroi_relay_state{fingerprint="CCCC",familyid="",state="configured_unchecked"} 1', content)
 
-    def test_invalid_relay(self):
-        relay = _make_relay("BBBB",
-                            contact="url:https://broken.org proof:dns-rsa ciissversion:2")
-        content, _ = self._generate([relay])
-        self.assertIn('aeo1_aroi_valid{fingerprint="BBBB",familyid=""} 0', content)
+    def test_state_not_configured(self):
+        relay = _make_relay("DDDD", contact="just a contact")
+        content, _ = self._generate([relay], aroi_data=_sample_aroi_data())
+        self.assertIn('aeo1_aroi_relay_state{fingerprint="DDDD",familyid="",state="not_configured"} 1', content)
 
-    def test_info_labels(self):
-        relay = _make_relay("AAAA", nickname="MyRelay",
-                            contact="url:https://example.com proof:uri-rsa ciissversion:2")
-        content, _ = self._generate([relay])
-        self.assertIn('nick="MyRelay"', content)
-        self.assertIn('domain="example.com"', content)
-        self.assertIn('proof_type="uri-rsa"', content)
+    def test_exactly_one_state_series_per_relay(self):
+        relays = [
+            _make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com"),
+            _make_relay("BBBB", contact="url:https://broken.org proof:dns-rsa ciissversion:2", aroi_domain="broken.org"),
+            _make_relay("CCCC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org"),
+            _make_relay("DDDD", contact="plain"),
+        ]
+        content, _ = self._generate(relays, aroi_data=_sample_aroi_data())
+        for fp in ("AAAA", "BBBB", "CCCC", "DDDD"):
+            matches = re.findall(
+                rf'^aeo1_aroi_relay_state\{{fingerprint="{fp}",familyid="",state="[^"]+"\}} 1$',
+                content,
+                re.MULTILINE,
+            )
+            self.assertEqual(len(matches), 1, f"expected exactly one state for {fp}")
+
+    def test_aggregate_state_counts(self):
+        relays = [
+            _make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com"),
+            _make_relay("BBBB", contact="url:https://broken.org proof:dns-rsa ciissversion:2", aroi_domain="broken.org"),
+            _make_relay("CCCC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org"),
+            _make_relay("DDDD", contact="plain"),
+        ]
+        content, stats = self._generate(relays, aroi_data=_sample_aroi_data())
+        self.assertEqual(stats["aroi_relays"], 3)
+        self.assertIn('aeo1_aroi_relays_count{state="not_configured"} 1', content)
+        self.assertIn('aeo1_aroi_relays_count{state="configured_unchecked"} 1', content)
+        self.assertIn('aeo1_aroi_relays_count{state="configured_checked_invalid"} 1', content)
+        self.assertIn('aeo1_aroi_relays_count{state="configured_checked_valid"} 1', content)
+
+    def test_legacy_aroi_valid_removed(self):
+        relay = _make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
+        content, _ = self._generate([relay], aroi_data=_sample_aroi_data())
+        self.assertNotIn("aeo1_aroi_valid{", content)
+        self.assertNotIn("aeo1_aroi_success_ratio", content)
+
+    def test_relay_info_uses_claimed_domain_when_unchecked(self):
+        relay = _make_relay("CCCC", nickname="RelayC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org")
+        content, _ = self._generate([relay], aroi_data=_sample_aroi_data())
+        line = next((ln for ln in content.split("\n") if ln.startswith('aeo1_aroi_relay_info{fingerprint="CCCC"')), "")
+        self.assertIn('domain="missing.org"', line)
 
 
 # ---------------------------------------------------------------------------
@@ -416,34 +412,47 @@ class TestAroiMetrics(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestSourceAvailability(unittest.TestCase):
-
     def test_both_sources_up(self):
         rs = _make_relay_set(
-            [_make_relay("AAAA")],
+            [_make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")],
             exit_dns_health_data=_sample_dns_metadata(),
             aroi_validation_data=_sample_aroi_data(),
         )
         with tempfile.TemporaryDirectory() as td:
             generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics")) as f:
+            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
                 content = f.read()
         self.assertIn('aeo1_source_up{source="exitdnshealth"} 1', content)
         self.assertIn('aeo1_source_up{source="aroi"} 1', content)
 
     def test_dns_source_down(self):
         rs = _make_relay_set(
-            [_make_relay("AAAA")],
+            [_make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")],
             exit_dns_health_data=None,
             aroi_validation_data=_sample_aroi_data(),
         )
         with tempfile.TemporaryDirectory() as td:
             generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics")) as f:
+            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
                 content = f.read()
         self.assertIn('aeo1_source_up{source="exitdnshealth"} 0', content)
         self.assertIn('aeo1_source_up{source="aroi"} 1', content)
-        # DNS section should be absent
         self.assertNotIn("aeo1_exit_dns_failed", content)
+
+    def test_aroi_source_down(self):
+        rs = _make_relay_set(
+            [_make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")],
+            exit_dns_health_data=_sample_dns_metadata(),
+            aroi_validation_data=None,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            generate_prometheus_metrics(rs, td)
+            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
+                content = f.read()
+        self.assertIn('aeo1_source_up{source="exitdnshealth"} 1', content)
+        self.assertIn('aeo1_source_up{source="aroi"} 0', content)
+        self.assertNotIn("aeo1_aroi_relay_state", content)
+        self.assertNotIn("aeo1_aroi_relays_count", content)
 
     def test_both_sources_down(self):
         rs = _make_relay_set(
@@ -453,35 +462,12 @@ class TestSourceAvailability(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as td:
             generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics")) as f:
+            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
                 content = f.read()
         self.assertIn('aeo1_source_up{source="exitdnshealth"} 0', content)
         self.assertIn('aeo1_source_up{source="aroi"} 0', content)
-        # Meta always present
         self.assertIn("aeo1_build_info", content)
         self.assertIn("aeo1_generation_timestamp_seconds", content)
-
-    def test_last_success_timestamp_zero_when_none(self):
-        rs = _make_relay_set([], exit_dns_health_data=None, aroi_validation_data=None)
-        with tempfile.TemporaryDirectory() as td:
-            generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics")) as f:
-                content = f.read()
-        self.assertIn('aeo1_source_last_success_timestamp_seconds{source="exitdnshealth"} 0', content)
-        self.assertIn('aeo1_source_last_success_timestamp_seconds{source="aroi"} 0', content)
-
-    def test_available_flags_reflect_source_presence_not_count(self):
-        """dns_available/aroi_available must be True when source exists, even with 0 matching relays."""
-        rs = _make_relay_set(
-            [_make_relay("AAAA", flags=["Guard", "Running"])],  # no Exit flag
-            exit_dns_health_data=_sample_dns_metadata(),
-            aroi_validation_data=_sample_aroi_data(),
-        )
-        with tempfile.TemporaryDirectory() as td:
-            stats = generate_prometheus_metrics(rs, td)
-        self.assertTrue(stats["dns_available"], "dns_available should be True when source data exists")
-        self.assertTrue(stats["aroi_available"], "aroi_available should be True when source data exists")
-        self.assertEqual(stats["exit_relays"], 0)
 
 
 # ---------------------------------------------------------------------------
@@ -489,14 +475,14 @@ class TestSourceAvailability(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestMetaAndFile(unittest.TestCase):
-
-    def test_build_info_present(self):
+    def test_build_info_present_schema_v2(self):
         rs = _make_relay_set([], exit_dns_health_data=_sample_dns_metadata())
         with tempfile.TemporaryDirectory() as td:
             generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics")) as f:
+            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
                 content = f.read()
         self.assertIn(f'aeo1_build_info{{schema="{SCHEMA_VERSION}",generator="allium"}} 1', content)
+        self.assertEqual(SCHEMA_VERSION, "2")
 
     def test_generation_timestamp_recent(self):
         rs = _make_relay_set([])
@@ -504,9 +490,9 @@ class TestMetaAndFile(unittest.TestCase):
             before = int(time.time())
             generate_prometheus_metrics(rs, td)
             after = int(time.time())
-            with open(os.path.join(td, "metrics")) as f:
+            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
                 content = f.read()
-        match = re.search(r'aeo1_generation_timestamp_seconds (\d+)', content)
+        match = re.search(r"aeo1_generation_timestamp_seconds (\d+)", content)
         self.assertIsNotNone(match)
         ts = int(match.group(1))
         self.assertGreaterEqual(ts, before)
@@ -525,18 +511,13 @@ class TestMetaAndFile(unittest.TestCase):
             self.assertFalse(os.path.exists(os.path.join(td, "metrics.tmp")))
 
     def test_unique_help_type_per_metric(self):
-        rs = _make_relay_set(
-            [_make_relay("AAAA",
-                         contact="url:https://x.com proof:uri-rsa ciissversion:2")],
-            exit_dns_health_data=_sample_dns_metadata(),
-            aroi_validation_data=_sample_aroi_data(),
-        )
+        relay = _make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
+        rs = _make_relay_set([relay], exit_dns_health_data=_sample_dns_metadata(), aroi_validation_data=_sample_aroi_data())
         with tempfile.TemporaryDirectory() as td:
             generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics")) as f:
+            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
                 content = f.read()
 
-        # Each metric name should have exactly one HELP and one TYPE
         help_counts = {}
         type_counts = {}
         for line in content.split("\n"):
@@ -556,34 +537,33 @@ class TestMetaAndFile(unittest.TestCase):
         rs = _make_relay_set([])
         with tempfile.TemporaryDirectory() as td:
             generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics")) as f:
+            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
                 content = f.read()
         self.assertIn("# EOF", content)
 
 
 # ---------------------------------------------------------------------------
-# Regression tests for bugs found in PR review
+# Regression tests
 # ---------------------------------------------------------------------------
 
 class TestParseTimestampEpoch(unittest.TestCase):
-    """Regression: _parse_timestamp_epoch must treat bare timestamps as UTC."""
-
     def test_z_suffix(self):
         from datetime import datetime, timezone
+
         expected = datetime(2026, 3, 8, 12, 0, 0, tzinfo=timezone.utc).timestamp()
         self.assertEqual(_parse_timestamp_epoch("2026-03-08T12:00:00Z"), expected)
 
     def test_offset_suffix(self):
         from datetime import datetime, timezone
+
         expected = datetime(2026, 3, 8, 12, 0, 0, tzinfo=timezone.utc).timestamp()
         self.assertEqual(_parse_timestamp_epoch("2026-03-08T12:00:00+00:00"), expected)
 
     def test_naive_timestamp_assumed_utc(self):
-        """Bare ISO timestamp without tz info must be treated as UTC, not local time."""
         from datetime import datetime, timezone
+
         expected = datetime(2026, 3, 8, 12, 0, 0, tzinfo=timezone.utc).timestamp()
-        result = _parse_timestamp_epoch("2026-03-08T12:00:00")
-        self.assertEqual(result, expected)
+        self.assertEqual(_parse_timestamp_epoch("2026-03-08T12:00:00"), expected)
 
     def test_empty_returns_zero(self):
         self.assertEqual(_parse_timestamp_epoch(""), 0)
@@ -594,28 +574,36 @@ class TestParseTimestampEpoch(unittest.TestCase):
 
 
 class TestDnsErrorTypesComplete(unittest.TestCase):
-    """Regression: all upstream error types must be emitted in Prometheus metrics."""
-
     def test_dns_error_and_unknown_emitted(self):
-        """dns_error and dns_unknown from exit_dns_health metadata must not be silently dropped."""
         rs = _make_relay_set(
             [_make_relay("AAAA")],
             exit_dns_health_data={
                 "metadata": {
                     "timestamp": "2026-03-08T08:00:00Z",
-                    "consensus_relays": 100, "tested_relays": 95,
-                    "unreachable_relays": 5, "dns_success": 80,
-                    "dns_fail": 3, "dns_timeout": 1, "dns_wrong_ip": 1,
-                    "dns_socks_error": 0, "dns_network_error": 0,
-                    "dns_error": 7, "dns_exception": 0, "dns_unknown": 3,
+                    "consensus_relays": 100,
+                    "tested_relays": 95,
+                    "unreachable_relays": 5,
+                    "dns_success": 80,
+                    "dns_fail": 3,
+                    "dns_timeout": 1,
+                    "dns_wrong_ip": 1,
+                    "dns_socks_error": 0,
+                    "dns_network_error": 0,
+                    "dns_error": 7,
+                    "dns_exception": 0,
+                    "dns_unknown": 3,
                     "timing": {"total": {}},
                 }
             },
         )
         with tempfile.TemporaryDirectory() as td:
             generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics")) as f:
+            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
                 content = f.read()
 
         self.assertIn('aeo1_exit_dns_errors_count{error_type="error"} 7', content)
         self.assertIn('aeo1_exit_dns_errors_count{error_type="unknown"} 3', content)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/unit/test_prometheus_metrics.py
+++ b/tests/unit/test_prometheus_metrics.py
@@ -3,6 +3,7 @@
 import re
 import time
 from pathlib import Path
+from typing import Tuple
 
 import pytest
 
@@ -56,7 +57,7 @@ def _generate(
     aroi_data=_USE_DEFAULT,
     fp_to_family=None,
     validated_domains=None,
-):
+) -> Tuple[str, dict]:
     selected_dns = sample_dns_metadata() if dns_data is _USE_DEFAULT else dns_data
     selected_aroi = _sample_aroi_data() if aroi_data is _USE_DEFAULT else aroi_data
     rs = make_relay_set(

--- a/tests/unit/test_prometheus_metrics.py
+++ b/tests/unit/test_prometheus_metrics.py
@@ -9,6 +9,8 @@ import tempfile
 import time
 import unittest
 
+# Add test utilities to path
+sys.path.insert(0, os.path.dirname(__file__))
 # Add the allium package to the path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "allium"))
 
@@ -23,103 +25,12 @@ from lib.prometheus_metrics import (  # noqa: E402
     _sanitize_prom_label,
     generate_prometheus_metrics,
 )
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _make_relay(
-    fingerprint,
-    nickname="TestRelay",
-    flags=None,
-    contact="",
-    dns_status="success",
-    dns_timing=1000,
-    dns_consecutive=0,
-    aroi_domain="none",
-):
-    return {
-        "fingerprint": fingerprint,
-        "nickname": nickname,
-        "flags": flags or ["Exit", "Fast", "Guard", "Running", "Stable", "Valid"],
-        "contact": contact,
-        "aroi_domain": aroi_domain,
-        "exit_dns_health_status": "success" if dns_status == "success" else "fail",
-        "exit_dns_health_detail": dns_status,
-        "exit_dns_health_timing_ms": dns_timing,
-        "exit_dns_health_consecutive_failures": dns_consecutive,
-    }
-
-
-def _make_relay_set(
-    relays,
-    exit_dns_health_data=None,
-    aroi_validation_data=None,
-    fp_to_family_key=None,
-    validated_aroi_domains=None,
-):
-    class MockRelaySet:
-        pass
-
-    rs = MockRelaySet()
-    rs.json = {"relays": relays}
-    rs.exit_dns_health_data = exit_dns_health_data
-    rs.aroi_validation_data = aroi_validation_data
-    rs._fp_to_family_key = fp_to_family_key or {}
-    rs.validated_aroi_domains = validated_aroi_domains or set()
-    return rs
-
-
-def _sample_dns_metadata():
-    return {
-        "metadata": {
-            "timestamp": "2026-03-08T08:00:00Z",
-            "consensus_relays": 100,
-            "tested_relays": 95,
-            "unreachable_relays": 5,
-            "dns_success": 90,
-            "dns_fail": 3,
-            "dns_timeout": 1,
-            "dns_wrong_ip": 1,
-            "dns_socks_error": 0,
-            "dns_network_error": 0,
-            "dns_error": 0,
-            "dns_exception": 0,
-            "dns_unknown": 0,
-            "timing": {
-                "total": {
-                    "avg_ms": 15000,
-                    "min_ms": 200,
-                    "max_ms": 30000,
-                    "p50_ms": 14000,
-                    "p95_ms": 25000,
-                    "p99_ms": 28000,
-                }
-            },
-        }
-    }
-
-
-def _sample_aroi_data():
-    return {
-        "metadata": {
-            "timestamp": "2026-03-08T10:00:00Z",
-            "total_relays": 200,
-            "valid_relays": 50,
-            "invalid_relays": 150,
-        },
-        "statistics": {
-            "proof_types": {
-                "uri_rsa": {"total": 40, "valid": 38},
-                "dns_rsa": {"total": 10, "valid": 8},
-            }
-        },
-        "results": [
-            {"fingerprint": "AAAA", "valid": True, "domain": "example.com", "proof_type": "uri-rsa"},
-            {"fingerprint": "BBBB", "valid": False, "domain": "broken.org", "proof_type": "dns-rsa"},
-        ],
-    }
+from prometheus_fixtures import (  # noqa: E402
+    make_relay as _make_relay,
+    make_relay_set as _make_relay_set,
+    sample_aroi_data as _sample_aroi_data,
+    sample_dns_metadata as _sample_dns_metadata,
+)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_prometheus_metrics.py
+++ b/tests/unit/test_prometheus_metrics.py
@@ -136,6 +136,14 @@ class TestGetFamilyId(unittest.TestCase):
 
 
 class TestIsAroiConfigured(unittest.TestCase):
+    def test_uses_cached_boolean_true(self):
+        relay = {"contact": "invalid", "aroi_configured": True}
+        self.assertTrue(_is_aroi_configured(relay))
+
+    def test_uses_cached_boolean_false(self):
+        relay = {"contact": "url:https://x proof:uri-rsa ciissversion:2", "aroi_configured": False}
+        self.assertFalse(_is_aroi_configured(relay))
+
     def test_all_fields(self):
         relay = {"contact": "email:a@b.com url:https://b.com proof:uri-rsa ciissversion:2"}
         self.assertTrue(_is_aroi_configured(relay))

--- a/tests/unit/test_prometheus_metrics.py
+++ b/tests/unit/test_prometheus_metrics.py
@@ -1,20 +1,12 @@
-"""
-Unit tests for allium.lib.prometheus_metrics (schema v2).
-"""
+"""Pytest tests for allium.lib.prometheus_metrics (schema v2)."""
 
-import os
 import re
-import sys
-import tempfile
 import time
-import unittest
+from pathlib import Path
 
-# Add test utilities to path
-sys.path.insert(0, os.path.dirname(__file__))
-# Add the allium package to the path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "allium"))
+import pytest
 
-from lib.prometheus_metrics import (  # noqa: E402
+from allium.lib.prometheus_metrics import (
     SCHEMA_VERSION,
     _build_aroi_map,
     _format_labels,
@@ -25,504 +17,405 @@ from lib.prometheus_metrics import (  # noqa: E402
     _sanitize_prom_label,
     generate_prometheus_metrics,
 )
-from prometheus_fixtures import (  # noqa: E402
+from tests.unit.prometheus_fixtures import (
     make_relay as _make_relay,
     make_relay_set as _make_relay_set,
     sample_aroi_data as _sample_aroi_data,
     sample_dns_metadata as _sample_dns_metadata,
 )
 
-
-# ---------------------------------------------------------------------------
-# Tests: label escaping
-# ---------------------------------------------------------------------------
-
-class TestSanitizeLabel(unittest.TestCase):
-    def test_normal_string(self):
-        self.assertEqual(_sanitize_prom_label("hello"), "hello")
-
-    def test_quotes(self):
-        self.assertEqual(_sanitize_prom_label('say "hi"'), 'say \\"hi\\"')
-
-    def test_backslash(self):
-        self.assertEqual(_sanitize_prom_label("a\\b"), "a\\\\b")
-
-    def test_newline(self):
-        self.assertEqual(_sanitize_prom_label("line1\nline2"), "line1\\nline2")
-
-    def test_none(self):
-        self.assertEqual(_sanitize_prom_label(None), "")
-
-    def test_empty(self):
-        self.assertEqual(_sanitize_prom_label(""), "")
+_USE_DEFAULT = object()
 
 
-class TestFormatLabels(unittest.TestCase):
-    def test_empty(self):
-        self.assertEqual(_format_labels({}), "")
-
-    def test_single(self):
-        self.assertEqual(_format_labels({"k": "v"}), '{k="v"}')
-
-    def test_multiple_preserves_order(self):
-        result = _format_labels({"a": "1", "b": "2", "c": "3"})
-        self.assertEqual(result, '{a="1",b="2",c="3"}')
-
-    def test_escaping_in_values(self):
-        result = _format_labels({"nick": 'say "hi"'})
-        self.assertEqual(result, '{nick="say \\"hi\\""}')
+@pytest.fixture
+def make_relay():
+    return _make_relay
 
 
-# ---------------------------------------------------------------------------
-# Tests: numeric coercion
-# ---------------------------------------------------------------------------
-
-class TestSafeNumeric(unittest.TestCase):
-    def test_int(self):
-        self.assertEqual(_safe_numeric(42), "42")
-
-    def test_zero(self):
-        self.assertEqual(_safe_numeric(0), "0")
-
-    def test_float(self):
-        self.assertEqual(_safe_numeric(3.14), "3.14")
-
-    def test_string_number(self):
-        self.assertEqual(_safe_numeric("99"), "99.0")
-
-    def test_non_numeric_string(self):
-        self.assertEqual(_safe_numeric("hello"), "0")
-
-    def test_injection_attempt(self):
-        self.assertEqual(_safe_numeric("1\naeo1_injected_metric 42"), "0")
-
-    def test_none(self):
-        self.assertEqual(_safe_numeric(None), "0")
-
-    def test_nan(self):
-        self.assertEqual(_safe_numeric(float("nan")), "0")
-
-    def test_inf(self):
-        self.assertEqual(_safe_numeric(float("inf")), "0")
-
-    def test_negative_inf(self):
-        self.assertEqual(_safe_numeric(float("-inf")), "0")
-
-    def test_bool_false(self):
-        self.assertEqual(_safe_numeric(False), "0.0")
-
-    def test_bool_true(self):
-        self.assertEqual(_safe_numeric(True), "1.0")
+@pytest.fixture
+def make_relay_set():
+    return _make_relay_set
 
 
-# ---------------------------------------------------------------------------
-# Tests: helpers
-# ---------------------------------------------------------------------------
-
-class TestGetFamilyId(unittest.TestCase):
-    def test_found(self):
-        rs = _make_relay_set([], fp_to_family_key={"AAAA": "FAMKEY1"})
-        self.assertEqual(_get_family_id(rs, "AAAA"), "FAMKEY1")
-        self.assertEqual(_get_family_id(rs, "aaaa"), "FAMKEY1")
-
-    def test_not_found(self):
-        rs = _make_relay_set([], fp_to_family_key={"AAAA": "FAMKEY1"})
-        self.assertEqual(_get_family_id(rs, "BBBB"), "")
-
-    def test_no_map(self):
-        rs = _make_relay_set([])
-        rs._fp_to_family_key = None
-        self.assertEqual(_get_family_id(rs, "AAAA"), "")
+@pytest.fixture
+def sample_aroi_data():
+    return _sample_aroi_data
 
 
-class TestIsAroiConfigured(unittest.TestCase):
-    def test_uses_cached_boolean_true(self):
-        relay = {"contact": "invalid", "aroi_configured": True}
-        self.assertTrue(_is_aroi_configured(relay))
-
-    def test_uses_cached_boolean_false(self):
-        relay = {"contact": "url:https://x proof:uri-rsa ciissversion:2", "aroi_configured": False}
-        self.assertFalse(_is_aroi_configured(relay))
-
-    def test_all_fields(self):
-        relay = {"contact": "email:a@b.com url:https://b.com proof:uri-rsa ciissversion:2"}
-        self.assertTrue(_is_aroi_configured(relay))
-
-    def test_missing_proof(self):
-        relay = {"contact": "email:a@b.com url:https://b.com ciissversion:2"}
-        self.assertFalse(_is_aroi_configured(relay))
-
-    def test_no_contact(self):
-        relay = {"contact": ""}
-        self.assertFalse(_is_aroi_configured(relay))
-
-    def test_none_contact(self):
-        relay = {}
-        self.assertFalse(_is_aroi_configured(relay))
+@pytest.fixture
+def sample_dns_metadata():
+    return _sample_dns_metadata
 
 
-class TestBuildAroiMap(unittest.TestCase):
-    def test_map_uses_uppercase_fingerprints(self):
-        rs = _make_relay_set([], aroi_validation_data=_sample_aroi_data())
-        amap = _build_aroi_map(rs)
-        self.assertIn("AAAA", amap)
-        self.assertIn("BBBB", amap)
-        self.assertTrue(amap["AAAA"]["valid"])
-        self.assertFalse(amap["BBBB"]["valid"])
+def _generate(
+    tmp_path: Path,
+    make_relay_set,
+    sample_dns_metadata,
+    relays,
+    dns_data=_USE_DEFAULT,
+    aroi_data=_USE_DEFAULT,
+    fp_to_family=None,
+    validated_domains=None,
+):
+    selected_dns = sample_dns_metadata() if dns_data is _USE_DEFAULT else dns_data
+    selected_aroi = _sample_aroi_data() if aroi_data is _USE_DEFAULT else aroi_data
+    rs = make_relay_set(
+        relays,
+        exit_dns_health_data=selected_dns,
+        aroi_validation_data=selected_aroi,
+        fp_to_family_key=fp_to_family or {},
+        validated_aroi_domains=validated_domains or set(),
+    )
+    stats = generate_prometheus_metrics(rs, str(tmp_path))
+    content = (tmp_path / "metrics").read_text(encoding="utf-8")
+    return content, stats
 
 
-# ---------------------------------------------------------------------------
-# Tests: DNS health section
-# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("hello", "hello"),
+        ('say "hi"', 'say \\"hi\\"'),
+        ("a\\b", "a\\\\b"),
+        ("line1\nline2", "line1\\nline2"),
+        (None, ""),
+        ("", ""),
+    ],
+)
+def test_sanitize_prom_label(value, expected):
+    assert _sanitize_prom_label(value) == expected
 
-class TestDnsHealthMetrics(unittest.TestCase):
-    def _generate(self, relays, dns_data=None, aroi_data=None, fp_to_family=None, validated_domains=None):
-        rs = _make_relay_set(
-            relays,
-            exit_dns_health_data=dns_data or _sample_dns_metadata(),
-            aroi_validation_data=aroi_data,
-            fp_to_family_key=fp_to_family or {},
-            validated_aroi_domains=validated_domains or set(),
+
+def test_format_labels_empty():
+    assert _format_labels({}) == ""
+
+
+def test_format_labels_single():
+    assert _format_labels({"k": "v"}) == '{k="v"}'
+
+
+def test_format_labels_multiple_preserves_order():
+    assert _format_labels({"a": "1", "b": "2", "c": "3"}) == '{a="1",b="2",c="3"}'
+
+
+def test_format_labels_escaping():
+    assert _format_labels({"nick": 'say "hi"'}) == '{nick="say \\"hi\\""}'
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (42, "42"),
+        (0, "0"),
+        (3.14, "3.14"),
+        ("99", "99.0"),
+        ("hello", "0"),
+        ("1\naeo1_injected_metric 42", "0"),
+        (None, "0"),
+        (float("nan"), "0"),
+        (float("inf"), "0"),
+        (float("-inf"), "0"),
+        (False, "0.0"),
+        (True, "1.0"),
+    ],
+)
+def test_safe_numeric(value, expected):
+    assert _safe_numeric(value) == expected
+
+
+def test_get_family_id_found(make_relay_set):
+    rs = make_relay_set([], fp_to_family_key={"AAAA": "FAMKEY1"})
+    assert _get_family_id(rs, "AAAA") == "FAMKEY1"
+    assert _get_family_id(rs, "aaaa") == "FAMKEY1"
+
+
+def test_get_family_id_not_found(make_relay_set):
+    rs = make_relay_set([], fp_to_family_key={"AAAA": "FAMKEY1"})
+    assert _get_family_id(rs, "BBBB") == ""
+
+
+def test_get_family_id_no_map(make_relay_set):
+    rs = make_relay_set([])
+    rs._fp_to_family_key = None
+    assert _get_family_id(rs, "AAAA") == ""
+
+
+def test_is_aroi_configured_uses_cached_true():
+    assert _is_aroi_configured({"contact": "invalid", "aroi_configured": True}) is True
+
+
+def test_is_aroi_configured_uses_cached_false():
+    relay = {"contact": "url:https://x proof:uri-rsa ciissversion:2", "aroi_configured": False}
+    assert _is_aroi_configured(relay) is False
+
+
+@pytest.mark.parametrize(
+    ("relay", "expected"),
+    [
+        ({"contact": "email:a@b.com url:https://b.com proof:uri-rsa ciissversion:2"}, True),
+        ({"contact": "email:a@b.com url:https://b.com ciissversion:2"}, False),
+        ({"contact": ""}, False),
+        ({}, False),
+    ],
+)
+def test_is_aroi_configured_variants(relay, expected):
+    assert _is_aroi_configured(relay) is expected
+
+
+def test_build_aroi_map_uppercase(make_relay_set, sample_aroi_data):
+    rs = make_relay_set([], aroi_validation_data=sample_aroi_data())
+    amap = _build_aroi_map(rs)
+    assert "AAAA" in amap
+    assert "BBBB" in amap
+    assert amap["AAAA"]["valid"] is True
+    assert amap["BBBB"]["valid"] is False
+
+
+def test_dns_metrics_healthy(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, [make_relay("AAAA", dns_status="success")])
+    assert 'aeo1_exit_dns_failed{fingerprint="AAAA",familyid="",status="success"} 0' in content
+
+
+def test_dns_metrics_failure(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
+    relays = [make_relay("BBBB", dns_status="dns_fail", dns_timing=5000, dns_consecutive=3)]
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays)
+    assert 'aeo1_exit_dns_failed{fingerprint="BBBB",familyid="",status="dns_fail"} 1' in content
+    assert 'aeo1_exit_dns_latency_ms{fingerprint="BBBB",familyid=""} 5000' in content
+    assert 'aeo1_exit_dns_consecutive_failures{fingerprint="BBBB",familyid=""} 3' in content
+
+
+def test_dns_unreachable_no_latency(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
+    relays = [make_relay("CCCC", dns_status="relay_unreachable", dns_timing=None)]
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays)
+    assert 'aeo1_exit_dns_failed{fingerprint="CCCC",familyid="",status="relay_unreachable"} 1' in content
+    assert 'aeo1_exit_dns_latency_ms{fingerprint="CCCC"' not in content
+
+
+def test_dns_untested_not_failed(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
+    relays = [make_relay("DDDD", dns_status="untested", dns_timing=None)]
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays)
+    assert 'aeo1_exit_dns_failed{fingerprint="DDDD",familyid="",status="untested"} 0' in content
+    assert 'aeo1_exit_dns_latency_ms{fingerprint="DDDD"' not in content
+
+
+def test_dns_non_exit_excluded(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+    relays = [make_relay("AAAA", flags=["Guard", "Running"]), make_relay("BBBB", flags=["Exit", "Running"])]
+    content, stats = _generate(
+        tmp_path, make_relay_set, sample_dns_metadata, relays, aroi_data=sample_aroi_data()
+    )
+    assert stats["exit_relays"] == 1
+    assert 'aeo1_exit_dns_failed{fingerprint="AAAA"' not in content
+
+
+def test_dns_familyid_populated(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
+    content, _ = _generate(
+        tmp_path,
+        make_relay_set,
+        sample_dns_metadata,
+        [make_relay("AAAA")],
+        fp_to_family={"AAAA": "MYFAMKEY"},
+    )
+    assert 'familyid="MYFAMKEY"' in content
+
+
+def test_dns_verifiedaroi_info(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+    relays = [make_relay("AAAA", aroi_domain="example.com", contact="url:https://example.com proof:uri-rsa ciissversion:2")]
+    aroi_data = sample_aroi_data()
+    aroi_data["results"] = [{"fingerprint": "AAAA", "valid": True, "domain": "example.com", "proof_type": "uri-rsa"}]
+    content, _ = _generate(
+        tmp_path,
+        make_relay_set,
+        sample_dns_metadata,
+        relays,
+        aroi_data=aroi_data,
+        validated_domains={"example.com"},
+    )
+    assert 'verifiedaroi="example.com"' in content
+
+
+def test_dns_metrics_sorted_by_fingerprint(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+    relays = [make_relay("CCCC"), make_relay("AAAA"), make_relay("BBBB")]
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays, aroi_data=sample_aroi_data())
+    fps = re.findall(r'aeo1_exit_dns_failed\{fingerprint="(\w+)"', content)
+    assert fps == sorted(fps)
+
+
+def test_aroi_state_and_counts(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+    relays = [
+        make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com"),
+        make_relay("BBBB", contact="url:https://broken.org proof:dns-rsa ciissversion:2", aroi_domain="broken.org"),
+        make_relay("CCCC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org"),
+        make_relay("DDDD", contact="plain"),
+    ]
+    content, stats = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays, aroi_data=sample_aroi_data())
+    assert stats["aroi_relays"] == 3
+    assert 'state="configured_checked_valid"} 1' in content
+    assert 'state="configured_checked_invalid"} 1' in content
+    assert 'state="configured_unchecked"} 1' in content
+    assert 'state="not_configured"} 1' in content
+    assert 'aeo1_aroi_relays_count{state="not_configured"} 1' in content
+    assert 'aeo1_aroi_relays_count{state="configured_unchecked"} 1' in content
+    assert 'aeo1_aroi_relays_count{state="configured_checked_invalid"} 1' in content
+    assert 'aeo1_aroi_relays_count{state="configured_checked_valid"} 1' in content
+
+
+def test_aroi_exactly_one_state_per_relay(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+    relays = [
+        make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com"),
+        make_relay("BBBB", contact="url:https://broken.org proof:dns-rsa ciissversion:2", aroi_domain="broken.org"),
+        make_relay("CCCC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org"),
+        make_relay("DDDD", contact="plain"),
+    ]
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays, aroi_data=sample_aroi_data())
+    for fp in ("AAAA", "BBBB", "CCCC", "DDDD"):
+        matches = re.findall(
+            rf'^aeo1_aroi_relay_state\{{fingerprint="{fp}",familyid="",state="[^"]+"\}} 1$',
+            content,
+            re.MULTILINE,
         )
-        with tempfile.TemporaryDirectory() as td:
-            stats = generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
-                content = f.read()
-        return content, stats
-
-    def test_healthy_relay(self):
-        relays = [_make_relay("AAAA", dns_status="success")]
-        content, _ = self._generate(relays)
-        self.assertIn('aeo1_exit_dns_failed{fingerprint="AAAA",familyid="",status="success"} 0', content)
-
-    def test_failing_relay(self):
-        relays = [_make_relay("BBBB", dns_status="dns_fail", dns_timing=5000, dns_consecutive=3)]
-        content, _ = self._generate(relays)
-        self.assertIn('aeo1_exit_dns_failed{fingerprint="BBBB",familyid="",status="dns_fail"} 1', content)
-        self.assertIn('aeo1_exit_dns_latency_ms{fingerprint="BBBB",familyid=""} 5000', content)
-        self.assertIn('aeo1_exit_dns_consecutive_failures{fingerprint="BBBB",familyid=""} 3', content)
-
-    def test_unreachable_relay_no_latency(self):
-        relays = [_make_relay("CCCC", dns_status="relay_unreachable", dns_timing=None)]
-        content, _ = self._generate(relays)
-        self.assertIn('aeo1_exit_dns_failed{fingerprint="CCCC",familyid="",status="relay_unreachable"} 1', content)
-        self.assertNotIn('aeo1_exit_dns_latency_ms{fingerprint="CCCC"', content)
-
-    def test_untested_relay_not_marked_failed(self):
-        relays = [_make_relay("DDDD", dns_status="untested", dns_timing=None)]
-        content, _ = self._generate(relays)
-        self.assertIn('aeo1_exit_dns_failed{fingerprint="DDDD",familyid="",status="untested"} 0', content)
-        self.assertNotIn('aeo1_exit_dns_latency_ms{fingerprint="DDDD"', content)
-
-    def test_non_exit_excluded(self):
-        relays = [
-            _make_relay("AAAA", flags=["Guard", "Running"]),
-            _make_relay("BBBB", flags=["Exit", "Running"]),
-        ]
-        content, stats = self._generate(relays, aroi_data=_sample_aroi_data())
-        self.assertEqual(stats["exit_relays"], 1)
-        self.assertNotIn('aeo1_exit_dns_failed{fingerprint="AAAA"', content)
-
-    def test_familyid_populated(self):
-        relays = [_make_relay("AAAA")]
-        content, _ = self._generate(relays, fp_to_family={"AAAA": "MYFAMKEY"})
-        self.assertIn('familyid="MYFAMKEY"', content)
-
-    def test_verifiedaroi_in_info(self):
-        relays = [_make_relay("AAAA", aroi_domain="example.com",
-                              contact="url:https://example.com proof:uri-rsa ciissversion:2")]
-        aroi_data = _sample_aroi_data()
-        aroi_data["results"] = [
-            {"fingerprint": "AAAA", "valid": True, "domain": "example.com", "proof_type": "uri-rsa"}
-        ]
-        content, _ = self._generate(relays, aroi_data=aroi_data, validated_domains={"example.com"})
-        self.assertIn('verifiedaroi="example.com"', content)
-
-    def test_sorted_by_fingerprint(self):
-        relays = [_make_relay("CCCC"), _make_relay("AAAA"), _make_relay("BBBB")]
-        content, _ = self._generate(relays, aroi_data=_sample_aroi_data())
-        fps = re.findall(r'aeo1_exit_dns_failed\{fingerprint="(\w+)"', content)
-        self.assertEqual(fps, sorted(fps))
+        assert len(matches) == 1, f"expected exactly one state for {fp}"
 
 
-# ---------------------------------------------------------------------------
-# Tests: AROI section (schema v2)
-# ---------------------------------------------------------------------------
-
-class TestAroiStateMetrics(unittest.TestCase):
-    def _generate(self, relays, aroi_data=None, fp_to_family=None):
-        rs = _make_relay_set(
-            relays,
-            exit_dns_health_data=_sample_dns_metadata(),
-            aroi_validation_data=aroi_data or _sample_aroi_data(),
-            fp_to_family_key=fp_to_family or {},
-        )
-        with tempfile.TemporaryDirectory() as td:
-            stats = generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
-                content = f.read()
-        return content, stats
-
-    def test_state_configured_checked_valid(self):
-        relay = _make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
-        content, _ = self._generate([relay], aroi_data=_sample_aroi_data())
-        self.assertIn('aeo1_aroi_relay_state{fingerprint="AAAA",familyid="",state="configured_checked_valid"} 1', content)
-
-    def test_state_configured_checked_invalid(self):
-        relay = _make_relay("BBBB", contact="url:https://broken.org proof:dns-rsa ciissversion:2", aroi_domain="broken.org")
-        content, _ = self._generate([relay], aroi_data=_sample_aroi_data())
-        self.assertIn('aeo1_aroi_relay_state{fingerprint="BBBB",familyid="",state="configured_checked_invalid"} 1', content)
-
-    def test_state_configured_unchecked(self):
-        relay = _make_relay("CCCC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org")
-        content, _ = self._generate([relay], aroi_data=_sample_aroi_data())
-        self.assertIn('aeo1_aroi_relay_state{fingerprint="CCCC",familyid="",state="configured_unchecked"} 1', content)
-
-    def test_state_not_configured(self):
-        relay = _make_relay("DDDD", contact="just a contact")
-        content, _ = self._generate([relay], aroi_data=_sample_aroi_data())
-        self.assertIn('aeo1_aroi_relay_state{fingerprint="DDDD",familyid="",state="not_configured"} 1', content)
-
-    def test_exactly_one_state_series_per_relay(self):
-        relays = [
-            _make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com"),
-            _make_relay("BBBB", contact="url:https://broken.org proof:dns-rsa ciissversion:2", aroi_domain="broken.org"),
-            _make_relay("CCCC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org"),
-            _make_relay("DDDD", contact="plain"),
-        ]
-        content, _ = self._generate(relays, aroi_data=_sample_aroi_data())
-        for fp in ("AAAA", "BBBB", "CCCC", "DDDD"):
-            matches = re.findall(
-                rf'^aeo1_aroi_relay_state\{{fingerprint="{fp}",familyid="",state="[^"]+"\}} 1$',
-                content,
-                re.MULTILINE,
-            )
-            self.assertEqual(len(matches), 1, f"expected exactly one state for {fp}")
-
-    def test_aggregate_state_counts(self):
-        relays = [
-            _make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com"),
-            _make_relay("BBBB", contact="url:https://broken.org proof:dns-rsa ciissversion:2", aroi_domain="broken.org"),
-            _make_relay("CCCC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org"),
-            _make_relay("DDDD", contact="plain"),
-        ]
-        content, stats = self._generate(relays, aroi_data=_sample_aroi_data())
-        self.assertEqual(stats["aroi_relays"], 3)
-        self.assertIn('aeo1_aroi_relays_count{state="not_configured"} 1', content)
-        self.assertIn('aeo1_aroi_relays_count{state="configured_unchecked"} 1', content)
-        self.assertIn('aeo1_aroi_relays_count{state="configured_checked_invalid"} 1', content)
-        self.assertIn('aeo1_aroi_relays_count{state="configured_checked_valid"} 1', content)
-
-    def test_legacy_aroi_valid_removed(self):
-        relay = _make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
-        content, _ = self._generate([relay], aroi_data=_sample_aroi_data())
-        self.assertNotIn("aeo1_aroi_valid{", content)
-        self.assertNotIn("aeo1_aroi_success_ratio", content)
-
-    def test_relay_info_uses_claimed_domain_when_unchecked(self):
-        relay = _make_relay("CCCC", nickname="RelayC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org")
-        content, _ = self._generate([relay], aroi_data=_sample_aroi_data())
-        line = next((ln for ln in content.split("\n") if ln.startswith('aeo1_aroi_relay_info{fingerprint="CCCC"')), "")
-        self.assertIn('domain="missing.org"', line)
+def test_aroi_legacy_metrics_removed(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+    relays = [make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")]
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays, aroi_data=sample_aroi_data())
+    assert "aeo1_aroi_valid{" not in content
+    assert "aeo1_aroi_success_ratio" not in content
 
 
-# ---------------------------------------------------------------------------
-# Tests: source availability
-# ---------------------------------------------------------------------------
-
-class TestSourceAvailability(unittest.TestCase):
-    def test_both_sources_up(self):
-        rs = _make_relay_set(
-            [_make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")],
-            exit_dns_health_data=_sample_dns_metadata(),
-            aroi_validation_data=_sample_aroi_data(),
-        )
-        with tempfile.TemporaryDirectory() as td:
-            generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
-                content = f.read()
-        self.assertIn('aeo1_source_up{source="exitdnshealth"} 1', content)
-        self.assertIn('aeo1_source_up{source="aroi"} 1', content)
-
-    def test_dns_source_down(self):
-        rs = _make_relay_set(
-            [_make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")],
-            exit_dns_health_data=None,
-            aroi_validation_data=_sample_aroi_data(),
-        )
-        with tempfile.TemporaryDirectory() as td:
-            generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
-                content = f.read()
-        self.assertIn('aeo1_source_up{source="exitdnshealth"} 0', content)
-        self.assertIn('aeo1_source_up{source="aroi"} 1', content)
-        self.assertNotIn("aeo1_exit_dns_failed", content)
-
-    def test_aroi_source_down(self):
-        rs = _make_relay_set(
-            [_make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")],
-            exit_dns_health_data=_sample_dns_metadata(),
-            aroi_validation_data=None,
-        )
-        with tempfile.TemporaryDirectory() as td:
-            generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
-                content = f.read()
-        self.assertIn('aeo1_source_up{source="exitdnshealth"} 1', content)
-        self.assertIn('aeo1_source_up{source="aroi"} 0', content)
-        self.assertNotIn("aeo1_aroi_relay_state", content)
-        self.assertNotIn("aeo1_aroi_relays_count", content)
-
-    def test_both_sources_down(self):
-        rs = _make_relay_set(
-            [_make_relay("AAAA")],
-            exit_dns_health_data=None,
-            aroi_validation_data=None,
-        )
-        with tempfile.TemporaryDirectory() as td:
-            generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
-                content = f.read()
-        self.assertIn('aeo1_source_up{source="exitdnshealth"} 0', content)
-        self.assertIn('aeo1_source_up{source="aroi"} 0', content)
-        self.assertIn("aeo1_build_info", content)
-        self.assertIn("aeo1_generation_timestamp_seconds", content)
+def test_aroi_unchecked_relay_info_uses_claimed_domain(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+    relays = [make_relay("CCCC", nickname="RelayC", contact="url:https://missing.org proof:dns-rsa ciissversion:2", aroi_domain="missing.org")]
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, relays, aroi_data=sample_aroi_data())
+    line = next((ln for ln in content.split("\n") if ln.startswith('aeo1_aroi_relay_info{fingerprint="CCCC"')), "")
+    assert 'domain="missing.org"' in line
 
 
-# ---------------------------------------------------------------------------
-# Tests: meta and file integrity
-# ---------------------------------------------------------------------------
-
-class TestMetaAndFile(unittest.TestCase):
-    def test_build_info_present_schema_v2(self):
-        rs = _make_relay_set([], exit_dns_health_data=_sample_dns_metadata())
-        with tempfile.TemporaryDirectory() as td:
-            generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
-                content = f.read()
-        self.assertIn(f'aeo1_build_info{{schema="{SCHEMA_VERSION}",generator="allium"}} 1', content)
-        self.assertEqual(SCHEMA_VERSION, "2")
-
-    def test_generation_timestamp_recent(self):
-        rs = _make_relay_set([])
-        with tempfile.TemporaryDirectory() as td:
-            before = int(time.time())
-            generate_prometheus_metrics(rs, td)
-            after = int(time.time())
-            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
-                content = f.read()
-        match = re.search(r"aeo1_generation_timestamp_seconds (\d+)", content)
-        self.assertIsNotNone(match)
-        ts = int(match.group(1))
-        self.assertGreaterEqual(ts, before)
-        self.assertLessEqual(ts, after)
-
-    def test_file_exists(self):
-        rs = _make_relay_set([])
-        with tempfile.TemporaryDirectory() as td:
-            generate_prometheus_metrics(rs, td)
-            self.assertTrue(os.path.exists(os.path.join(td, "metrics")))
-
-    def test_no_tmp_file_left(self):
-        rs = _make_relay_set([])
-        with tempfile.TemporaryDirectory() as td:
-            generate_prometheus_metrics(rs, td)
-            self.assertFalse(os.path.exists(os.path.join(td, "metrics.tmp")))
-
-    def test_unique_help_type_per_metric(self):
-        relay = _make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
-        rs = _make_relay_set([relay], exit_dns_health_data=_sample_dns_metadata(), aroi_validation_data=_sample_aroi_data())
-        with tempfile.TemporaryDirectory() as td:
-            generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
-                content = f.read()
-
-        help_counts = {}
-        type_counts = {}
-        for line in content.split("\n"):
-            if line.startswith("# HELP "):
-                name = line.split()[2]
-                help_counts[name] = help_counts.get(name, 0) + 1
-            elif line.startswith("# TYPE "):
-                name = line.split()[2]
-                type_counts[name] = type_counts.get(name, 0) + 1
-
-        for name, count in help_counts.items():
-            self.assertEqual(count, 1, f"Duplicate HELP for {name}")
-        for name, count in type_counts.items():
-            self.assertEqual(count, 1, f"Duplicate TYPE for {name}")
-
-    def test_eof_marker(self):
-        rs = _make_relay_set([])
-        with tempfile.TemporaryDirectory() as td:
-            generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
-                content = f.read()
-        self.assertIn("# EOF", content)
+def test_source_availability_permutations(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+    relay = make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
+    # both up
+    content, _ = _generate(
+        tmp_path, make_relay_set, sample_dns_metadata, [relay], aroi_data=sample_aroi_data()
+    )
+    assert 'aeo1_source_up{source="exitdnshealth"} 1' in content
+    assert 'aeo1_source_up{source="aroi"} 1' in content
 
 
-# ---------------------------------------------------------------------------
-# Regression tests
-# ---------------------------------------------------------------------------
-
-class TestParseTimestampEpoch(unittest.TestCase):
-    def test_z_suffix(self):
-        from datetime import datetime, timezone
-
-        expected = datetime(2026, 3, 8, 12, 0, 0, tzinfo=timezone.utc).timestamp()
-        self.assertEqual(_parse_timestamp_epoch("2026-03-08T12:00:00Z"), expected)
-
-    def test_offset_suffix(self):
-        from datetime import datetime, timezone
-
-        expected = datetime(2026, 3, 8, 12, 0, 0, tzinfo=timezone.utc).timestamp()
-        self.assertEqual(_parse_timestamp_epoch("2026-03-08T12:00:00+00:00"), expected)
-
-    def test_naive_timestamp_assumed_utc(self):
-        from datetime import datetime, timezone
-
-        expected = datetime(2026, 3, 8, 12, 0, 0, tzinfo=timezone.utc).timestamp()
-        self.assertEqual(_parse_timestamp_epoch("2026-03-08T12:00:00"), expected)
-
-    def test_empty_returns_zero(self):
-        self.assertEqual(_parse_timestamp_epoch(""), 0)
-        self.assertEqual(_parse_timestamp_epoch(None), 0)
-
-    def test_numeric_passthrough(self):
-        self.assertEqual(_parse_timestamp_epoch("1234567890"), 1234567890.0)
+def test_source_dns_down(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+    relay = make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
+    content, _ = _generate(
+        tmp_path, make_relay_set, sample_dns_metadata, [relay], dns_data=None, aroi_data=sample_aroi_data()
+    )
+    assert 'aeo1_source_up{source="exitdnshealth"} 0' in content
+    assert 'aeo1_source_up{source="aroi"} 1' in content
+    assert "aeo1_exit_dns_failed" not in content
 
 
-class TestDnsErrorTypesComplete(unittest.TestCase):
-    def test_dns_error_and_unknown_emitted(self):
-        rs = _make_relay_set(
-            [_make_relay("AAAA")],
-            exit_dns_health_data={
-                "metadata": {
-                    "timestamp": "2026-03-08T08:00:00Z",
-                    "consensus_relays": 100,
-                    "tested_relays": 95,
-                    "unreachable_relays": 5,
-                    "dns_success": 80,
-                    "dns_fail": 3,
-                    "dns_timeout": 1,
-                    "dns_wrong_ip": 1,
-                    "dns_socks_error": 0,
-                    "dns_network_error": 0,
-                    "dns_error": 7,
-                    "dns_exception": 0,
-                    "dns_unknown": 3,
-                    "timing": {"total": {}},
-                }
-            },
-        )
-        with tempfile.TemporaryDirectory() as td:
-            generate_prometheus_metrics(rs, td)
-            with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
-                content = f.read()
-
-        self.assertIn('aeo1_exit_dns_errors_count{error_type="error"} 7', content)
-        self.assertIn('aeo1_exit_dns_errors_count{error_type="unknown"} 3', content)
+def test_source_aroi_down(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
+    relay = make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, [relay], aroi_data=None)
+    assert 'aeo1_source_up{source="exitdnshealth"} 1' in content
+    assert 'aeo1_source_up{source="aroi"} 0' in content
+    assert "aeo1_aroi_relay_state" not in content
+    assert "aeo1_aroi_relays_count" not in content
 
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
+def test_source_both_down(tmp_path, make_relay, make_relay_set, sample_dns_metadata):
+    content, _ = _generate(tmp_path, make_relay_set, sample_dns_metadata, [make_relay("AAAA")], dns_data=None, aroi_data=None)
+    assert 'aeo1_source_up{source="exitdnshealth"} 0' in content
+    assert 'aeo1_source_up{source="aroi"} 0' in content
+    assert "aeo1_build_info" in content
+    assert "aeo1_generation_timestamp_seconds" in content
+
+
+def test_meta_build_info(tmp_path, make_relay_set, sample_dns_metadata):
+    rs = make_relay_set([], exit_dns_health_data=sample_dns_metadata())
+    generate_prometheus_metrics(rs, str(tmp_path))
+    content = (tmp_path / "metrics").read_text(encoding="utf-8")
+    assert f'aeo1_build_info{{schema="{SCHEMA_VERSION}",generator="allium"}} 1' in content
+    assert SCHEMA_VERSION == "2"
+
+
+def test_generation_timestamp_recent(tmp_path, make_relay_set):
+    rs = make_relay_set([])
+    before = int(time.time())
+    generate_prometheus_metrics(rs, str(tmp_path))
+    after = int(time.time())
+    content = (tmp_path / "metrics").read_text(encoding="utf-8")
+    match = re.search(r"aeo1_generation_timestamp_seconds (\d+)", content)
+    assert match is not None
+    ts = int(match.group(1))
+    assert before <= ts <= after
+
+
+def test_file_written_and_tmp_removed(tmp_path, make_relay_set):
+    rs = make_relay_set([])
+    generate_prometheus_metrics(rs, str(tmp_path))
+    assert (tmp_path / "metrics").exists()
+    assert not (tmp_path / "metrics.tmp").exists()
+
+
+def test_unique_help_type_per_metric(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data):
+    relay = make_relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com")
+    rs = make_relay_set([relay], exit_dns_health_data=sample_dns_metadata(), aroi_validation_data=sample_aroi_data())
+    generate_prometheus_metrics(rs, str(tmp_path))
+    content = (tmp_path / "metrics").read_text(encoding="utf-8")
+
+    help_counts = {}
+    type_counts = {}
+    for line in content.split("\n"):
+        if line.startswith("# HELP "):
+            name = line.split()[2]
+            help_counts[name] = help_counts.get(name, 0) + 1
+        elif line.startswith("# TYPE "):
+            name = line.split()[2]
+            type_counts[name] = type_counts.get(name, 0) + 1
+
+    assert all(count == 1 for count in help_counts.values())
+    assert all(count == 1 for count in type_counts.values())
+
+
+def test_eof_marker_present(tmp_path, make_relay_set):
+    rs = make_relay_set([])
+    generate_prometheus_metrics(rs, str(tmp_path))
+    content = (tmp_path / "metrics").read_text(encoding="utf-8")
+    assert "# EOF" in content
+
+
+def test_parse_timestamp_epoch_variants():
+    from datetime import datetime, timezone
+
+    expected = datetime(2026, 3, 8, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+    assert _parse_timestamp_epoch("2026-03-08T12:00:00Z") == expected
+    assert _parse_timestamp_epoch("2026-03-08T12:00:00+00:00") == expected
+    assert _parse_timestamp_epoch("2026-03-08T12:00:00") == expected
+    assert _parse_timestamp_epoch("") == 0
+    assert _parse_timestamp_epoch(None) == 0
+    assert _parse_timestamp_epoch("1234567890") == 1234567890.0
+
+
+def test_dns_error_and_unknown_emitted(tmp_path, make_relay, make_relay_set):
+    rs = make_relay_set(
+        [make_relay("AAAA")],
+        exit_dns_health_data={
+            "metadata": {
+                "timestamp": "2026-03-08T08:00:00Z",
+                "consensus_relays": 100,
+                "tested_relays": 95,
+                "unreachable_relays": 5,
+                "dns_success": 80,
+                "dns_fail": 3,
+                "dns_timeout": 1,
+                "dns_wrong_ip": 1,
+                "dns_socks_error": 0,
+                "dns_network_error": 0,
+                "dns_error": 7,
+                "dns_exception": 0,
+                "dns_unknown": 3,
+                "timing": {"total": {}},
+            }
+        },
+    )
+    generate_prometheus_metrics(rs, str(tmp_path))
+    content = (tmp_path / "metrics").read_text(encoding="utf-8")
+    assert 'aeo1_exit_dns_errors_count{error_type="error"} 7' in content
+    assert 'aeo1_exit_dns_errors_count{error_type="unknown"} 3' in content

--- a/tests/unit/test_prometheus_metrics.py
+++ b/tests/unit/test_prometheus_metrics.py
@@ -1,9 +1,10 @@
 """Pytest tests for allium.lib.prometheus_metrics (schema v2)."""
 
+from __future__ import annotations
+
 import re
 import time
 from pathlib import Path
-from typing import Tuple
 
 import pytest
 
@@ -57,7 +58,7 @@ def _generate(
     aroi_data=_USE_DEFAULT,
     fp_to_family=None,
     validated_domains=None,
-) -> Tuple[str, dict]:
+) -> tuple[str, dict]:
     selected_dns = sample_dns_metadata() if dns_data is _USE_DEFAULT else dns_data
     selected_aroi = _sample_aroi_data() if aroi_data is _USE_DEFAULT else aroi_data
     rs = make_relay_set(

--- a/tests/unit/test_prometheus_metrics.py
+++ b/tests/unit/test_prometheus_metrics.py
@@ -138,7 +138,12 @@ def test_is_aroi_configured_variants(relay, expected):
 
 
 def test_build_aroi_map_uppercase(make_relay_set, sample_aroi_data):
-    rs = make_relay_set([], aroi_validation_data=sample_aroi_data())
+    aroi_payload = sample_aroi_data()
+    aroi_payload["results"] = [
+        {"fingerprint": "aaaa", "valid": True, "domain": "example.com", "proof_type": "uri-rsa"},
+        {"fingerprint": "BbBb", "valid": False, "domain": "broken.org", "proof_type": "dns-rsa"},
+    ]
+    rs = make_relay_set([], aroi_validation_data=aroi_payload)
     amap = _build_aroi_map(rs)
     assert "AAAA" in amap
     assert "BBBB" in amap
@@ -236,10 +241,10 @@ def test_aroi_state_and_counts(tmp_path, make_relay, make_relay_set, sample_dns_
         tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, relays, aroi_data=sample_aroi_data()
     )
     assert stats["aroi_relays"] == 3
-    assert 'state="configured_checked_valid"} 1' in content
-    assert 'state="configured_checked_invalid"} 1' in content
-    assert 'state="configured_unchecked"} 1' in content
-    assert 'state="not_configured"} 1' in content
+    assert 'aeo1_aroi_relay_state{fingerprint="AAAA",familyid="",state="configured_checked_valid"} 1' in content
+    assert 'aeo1_aroi_relay_state{fingerprint="BBBB",familyid="",state="configured_checked_invalid"} 1' in content
+    assert 'aeo1_aroi_relay_state{fingerprint="CCCC",familyid="",state="configured_unchecked"} 1' in content
+    assert 'aeo1_aroi_relay_state{fingerprint="DDDD",familyid="",state="not_configured"} 1' in content
     assert 'aeo1_aroi_relays_count{state="not_configured"} 1' in content
     assert 'aeo1_aroi_relays_count{state="configured_unchecked"} 1' in content
     assert 'aeo1_aroi_relays_count{state="configured_checked_invalid"} 1' in content
@@ -257,13 +262,22 @@ def test_aroi_exactly_one_state_per_relay(tmp_path, make_relay, make_relay_set, 
     content, _ = _generate(
         tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, relays, aroi_data=sample_aroi_data()
     )
-    for fp in ("AAAA", "BBBB", "CCCC", "DDDD"):
+    expected_states = {
+        "AAAA": "configured_checked_valid",
+        "BBBB": "configured_checked_invalid",
+        "CCCC": "configured_unchecked",
+        "DDDD": "not_configured",
+    }
+    for fp, expected_state in expected_states.items():
         matches = re.findall(
             rf'^aeo1_aroi_relay_state\{{fingerprint="{fp}",familyid="",state="[^"]+"\}} 1$',
             content,
             re.MULTILINE,
         )
         assert len(matches) == 1, f"expected exactly one state for {fp}"
+        assert (
+            f'aeo1_aroi_relay_state{{fingerprint="{fp}",familyid="",state="{expected_state}"}} 1' in content
+        ), f"expected state {expected_state} for {fp}"
 
 
 def test_aroi_legacy_metrics_removed(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data,

--- a/tests/unit/test_prometheus_schema_contract.py
+++ b/tests/unit/test_prometheus_schema_contract.py
@@ -6,22 +6,21 @@ These tests are intentionally integration-leaning:
 - validate docs + alert examples stay aligned with emitted contract.
 """
 
-import os
 import re
-import sys
-import tempfile
-import unittest
+from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(__file__))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "allium"))
+import pytest
 
-from lib.prometheus_metrics import generate_prometheus_metrics  # noqa: E402
-from prometheus_fixtures import (  # noqa: E402
+from allium.lib.prometheus_metrics import generate_prometheus_metrics
+from tests.unit.prometheus_fixtures import (
     make_relay as _make_base_relay,
     make_relay_set as _make_base_relay_set,
     sample_aroi_data as _sample_base_aroi_data,
     sample_dns_metadata as _sample_base_dns_metadata,
 )
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOCS_DIR = _REPO_ROOT / "docs" / "prometheus"
 
 
 def _relay(
@@ -84,7 +83,8 @@ def _aroi_data():
     return data
 
 
-def _render_metrics():
+@pytest.fixture
+def render_metrics(tmp_path):
     relays = [
         # configured + checked + valid
         _relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com", dns_detail="success"),
@@ -98,10 +98,8 @@ def _render_metrics():
         _relay("EEEE", contact="", aroi_domain="none", dns_detail="untested"),
     ]
     rs = _relay_set(relays, _dns_data(), _aroi_data())
-    with tempfile.TemporaryDirectory() as td:
-        generate_prometheus_metrics(rs, td)
-        with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
-            return f.read()
+    generate_prometheus_metrics(rs, str(tmp_path))
+    return (tmp_path / "metrics").read_text(encoding="utf-8")
 
 
 def _metric_names_from_content(content: str):
@@ -129,192 +127,171 @@ def _label_key_sets_for_metric(content: str, metric_name: str):
     return label_sets
 
 
-def _extract_non_comment_aeo1_tokens(path: str):
+def _extract_non_comment_aeo1_tokens(path: Path):
     with open(path, encoding="utf-8") as f:
         lines = f.readlines()
     active_lines = [ln for ln in lines if not ln.lstrip().startswith("#")]
     return set(re.findall(r"\baeo1_[a-zA-Z0-9_:]+\b", "".join(active_lines)))
 
 
-def _extract_record_names(path: str):
+def _extract_record_names(path: Path):
     with open(path, encoding="utf-8") as f:
         text = f.read()
     return set(re.findall(r"^\s*-\s*record:\s*(aeo1_[a-zA-Z0-9_:]+)\s*$", text, re.MULTILINE))
 
 
-def _extract_group_names(path: str):
+def _extract_group_names(path: Path):
     with open(path, encoding="utf-8") as f:
         text = f.read()
     return set(re.findall(r"^\s*-\s*name:\s*(aeo1_[a-zA-Z0-9_:]+)\s*$", text, re.MULTILINE))
 
 
-class TestPrometheusSchemaV2Contract(unittest.TestCase):
-    def test_metric_family_contract_and_legacy_absence(self):
-        content = _render_metrics()
-        metric_names = set()
-        for line in content.split("\n"):
-            if not line or line.startswith("#"):
-                continue
-            metric_names.add(line.split("{", 1)[0].split(" ", 1)[0])
+def test_metric_family_contract_and_legacy_absence(render_metrics):
+    metric_names = _metric_names_from_content(render_metrics)
 
-        required = {
-            "aeo1_build_info",
-            "aeo1_generation_timestamp_seconds",
-            "aeo1_source_up",
-            "aeo1_source_last_success_timestamp_seconds",
-            "aeo1_exit_dns_failed",
-            "aeo1_exit_dns_errors_count",
-            "aeo1_aroi_relay_state",
-            "aeo1_aroi_relays_count",
-            "aeo1_aroi_scan_timestamp_seconds",
-            "aeo1_aroi_relay_info",
-        }
-        removed = {
-            "aeo1_aroi_valid",
-            "aeo1_aroi_success_ratio",
-            "aeo1_aroi_valid_relays_count",
-        }
+    required = {
+        "aeo1_build_info",
+        "aeo1_generation_timestamp_seconds",
+        "aeo1_source_up",
+        "aeo1_source_last_success_timestamp_seconds",
+        "aeo1_exit_dns_failed",
+        "aeo1_exit_dns_errors_count",
+        "aeo1_aroi_relay_state",
+        "aeo1_aroi_relays_count",
+        "aeo1_aroi_scan_timestamp_seconds",
+        "aeo1_aroi_relay_info",
+    }
+    removed = {
+        "aeo1_aroi_valid",
+        "aeo1_aroi_success_ratio",
+        "aeo1_aroi_valid_relays_count",
+    }
 
-        self.assertTrue(required.issubset(metric_names))
-        self.assertTrue(removed.isdisjoint(metric_names))
+    assert required.issubset(metric_names)
+    assert removed.isdisjoint(metric_names)
 
-    def test_frozen_aroi_state_enum_values(self):
-        content = _render_metrics()
-        states = set(
-            re.findall(
-                r'aeo1_aroi_relay_state\{[^}]*state="([^"]+)"\} 1',
-                content,
-            )
+
+def test_frozen_aroi_state_enum_values(render_metrics):
+    states = set(
+        re.findall(
+            r'aeo1_aroi_relay_state\{[^}]*state="([^"]+)"\} 1',
+            render_metrics,
         )
-        self.assertEqual(
-            states,
-            {
-                "not_configured",
-                "configured_unchecked",
-                "configured_checked_invalid",
-                "configured_checked_valid",
-            },
+    )
+    assert states == {
+        "not_configured",
+        "configured_unchecked",
+        "configured_checked_invalid",
+        "configured_checked_valid",
+    }
+
+
+def test_frozen_label_keys_for_core_metrics(render_metrics):
+    expected = {
+        "aeo1_build_info": {"schema", "generator"},
+        "aeo1_source_up": {"source"},
+        "aeo1_source_last_success_timestamp_seconds": {"source"},
+        "aeo1_exit_dns_errors_count": {"error_type"},
+        "aeo1_exit_dns_latency_ms_stat": {"stat"},
+        "aeo1_exit_dns_failed": {"fingerprint", "familyid", "status"},
+        "aeo1_exit_dns_latency_ms": {"fingerprint", "familyid"},
+        "aeo1_exit_dns_consecutive_failures": {"fingerprint", "familyid"},
+        "aeo1_exit_relay_info": {"fingerprint", "familyid", "nick", "verifiedaroi"},
+        "aeo1_aroi_relay_state": {"fingerprint", "familyid", "state"},
+        "aeo1_aroi_relays_count": {"state"},
+        "aeo1_aroi_relay_info": {"fingerprint", "familyid", "nick", "domain", "proof_type"},
+    }
+    for metric, expected_keys in expected.items():
+        found = _label_key_sets_for_metric(render_metrics, metric)
+        assert found, f"missing metric lines for {metric}"
+        assert found == {frozenset(expected_keys)}, f"unexpected labels for {metric}"
+
+
+def test_dns_status_enum_includes_untested(render_metrics):
+    statuses = set(
+        re.findall(
+            r'aeo1_exit_dns_failed\{[^}]*status="([^"]+)"\}',
+            render_metrics,
         )
+    )
+    assert {"success", "dns_fail", "timeout", "relay_unreachable", "untested"}.issubset(statuses)
 
-    def test_frozen_label_keys_for_core_metrics(self):
-        content = _render_metrics()
-        expected = {
-            "aeo1_build_info": {"schema", "generator"},
-            "aeo1_source_up": {"source"},
-            "aeo1_source_last_success_timestamp_seconds": {"source"},
-            "aeo1_exit_dns_errors_count": {"error_type"},
-            "aeo1_exit_dns_latency_ms_stat": {"stat"},
-            "aeo1_exit_dns_failed": {"fingerprint", "familyid", "status"},
-            "aeo1_exit_dns_latency_ms": {"fingerprint", "familyid"},
-            "aeo1_exit_dns_consecutive_failures": {"fingerprint", "familyid"},
-            "aeo1_exit_relay_info": {"fingerprint", "familyid", "nick", "verifiedaroi"},
-            "aeo1_aroi_relay_state": {"fingerprint", "familyid", "state"},
-            "aeo1_aroi_relays_count": {"state"},
-            "aeo1_aroi_relay_info": {"fingerprint", "familyid", "nick", "domain", "proof_type"},
-        }
-        for metric, expected_keys in expected.items():
-            found = _label_key_sets_for_metric(content, metric)
-            self.assertTrue(found, f"missing metric lines for {metric}")
-            self.assertEqual(found, {frozenset(expected_keys)}, f"unexpected labels for {metric}")
 
-    def test_dns_status_enum_includes_untested(self):
-        content = _render_metrics()
-        statuses = set(
-            re.findall(
-                r'aeo1_exit_dns_failed\{[^}]*status="([^"]+)"\}',
-                content,
-            )
+def test_derived_ratios_from_canonical_counts(render_metrics):
+    state_counts = {
+        state: int(value)
+        for state, value in re.findall(
+            r'aeo1_aroi_relays_count\{state="([^"]+)"\} ([0-9]+)',
+            render_metrics,
         )
-        self.assertTrue(
-            {"success", "dns_fail", "timeout", "relay_unreachable", "untested"}.issubset(statuses)
-        )
+    }
+    configured_total = (
+        state_counts["configured_unchecked"]
+        + state_counts["configured_checked_invalid"]
+        + state_counts["configured_checked_valid"]
+    )
+    assert configured_total > 0, f"configured_total must be >0, got {configured_total} from {state_counts}"
 
-    def test_derived_ratios_from_canonical_counts(self):
-        content = _render_metrics()
-        state_counts = {
-            state: int(value)
-            for state, value in re.findall(
-                r'aeo1_aroi_relays_count\{state="([^"]+)"\} ([0-9]+)',
-                content,
-            )
-        }
-        configured_total = (
-            state_counts["configured_unchecked"]
-            + state_counts["configured_checked_invalid"]
-            + state_counts["configured_checked_valid"]
-        )
-        checked_total = (
-            state_counts["configured_checked_invalid"]
-            + state_counts["configured_checked_valid"]
-        )
-        success_ratio = state_counts["configured_checked_valid"] / configured_total
-        checked_ratio = checked_total / configured_total
-        self.assertGreaterEqual(success_ratio, 0.0)
-        self.assertLessEqual(success_ratio, 1.0)
-        self.assertGreaterEqual(checked_ratio, 0.0)
-        self.assertLessEqual(checked_ratio, 1.0)
+    checked_total = (
+        state_counts["configured_checked_invalid"]
+        + state_counts["configured_checked_valid"]
+    )
+    success_ratio = state_counts["configured_checked_valid"] / configured_total
+    checked_ratio = checked_total / configured_total
+    assert 0.0 <= success_ratio <= 1.0, f"success_ratio out of bounds: {success_ratio}"
+    assert 0.0 <= checked_ratio <= 1.0, f"checked_ratio out of bounds: {checked_ratio}"
 
 
-class TestPrometheusDocsAndAlertsContract(unittest.TestCase):
-    def test_readme_contains_v2_contract_and_dns_note(self):
-        readme = "/workspace/docs/prometheus/README.md"
-        with open(readme, encoding="utf-8") as f:
-            text = f.read()
+def test_readme_contains_v2_contract_and_dns_note():
+    readme = _DOCS_DIR / "README.md"
+    text = readme.read_text(encoding="utf-8")
 
-        # Schema + state model
-        self.assertIn("**Schema:** v2", text)
-        self.assertIn("aeo1_aroi_relay_state", text)
-        self.assertIn("configured_unchecked", text)
-        self.assertIn("configured_checked_invalid", text)
-        self.assertIn("configured_checked_valid", text)
-
-        # DNS enum completeness in docs
-        self.assertIn("`error`", text)
-        self.assertIn("`unknown`", text)
-        self.assertIn("`untested`", text)
-
-        # Migration/joins presence
-        self.assertIn("Side-by-side query mapping", text)
-        self.assertIn("Domain unchecked", text)
-        self.assertIn("Migration checklist", text)
-        self.assertIn("Operator Runbook", text)
-        self.assertIn("Aggregate-only dashboard mode", text)
-        self.assertIn("recording_rules.yml", text)
-
-    def test_alert_examples_use_v2_metrics_only(self):
-        alert_path = "/workspace/docs/prometheus/alerts_aroi.yml"
-        with open(alert_path, encoding="utf-8") as f:
-            alerts = f.read()
-
-        self.assertIn("Schema: v2", alerts)
-        self.assertIn("aeo1_aroi_relay_state", alerts)
-        self.assertIn("aeo1_aroi_relays_count", alerts)
-        self.assertNotIn("aeo1_aroi_valid", alerts)
-
-    def test_recording_rules_file_exists_and_uses_v2_states(self):
-        rules_path = "/workspace/docs/prometheus/recording_rules.yml"
-        self.assertTrue(os.path.exists(rules_path))
-        with open(rules_path, encoding="utf-8") as f:
-            text = f.read()
-        self.assertIn('state="configured_unchecked"', text)
-        self.assertIn('state="configured_checked_invalid"', text)
-        self.assertIn('state="configured_checked_valid"', text)
-
-    def test_alert_and_recording_rule_metric_references_exist(self):
-        emitted = _metric_names_from_content(_render_metrics())
-
-        alerts_path = "/workspace/docs/prometheus/alerts_aroi.yml"
-        alerts_refs = _extract_non_comment_aeo1_tokens(alerts_path)
-        alerts_refs -= _extract_group_names(alerts_path)
-        self.assertTrue(alerts_refs.issubset(emitted), f"unknown alert refs: {sorted(alerts_refs - emitted)}")
-
-        rules_path = "/workspace/docs/prometheus/recording_rules.yml"
-        rules_refs = _extract_non_comment_aeo1_tokens(rules_path)
-        record_names = _extract_record_names(rules_path)
-        group_names = _extract_group_names(rules_path)
-        expr_refs = rules_refs - record_names - group_names
-        self.assertTrue(expr_refs.issubset(emitted), f"unknown recording expr refs: {sorted(expr_refs - emitted)}")
+    assert "**Schema:** v2" in text
+    assert "aeo1_aroi_relay_state" in text
+    assert "configured_unchecked" in text
+    assert "configured_checked_invalid" in text
+    assert "configured_checked_valid" in text
+    assert "`error`" in text
+    assert "`unknown`" in text
+    assert "`untested`" in text
+    assert "Side-by-side query mapping" in text
+    assert "Domain unchecked" in text
+    assert "Migration checklist" in text
+    assert "Operator Runbook" in text
+    assert "Aggregate-only dashboard mode" in text
+    assert "recording_rules.yml" in text
 
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
+def test_alert_examples_use_v2_metrics_only():
+    alert_path = _DOCS_DIR / "alerts_aroi.yml"
+    alerts = alert_path.read_text(encoding="utf-8")
+
+    assert "Schema: v2" in alerts
+    assert "aeo1_aroi_relay_state" in alerts
+    assert "aeo1_aroi_relays_count" in alerts
+    assert "aeo1_aroi_valid" not in alerts
+
+
+def test_recording_rules_file_exists_and_uses_v2_states():
+    rules_path = _DOCS_DIR / "recording_rules.yml"
+    assert rules_path.exists()
+    text = rules_path.read_text(encoding="utf-8")
+    assert 'state="configured_unchecked"' in text
+    assert 'state="configured_checked_invalid"' in text
+    assert 'state="configured_checked_valid"' in text
+
+
+def test_alert_and_recording_rule_metric_references_exist(render_metrics):
+    emitted = _metric_names_from_content(render_metrics)
+
+    alerts_path = _DOCS_DIR / "alerts_aroi.yml"
+    alerts_refs = _extract_non_comment_aeo1_tokens(alerts_path)
+    alerts_refs -= _extract_group_names(alerts_path)
+    assert alerts_refs.issubset(emitted), f"unknown alert refs: {sorted(alerts_refs - emitted)}"
+
+    rules_path = _DOCS_DIR / "recording_rules.yml"
+    rules_refs = _extract_non_comment_aeo1_tokens(rules_path)
+    record_names = _extract_record_names(rules_path)
+    group_names = _extract_group_names(rules_path)
+    expr_refs = rules_refs - record_names - group_names
+    assert expr_refs.issubset(emitted), f"unknown recording expr refs: {sorted(expr_refs - emitted)}"

--- a/tests/unit/test_prometheus_schema_contract.py
+++ b/tests/unit/test_prometheus_schema_contract.py
@@ -12,9 +12,16 @@ import sys
 import tempfile
 import unittest
 
+sys.path.insert(0, os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "allium"))
 
 from lib.prometheus_metrics import generate_prometheus_metrics  # noqa: E402
+from prometheus_fixtures import (  # noqa: E402
+    make_relay as _make_base_relay,
+    make_relay_set as _make_base_relay_set,
+    sample_aroi_data as _sample_base_aroi_data,
+    sample_dns_metadata as _sample_base_dns_metadata,
+)
 
 
 def _relay(
@@ -24,61 +31,57 @@ def _relay(
     flags=None,
     dns_detail="success",
 ):
-    return {
-        "fingerprint": fingerprint,
-        "nickname": f"n{fingerprint[:4]}",
-        "contact": contact,
-        "aroi_domain": aroi_domain,
-        "flags": flags or ["Exit", "Running", "Valid"],
-        "exit_dns_health_detail": dns_detail,
-        "exit_dns_health_timing_ms": None if dns_detail in ("relay_unreachable", "untested") else 1000,
-        "exit_dns_health_consecutive_failures": 0,
-    }
+    return _make_base_relay(
+        fingerprint=fingerprint,
+        nickname=f"n{fingerprint[:4]}",
+        flags=flags or ["Exit", "Running", "Valid"],
+        contact=contact,
+        aroi_domain=aroi_domain,
+        dns_status=dns_detail,
+        dns_timing=None if dns_detail in ("relay_unreachable", "untested") else 1000,
+        dns_consecutive=0,
+    )
 
 
 def _relay_set(relays, dns_data, aroi_data):
-    class RS:
-        pass
-
-    rs = RS()
-    rs.json = {"relays": relays}
-    rs.exit_dns_health_data = dns_data
-    rs.aroi_validation_data = aroi_data
-    rs._fp_to_family_key = {}
-    rs.validated_aroi_domains = set()
-    return rs
+    return _make_base_relay_set(
+        relays,
+        exit_dns_health_data=dns_data,
+        aroi_validation_data=aroi_data,
+        fp_to_family_key={},
+        validated_aroi_domains=set(),
+    )
 
 
 def _dns_data():
-    return {
-        "metadata": {
-            "timestamp": "2026-03-08T08:00:00Z",
-            "consensus_relays": 5,
-            "tested_relays": 5,
-            "unreachable_relays": 0,
-            "dns_success": 1,
-            "dns_fail": 1,
-            "dns_timeout": 1,
-            "dns_wrong_ip": 0,
-            "dns_socks_error": 0,
-            "dns_network_error": 0,
-            "dns_error": 1,
-            "dns_exception": 0,
-            "dns_unknown": 1,
-            "timing": {"total": {"avg_ms": 1, "min_ms": 1, "max_ms": 1, "p50_ms": 1, "p95_ms": 1, "p99_ms": 1}},
-        }
-    }
+    data = _sample_base_dns_metadata()
+    data["metadata"].update({
+        "consensus_relays": 5,
+        "tested_relays": 5,
+        "unreachable_relays": 0,
+        "dns_success": 1,
+        "dns_fail": 1,
+        "dns_timeout": 1,
+        "dns_wrong_ip": 0,
+        "dns_socks_error": 0,
+        "dns_network_error": 0,
+        "dns_error": 1,
+        "dns_exception": 0,
+        "dns_unknown": 1,
+    })
+    data["metadata"]["timing"] = {"total": {"avg_ms": 1, "min_ms": 1, "max_ms": 1, "p50_ms": 1, "p95_ms": 1, "p99_ms": 1}}
+    return data
 
 
 def _aroi_data():
-    return {
-        "metadata": {"timestamp": "2026-03-08T10:00:00Z"},
-        "statistics": {},
-        "results": [
-            {"fingerprint": "AAAA", "valid": True, "domain": "example.com", "proof_type": "uri-rsa"},
-            {"fingerprint": "BBBB", "valid": False, "domain": "broken.org", "proof_type": "dns-rsa"},
-        ],
-    }
+    data = _sample_base_aroi_data()
+    data["metadata"] = {"timestamp": "2026-03-08T10:00:00Z"}
+    data["statistics"] = {}
+    data["results"] = [
+        {"fingerprint": "AAAA", "valid": True, "domain": "example.com", "proof_type": "uri-rsa"},
+        {"fingerprint": "BBBB", "valid": False, "domain": "broken.org", "proof_type": "dns-rsa"},
+    ]
+    return data
 
 
 def _render_metrics():
@@ -99,6 +102,34 @@ def _render_metrics():
         generate_prometheus_metrics(rs, td)
         with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
             return f.read()
+
+
+def _metric_names_from_content(content: str):
+    names = set()
+    for line in content.split("\n"):
+        if not line or line.startswith("#"):
+            continue
+        names.add(line.split("{", 1)[0].split(" ", 1)[0])
+    return names
+
+
+def _extract_non_comment_aeo1_tokens(path: str):
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+    active_lines = [ln for ln in lines if not ln.lstrip().startswith("#")]
+    return set(re.findall(r"\baeo1_[a-zA-Z0-9_:]+\b", "".join(active_lines)))
+
+
+def _extract_record_names(path: str):
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    return set(re.findall(r"^\s*-\s*record:\s*(aeo1_[a-zA-Z0-9_:]+)\s*$", text, re.MULTILINE))
+
+
+def _extract_group_names(path: str):
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    return set(re.findall(r"^\s*-\s*name:\s*(aeo1_[a-zA-Z0-9_:]+)\s*$", text, re.MULTILINE))
 
 
 class TestPrometheusSchemaV2Contract(unittest.TestCase):
@@ -231,6 +262,21 @@ class TestPrometheusDocsAndAlertsContract(unittest.TestCase):
         self.assertIn('state="configured_unchecked"', text)
         self.assertIn('state="configured_checked_invalid"', text)
         self.assertIn('state="configured_checked_valid"', text)
+
+    def test_alert_and_recording_rule_metric_references_exist(self):
+        emitted = _metric_names_from_content(_render_metrics())
+
+        alerts_path = "/workspace/docs/prometheus/alerts_aroi.yml"
+        alerts_refs = _extract_non_comment_aeo1_tokens(alerts_path)
+        alerts_refs -= _extract_group_names(alerts_path)
+        self.assertTrue(alerts_refs.issubset(emitted), f"unknown alert refs: {sorted(alerts_refs - emitted)}")
+
+        rules_path = "/workspace/docs/prometheus/recording_rules.yml"
+        rules_refs = _extract_non_comment_aeo1_tokens(rules_path)
+        record_names = _extract_record_names(rules_path)
+        group_names = _extract_group_names(rules_path)
+        expr_refs = rules_refs - record_names - group_names
+        self.assertTrue(expr_refs.issubset(emitted), f"unknown recording expr refs: {sorted(expr_refs - emitted)}")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_prometheus_schema_contract.py
+++ b/tests/unit/test_prometheus_schema_contract.py
@@ -1,0 +1,237 @@
+"""
+Schema-contract and migration-guard tests for Prometheus schema v2.
+
+These tests are intentionally integration-leaning:
+- validate emitted metric families/labels for schema contract stability,
+- validate docs + alert examples stay aligned with emitted contract.
+"""
+
+import os
+import re
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "allium"))
+
+from lib.prometheus_metrics import generate_prometheus_metrics  # noqa: E402
+
+
+def _relay(
+    fingerprint,
+    contact="",
+    aroi_domain="none",
+    flags=None,
+    dns_detail="success",
+):
+    return {
+        "fingerprint": fingerprint,
+        "nickname": f"n{fingerprint[:4]}",
+        "contact": contact,
+        "aroi_domain": aroi_domain,
+        "flags": flags or ["Exit", "Running", "Valid"],
+        "exit_dns_health_detail": dns_detail,
+        "exit_dns_health_timing_ms": None if dns_detail in ("relay_unreachable", "untested") else 1000,
+        "exit_dns_health_consecutive_failures": 0,
+    }
+
+
+def _relay_set(relays, dns_data, aroi_data):
+    class RS:
+        pass
+
+    rs = RS()
+    rs.json = {"relays": relays}
+    rs.exit_dns_health_data = dns_data
+    rs.aroi_validation_data = aroi_data
+    rs._fp_to_family_key = {}
+    rs.validated_aroi_domains = set()
+    return rs
+
+
+def _dns_data():
+    return {
+        "metadata": {
+            "timestamp": "2026-03-08T08:00:00Z",
+            "consensus_relays": 5,
+            "tested_relays": 5,
+            "unreachable_relays": 0,
+            "dns_success": 1,
+            "dns_fail": 1,
+            "dns_timeout": 1,
+            "dns_wrong_ip": 0,
+            "dns_socks_error": 0,
+            "dns_network_error": 0,
+            "dns_error": 1,
+            "dns_exception": 0,
+            "dns_unknown": 1,
+            "timing": {"total": {"avg_ms": 1, "min_ms": 1, "max_ms": 1, "p50_ms": 1, "p95_ms": 1, "p99_ms": 1}},
+        }
+    }
+
+
+def _aroi_data():
+    return {
+        "metadata": {"timestamp": "2026-03-08T10:00:00Z"},
+        "statistics": {},
+        "results": [
+            {"fingerprint": "AAAA", "valid": True, "domain": "example.com", "proof_type": "uri-rsa"},
+            {"fingerprint": "BBBB", "valid": False, "domain": "broken.org", "proof_type": "dns-rsa"},
+        ],
+    }
+
+
+def _render_metrics():
+    relays = [
+        # configured + checked + valid
+        _relay("AAAA", contact="url:https://example.com proof:uri-rsa ciissversion:2", aroi_domain="example.com", dns_detail="success"),
+        # configured + checked + invalid
+        _relay("BBBB", contact="url:https://broken.org proof:dns-rsa ciissversion:2", aroi_domain="broken.org", dns_detail="dns_fail"),
+        # configured + unchecked
+        _relay("CCCC", contact="url:https://unchecked.org proof:dns-rsa ciissversion:2", aroi_domain="unchecked.org", dns_detail="timeout"),
+        # not configured
+        _relay("DDDD", contact="plain contact", aroi_domain="none", dns_detail="relay_unreachable"),
+        # untested dns status coverage
+        _relay("EEEE", contact="", aroi_domain="none", dns_detail="untested"),
+    ]
+    rs = _relay_set(relays, _dns_data(), _aroi_data())
+    with tempfile.TemporaryDirectory() as td:
+        generate_prometheus_metrics(rs, td)
+        with open(os.path.join(td, "metrics"), encoding="utf-8") as f:
+            return f.read()
+
+
+class TestPrometheusSchemaV2Contract(unittest.TestCase):
+    def test_metric_family_contract_and_legacy_absence(self):
+        content = _render_metrics()
+        metric_names = set()
+        for line in content.split("\n"):
+            if not line or line.startswith("#"):
+                continue
+            metric_names.add(line.split("{", 1)[0].split(" ", 1)[0])
+
+        required = {
+            "aeo1_build_info",
+            "aeo1_generation_timestamp_seconds",
+            "aeo1_source_up",
+            "aeo1_source_last_success_timestamp_seconds",
+            "aeo1_exit_dns_failed",
+            "aeo1_exit_dns_errors_count",
+            "aeo1_aroi_relay_state",
+            "aeo1_aroi_relays_count",
+            "aeo1_aroi_scan_timestamp_seconds",
+            "aeo1_aroi_relay_info",
+        }
+        removed = {
+            "aeo1_aroi_valid",
+            "aeo1_aroi_success_ratio",
+            "aeo1_aroi_valid_relays_count",
+        }
+
+        self.assertTrue(required.issubset(metric_names))
+        self.assertTrue(removed.isdisjoint(metric_names))
+
+    def test_frozen_aroi_state_enum_values(self):
+        content = _render_metrics()
+        states = set(
+            re.findall(
+                r'aeo1_aroi_relay_state\{[^}]*state="([^"]+)"\} 1',
+                content,
+            )
+        )
+        self.assertEqual(
+            states,
+            {
+                "not_configured",
+                "configured_unchecked",
+                "configured_checked_invalid",
+                "configured_checked_valid",
+            },
+        )
+
+    def test_dns_status_enum_includes_untested(self):
+        content = _render_metrics()
+        statuses = set(
+            re.findall(
+                r'aeo1_exit_dns_failed\{[^}]*status="([^"]+)"\}',
+                content,
+            )
+        )
+        self.assertTrue(
+            {"success", "dns_fail", "timeout", "relay_unreachable", "untested"}.issubset(statuses)
+        )
+
+    def test_derived_ratios_from_canonical_counts(self):
+        content = _render_metrics()
+        state_counts = {
+            state: int(value)
+            for state, value in re.findall(
+                r'aeo1_aroi_relays_count\{state="([^"]+)"\} ([0-9]+)',
+                content,
+            )
+        }
+        configured_total = (
+            state_counts["configured_unchecked"]
+            + state_counts["configured_checked_invalid"]
+            + state_counts["configured_checked_valid"]
+        )
+        checked_total = (
+            state_counts["configured_checked_invalid"]
+            + state_counts["configured_checked_valid"]
+        )
+        success_ratio = state_counts["configured_checked_valid"] / configured_total
+        checked_ratio = checked_total / configured_total
+        self.assertGreaterEqual(success_ratio, 0.0)
+        self.assertLessEqual(success_ratio, 1.0)
+        self.assertGreaterEqual(checked_ratio, 0.0)
+        self.assertLessEqual(checked_ratio, 1.0)
+
+
+class TestPrometheusDocsAndAlertsContract(unittest.TestCase):
+    def test_readme_contains_v2_contract_and_dns_note(self):
+        readme = "/workspace/docs/prometheus/README.md"
+        with open(readme, encoding="utf-8") as f:
+            text = f.read()
+
+        # Schema + state model
+        self.assertIn("**Schema:** v2", text)
+        self.assertIn("aeo1_aroi_relay_state", text)
+        self.assertIn("configured_unchecked", text)
+        self.assertIn("configured_checked_invalid", text)
+        self.assertIn("configured_checked_valid", text)
+
+        # DNS enum completeness in docs
+        self.assertIn("`error`", text)
+        self.assertIn("`unknown`", text)
+        self.assertIn("`untested`", text)
+
+        # Migration/joins presence
+        self.assertIn("Side-by-side query mapping", text)
+        self.assertIn("Domain unchecked", text)
+        self.assertIn("Migration checklist", text)
+        self.assertIn("Operator Runbook", text)
+        self.assertIn("Aggregate-only dashboard mode", text)
+        self.assertIn("recording_rules.yml", text)
+
+    def test_alert_examples_use_v2_metrics_only(self):
+        alert_path = "/workspace/docs/prometheus/alerts_aroi.yml"
+        with open(alert_path, encoding="utf-8") as f:
+            alerts = f.read()
+
+        self.assertIn("Schema: v2", alerts)
+        self.assertIn("aeo1_aroi_relay_state", alerts)
+        self.assertIn("aeo1_aroi_relays_count", alerts)
+        self.assertNotIn("aeo1_aroi_valid", alerts)
+
+    def test_recording_rules_file_exists_and_uses_v2_states(self):
+        rules_path = "/workspace/docs/prometheus/recording_rules.yml"
+        self.assertTrue(os.path.exists(rules_path))
+        with open(rules_path, encoding="utf-8") as f:
+            text = f.read()
+        self.assertIn('state="configured_unchecked"', text)
+        self.assertIn('state="configured_checked_invalid"', text)
+        self.assertIn('state="configured_checked_valid"', text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/unit/test_prometheus_schema_contract.py
+++ b/tests/unit/test_prometheus_schema_contract.py
@@ -113,6 +113,22 @@ def _metric_names_from_content(content: str):
     return names
 
 
+def _label_key_sets_for_metric(content: str, metric_name: str):
+    label_sets = set()
+    pattern = re.compile(rf'^{re.escape(metric_name)}(?:\{{([^}}]*)\}})?\s', re.MULTILINE)
+    for labels_blob in pattern.findall(content):
+        if not labels_blob:
+            label_sets.add(frozenset())
+            continue
+        keys = []
+        for token in labels_blob.split(","):
+            key = token.split("=", 1)[0].strip()
+            if key:
+                keys.append(key)
+        label_sets.add(frozenset(keys))
+    return label_sets
+
+
 def _extract_non_comment_aeo1_tokens(path: str):
     with open(path, encoding="utf-8") as f:
         lines = f.readlines()
@@ -179,6 +195,27 @@ class TestPrometheusSchemaV2Contract(unittest.TestCase):
                 "configured_checked_valid",
             },
         )
+
+    def test_frozen_label_keys_for_core_metrics(self):
+        content = _render_metrics()
+        expected = {
+            "aeo1_build_info": {"schema", "generator"},
+            "aeo1_source_up": {"source"},
+            "aeo1_source_last_success_timestamp_seconds": {"source"},
+            "aeo1_exit_dns_errors_count": {"error_type"},
+            "aeo1_exit_dns_latency_ms_stat": {"stat"},
+            "aeo1_exit_dns_failed": {"fingerprint", "familyid", "status"},
+            "aeo1_exit_dns_latency_ms": {"fingerprint", "familyid"},
+            "aeo1_exit_dns_consecutive_failures": {"fingerprint", "familyid"},
+            "aeo1_exit_relay_info": {"fingerprint", "familyid", "nick", "verifiedaroi"},
+            "aeo1_aroi_relay_state": {"fingerprint", "familyid", "state"},
+            "aeo1_aroi_relays_count": {"state"},
+            "aeo1_aroi_relay_info": {"fingerprint", "familyid", "nick", "domain", "proof_type"},
+        }
+        for metric, expected_keys in expected.items():
+            found = _label_key_sets_for_metric(content, metric)
+            self.assertTrue(found, f"missing metric lines for {metric}")
+            self.assertEqual(found, {frozenset(expected_keys)}, f"unexpected labels for {metric}")
 
     def test_dns_status_enum_includes_untested(self):
         content = _render_metrics()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refactor Prometheus AROI metrics to schema v2 for clarity and robustness.

This PR resolves ambiguity in AROI relay validation by introducing a single state metric (`aeo1_aroi_relay_state`) and aggregate counts, explicitly distinguishing between configured, checked, and valid states. It also clarifies DNS health `untested` status, adds schema contract tests, and provides comprehensive migration documentation and recording rules.

<div><a href="https://cursor.com/agents/bc-da5410e0-2123-4bf1-9036-88a33f1354eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da5410e0-2123-4bf1-9036-88a33f1354eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prometheus metrics schema bumped to v2: added canonical AROI relay-state metrics (aeo1_aroi_relay_state, aeo1_aroi_relays_count) and removed legacy AROI aggregates; DNS health now includes "untested"; new alert for unchecked relays.

* **Documentation**
  * Updated Prometheus docs for v2, migration guide, alerts, recording rules, and added a production promotion checklist.

* **Tests**
  * New pytest suites, schema contract tests, recording-rule checks, and Prometheus test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->