### PR TITLE
AROI v3: dual-spec validation (ciissversion 2 + 3) with full operator-facing UI, hardening, and reviewer-priority follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,11 @@ Authenticated Relay Operator Identification system ranking verified operators:
 **Roles**: Exit/Guard Authority Champions, Exit/Guard Operators  
 **Reliability**: Reliability Masters (6mo), Legacy Titans (5yr), Bandwidth Served Masters (6mo), Bandwidth Served Legends (5yr)  
 **Diversity**: Most Diverse, Platform Diversity (non-Linux), Non-EU Leaders, Frontier Builders (rare countries)  
-**Infrastructure**: Network Veterans (tenure), IPv4/IPv6 Address Leaders, AROI Validation Champions
+**Infrastructure**: Network Veterans (tenure), IPv4/IPv6 Address Leaders, AROI Validation Champions (with v2/v3 split columns + tiered migration badges 🔍/🔁/🚀/🏆)
 
 - Paginated rankings (Top 10, 11-20, 21-25) with CSS-only navigation
 - Champion badge system for top performers
+- Dual CIISS spec support: tracks both ciissversion:2 (RSA-fingerprint proofs) and ciissversion:3 (ed25519 happy-family proofs) with operator-level migration tier classification
 
 </details>
 
@@ -131,7 +132,7 @@ Real-time metrics at `network-health.html`:
 - Relay counts by role (exit/guard/middle) with percentages
 - Bandwidth distribution (total, by role, mean/median per category)
 - Uptime statistics (1mo mean/median by role, multi-period series)
-- AROI validation status (validated/invalid/unconfigured counts)
+- AROI validation status (CIISS spec v2 + v3 dual-spec): per-version success rates, ciissversion adoption, peer-issue alerts (🚨 leaked-key incidents, ⏳ pending Onionoo refresh)
 - IPv4/IPv6 adoption rates
 - Flag distribution (Fast, Stable, HSDir, V2Dir, Authority)
 - New relay tracking (24h, 30d, 6mo, 1yr)

--- a/allium/lib/api_diagnostics.py
+++ b/allium/lib/api_diagnostics.py
@@ -332,6 +332,117 @@ def _format_timestamp(epoch_time):
     return time.strftime("%Y-%m-%d %H:%M:%S GMT", time.gmtime(epoch_time))
 
 
+# ============================================================================
+# AROI extended diagnostics — Python-side row formatters (item D)
+# ============================================================================
+# These helpers move presentation logic out of api-diagnostics.html so
+# the template just iterates ready-to-render lists. Each row is a small
+# dict with stable keys the template renders verbatim. Centralizing the
+# version-classification logic here also makes it test-able from Python
+# (no Jinja string-substring quirks).
+#
+# P3 (DRY): proof-type -> version classification lives in ONE place
+# now — aroi_validation.get_proof_type_version. Previously this module
+# carried a local _PROOF_TYPE_VERSION_MAP duplicating that knowledge,
+# which would silently drift if upstream ever added a new proof type.
+
+# Badge color cache for the version-classification result. Built once,
+# reused for every row.
+_VERSION_BADGE_COLOR = {
+    '3': '#007bff',     # blue — v3 (recommended)
+    '2': '#6c757d',     # grey — v2 (legacy)
+    'unknown': '#adb5bd',  # neutral grey
+}
+
+
+def _format_proof_type_rows(proof_types_summary):
+    """Pre-build the per-proof-type render rows for the diagnostics page.
+
+    Inputs:
+        proof_types_summary: dict mapping proof_type key -> {'valid': N,
+                             'total': M, ...} (from upstream stats_block)
+
+    Returns:
+        list of dicts sorted alphabetically by proof_type, EXCLUDING
+        the 'no_proof' bucket and any zero-total entries. Each row:
+            {
+                'proof_type': str,
+                'version': '2'|'3'|'unknown',
+                'valid': int,
+                'total': int,
+                'badge_color': hex string,
+            }
+    """
+    from .aroi_validation import get_proof_type_version
+    rows = []
+    if not isinstance(proof_types_summary, dict):
+        return rows
+    for pt, info in sorted(proof_types_summary.items()):
+        if pt == 'no_proof':
+            continue
+        if not isinstance(info, dict):
+            continue
+        total = info.get('total', 0) or 0
+        if total <= 0:
+            continue
+        # P3: single source of truth for proof_type -> version. Accepts
+        # both dashed and underscored proof_type keys; future proof
+        # types added upstream classify as 'unknown' until the central
+        # PROOF_TYPE_VERSION dict in aroi_validation.py is updated.
+        version = get_proof_type_version(pt)
+        rows.append({
+            'proof_type': pt,
+            'version': version,
+            'valid': info.get('valid', 0) or 0,
+            'total': total,
+            # Template uses badge_color directly — no inline ternaries.
+            'badge_color': _VERSION_BADGE_COLOR.get(version, _VERSION_BADGE_COLOR['unknown']),
+        })
+    return rows
+
+
+def _format_ciissversion_rows(ciissversion_declared):
+    """Pre-build the per-version row list for the 'ciissversion declared'
+    metric in the diagnostics page.
+
+    Output rows are sorted with 'none' last (the legacy template displays
+    none with no badge after the v1/v2/v3 badges).
+
+    Each row:
+        {
+            'key':         '1'|'2'|'3'|'none' (or whatever upstream returns),
+            'count':       int,
+            'is_none':     True/False (templates use this directly),
+            'badge_color': hex string,
+        }
+    """
+    rows = []
+    if not isinstance(ciissversion_declared, dict):
+        return rows
+    # P4 (future-proof sort): numeric versions ascend numerically (so a
+    # hypothetical v10 sorts AFTER v3, not after v1 like a plain string
+    # sort would). Non-numeric keys ('none', 'unknown', or whatever
+    # upstream invents next) sort last in alphabetical order.
+    def _sort_key(kv):
+        k = kv[0]
+        try:
+            return (0, int(k), '')   # numeric first, ascending by int value
+        except (TypeError, ValueError):
+            return (1, 0, k)         # non-numeric last, alpha by key
+    items = sorted(ciissversion_declared.items(), key=_sort_key)
+    for k, v in items:
+        is_none = (k == 'none')
+        rows.append({
+            'key': k,
+            'count': v,
+            'is_none': is_none,
+            # v3 is highlighted (blue, recommended); everything else
+            # (v1, v2, unknown future versions, 'none') uses neutral grey.
+            'badge_color': '#007bff' if k == '3' else '#6c757d',
+        })
+    return rows
+
+
 def _get_api_data(relay_set, metadata):
     """
     Get the raw API data dict from relay_set using metadata-driven lookup.
@@ -474,6 +585,46 @@ def collect_api_diagnostics(relay_set, args):
         item_count = _get_item_count(relay_set, metadata) if enabled else None
         extra_info = _get_extra_info(relay_set, metadata) if enabled else None
 
+        # B6: AROI-specific extended diagnostics — schema version, version
+        # distribution, top error_category counts. Helps non-developer
+        # operators diagnose upstream regressions.
+        aroi_extras = {}
+        if api_name == "aroi_validation" and enabled:
+            aroi_data = _get_api_data(relay_set, metadata)
+            if aroi_data and isinstance(aroi_data, dict):
+                meta_block = aroi_data.get("metadata", {}) or {}
+                stats_block = aroi_data.get("statistics", {}) or {}
+                aroi_extras["schema_version"] = meta_block.get("aroivalidator_schema_version")
+                # Item D (template-side formatting -> Python helpers):
+                # Pre-format the version-declared block + proof-types
+                # block so the template just iterates ready-to-render
+                # lists instead of doing dictsort + per-row
+                # 'v2/v3' string-classification logic in Jinja.
+                aroi_extras["ciissversion_declared"] = stats_block.get("ciissversion_declared", {}) or {}
+                aroi_extras["ciissversion_declared_rows"] = _format_ciissversion_rows(
+                    aroi_extras["ciissversion_declared"]
+                )
+                aroi_extras["proof_types_summary"] = stats_block.get("proof_types", {}) or {}
+                aroi_extras["proof_types_rows"] = _format_proof_type_rows(
+                    aroi_extras["proof_types_summary"]
+                )
+                # Top error_category counts (already aggregated upstream).
+                v3_cats = stats_block.get("v3_failure_categories", {}) or {}
+                aroi_extras["top_error_categories"] = sorted(
+                    [(k, v) for k, v in v3_cats.items() if v > 0],
+                    key=lambda x: -x[1],
+                )[:5]
+                # B6 (final): warning feed from this build's aroi_validation
+                # module. Plan called for "Last warning timestamp for:
+                # unknown error_category, unknown proof_type, schema version
+                # mismatch" — surfaced here as a structured list so the
+                # template can render with timestamps.
+                try:
+                    from .aroi_validation import get_aroi_warnings_log
+                    aroi_extras["warnings"] = get_aroi_warnings_log()
+                except Exception:
+                    aroi_extras["warnings"] = []
+
         api_diagnostics.append({
             "name": api_name,
             "display_name": metadata["display_name"],
@@ -499,6 +650,8 @@ def collect_api_diagnostics(relay_set, args):
             "extra_info": extra_info,
             "enabled": enabled,
             "affected_sections": metadata["affected_sections"],
+            # B6: extended fields populated only for AROI API
+            "aroi_extras": aroi_extras,
         })
 
     # Build section dependencies with freshness propagation

--- a/allium/lib/aroi_validation.py
+++ b/allium/lib/aroi_validation.py
@@ -544,6 +544,20 @@ def _check_aroi_fields(contact: str) -> Dict:
     # the unsupported value once (for A.8 observability) and leave
     # version=None so the relay gets bucketed as "no AROI" until the
     # operator fixes the contact string.
+    # Reviewer-flagged: previously when the FIRST declared token was
+    # unsupported (e.g. 'ciissversion:99'), version was set to None and
+    # downstream _categorize_by_missing_fields() bucketed the relay as
+    # "missing field". That hid the operator-actionable distinction
+    # between "didn't declare any version" and "declared an unsupported
+    # version". Fix: keep the raw first token in `version` even when
+    # unsupported, while STILL calling _record_warning so the
+    # build-time observability log captures the unknown value. The
+    # existing has_ciissversion / complete computation below uses
+    # bool(version), so the relay now appears as "version present"
+    # in the aroi_fields dict — the explicit-but-unsupported case
+    # gets routed accordingly by the caller (typically lands in the
+    # version_proof_mismatch bucket because PROOF_TYPE_VERSION can't
+    # match the unsupported value).
     version = None
     any_match = _CIISS_ANY_VERSION_RE.search(contact)
     if any_match:
@@ -551,6 +565,8 @@ def _check_aroi_fields(contact: str) -> Dict:
         if first_v in SUPPORTED_CIISSVERSIONS:
             version = first_v
         else:
+            # Preserve the raw unsupported token (don't discard it).
+            version = first_v
             if first_v not in _warned_unsupported_ciissversion:
                 _warned_unsupported_ciissversion.add(first_v)
                 logger.info(
@@ -559,7 +575,8 @@ def _check_aroi_fields(contact: str) -> Dict:
                 )
                 _record_warning('unsupported_ciissversion', first_v)
 
-    # Same first-wins logic for proof_type.
+    # Same first-wins logic for proof_type — same preservation
+    # treatment for unsupported proof types.
     proof_type = None
     any_match = _PROOF_ANY_TYPE_RE.search(contact)
     if any_match:
@@ -567,6 +584,8 @@ def _check_aroi_fields(contact: str) -> Dict:
         if first_pt in ALL_PROOF_TYPES:
             proof_type = first_pt
         else:
+            # Preserve the raw unsupported proof type (don't discard).
+            proof_type = first_pt
             if first_pt not in _warned_unsupported_proof_type:
                 _warned_unsupported_proof_type.add(first_pt)
                 logger.warning(

--- a/allium/lib/aroi_validation.py
+++ b/allium/lib/aroi_validation.py
@@ -368,17 +368,22 @@ SHARED_ERROR_CATEGORIES = frozenset({
 })
 
 # v3-only error categories (no v2 analog because v2 has no family_ids /
-# secret_family_key concepts).
+# secret_family_key / ciissversion-aware concepts).
+#
+# Reviewer-flagged correction: dns_txt_missing / dns_content_mismatch /
+# uri_file_missing / uri_content_mismatch were previously listed here but
+# they fire for BOTH v2 (RSA-fingerprint proof file/TXT) and v3 (ed25519
+# happy-family proof file/TXT). Including them in v3-only caused
+# _build_error_rollup() to mis-bucket every v2 proof-file failure as
+# v3-only. Removed; those four categories now flow through
+# SHARED_ERROR_CATEGORIES handling and are counted correctly in both
+# v2 and v3 rollups.
 V3_ONLY_ERROR_CATEGORIES = frozenset({
-    'missing_family_ids',
-    'dns_txt_missing',
-    'dns_content_mismatch',
-    'uri_file_missing',
-    'uri_content_mismatch',
-    'wrong_proof_type_rsa',
-    'missing_proof_field',
-    'secret_key_leaked',
-    'ciissversion_unsupported',
+    'missing_family_ids',       # only v3: there are no family_ids in v2
+    'wrong_proof_type_rsa',     # only v3: a v3 contact accidentally declares uri-rsa
+    'missing_proof_field',      # only v3: v3 has the proof: field; v2 doesn't
+    'secret_key_leaked',        # only v3: v2 has no secret_family_key concept
+    'ciissversion_unsupported', # only v3: v2 doesn't carry ciissversion at all
 })
 
 
@@ -1059,6 +1064,18 @@ def calculate_aroi_validation_metrics(relays: List[Dict], validation_data: Optio
         metrics['relays_no_contact_percentage'] = _calc_percentage(metrics['relays_no_contact'], total_relays)
         metrics['relays_no_aroi_info_percentage'] = _calc_percentage(metrics['relays_no_aroi_info'], total_relays)
         metrics['relays_missing_two_aroi_percentage'] = _calc_percentage(metrics['relays_missing_two_aroi'], total_relays)
+        # Reviewer-flagged: previously these two newly-added counters
+        # were incremented in the early-return fallback branch but
+        # their *_percentage companions were never computed. Compute
+        # them here alongside the rest so downstream code (templates,
+        # network-health dashboard, prometheus) can rely on the
+        # _percentage field always being present.
+        metrics['relays_version_proof_mismatch_percentage'] = _calc_percentage(
+            metrics['relays_version_proof_mismatch'], total_relays
+        )
+        metrics['relays_v3_informational_percentage'] = _calc_percentage(
+            metrics['relays_v3_informational'], total_relays
+        )
         
         # Add operator-level metrics even without validation data
         if calculate_operator_metrics:

--- a/allium/lib/aroi_validation.py
+++ b/allium/lib/aroi_validation.py
@@ -1684,6 +1684,13 @@ def get_contact_validation_status(relays: List[Dict], validation_data: Optional[
                 # validate against.
                 summary['not_configured_count'] += 1
                 summary['not_configured_no_aroi_info_count'] += 1
+                # Reviewer-flagged: also bump the dedicated counter so
+                # the validation_summary's incomplete_v3_informational_count
+                # field (initialised to 0 at construction time) reflects
+                # the actual number of v3-informational-only relays.
+                # Without this, the field was always 0 even when v3
+                # informational relays existed.
+                summary['incomplete_v3_informational_count'] += 1
                 relay_info['missing'] = (
                     "ciissversion:3 with no url (spec-legal informational only)"
                 )

--- a/allium/lib/aroi_validation.py
+++ b/allium/lib/aroi_validation.py
@@ -7,13 +7,401 @@ Provides validation metrics for network health dashboard
 
 Uses existing infrastructure from workers.py and file_io_utils.py
 Functional approach for simplicity and maintainability
+
+Supports both CIISS ContactInfo specification version 2 (RSA-fingerprint
+proofs: dns-rsa, uri-rsa) and version 3 (ed25519 family-ID proofs:
+dns-familyid-ed25519, uri-familyid-ed25519). Spec:
+https://nusenu.github.io/ContactInfo-Information-Sharing-Specification/
 """
 
 import json
+import logging
 import re
 from collections import defaultdict
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Tuple
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# CIISS spec & validator API constants (single source of truth)
+# =============================================================================
+
+# CIISS ContactInfo specification versions Allium recognises.
+# v1 is legacy (silently ignored on parse); v2 and v3 are actively supported.
+SUPPORTED_CIISSVERSIONS = ("2", "3")
+
+# Proof types per spec version. The aroivalidator latest.json reports
+# proof_types with underscored keys (dns-rsa -> dns_rsa); use
+# PROOF_TYPE_STAT_KEYS when reading those statistics.
+V2_PROOF_TYPES = ("dns-rsa", "uri-rsa")
+V3_PROOF_TYPES = ("dns-familyid-ed25519", "uri-familyid-ed25519")
+ALL_PROOF_TYPES = V2_PROOF_TYPES + V3_PROOF_TYPES
+PROOF_TYPE_STAT_KEYS = tuple(p.replace('-', '_') for p in ALL_PROOF_TYPES)
+
+# Map proof type -> ciissversion that declares it. Used to detect operator
+# copy-paste mistakes during migration (e.g. 'ciissversion:2 proof:uri-familyid-ed25519').
+#
+# Two key forms are populated so callers can look up by either:
+#   - dashed form ('dns-rsa')      — used by relay ContactInfo strings
+#   - underscored form ('dns_rsa') — used by upstream stats_block keys
+# This is the SINGLE source of truth (P3 from reviewer feedback): all
+# downstream code (api_diagnostics row formatters, validation cascade,
+# template-side classification) must use this dict instead of redefining
+# the mapping locally, or proof-type/version labels can drift over time.
+PROOF_TYPE_VERSION = {
+    **{p: "2" for p in V2_PROOF_TYPES},
+    **{p: "3" for p in V3_PROOF_TYPES},
+    # Also expose underscored variants — same versions.
+    **{p.replace('-', '_'): "2" for p in V2_PROOF_TYPES},
+    **{p.replace('-', '_'): "3" for p in V3_PROOF_TYPES},
+}
+
+
+def get_proof_type_version(proof_type):
+    """Resolve a proof_type string (in either dashed or underscored form)
+    to its CIISS spec version ('2' or '3'). Returns 'unknown' for any
+    proof_type not in PROOF_TYPE_VERSION.
+
+    Preferred over inline 'familyid in pt'/'rsa in pt' substring checks
+    because it gracefully handles future proof types added to upstream
+    (which would silently classify as 'unknown' instead of being
+    miscategorized as v2 because they happen to contain 'rsa' or as v3
+    because they happen to contain 'family').
+    """
+    if not proof_type:
+        return 'unknown'
+    return PROOF_TYPE_VERSION.get(proof_type, 'unknown')
+
+# Schemas of aroivalidator latest.json that this build was tested against.
+# When upstream emits a schema number outside this tuple, A.1 logs a
+# one-time warning. Schema field appears in metadata.aroivalidator_schema_version.
+AROIVALIDATOR_TESTED_SCHEMAS = (1, 2)
+
+# v3 migration tiers (operator-level): inclusive lower bounds.
+# Tuned to recognise effort at every stage of migration so an operator
+# with 1 v3 relay sees recognition AND a 100%-migrated operator gets a
+# distinct top tier.
+V3_TIER_EXPLORER = 0.001    # >= 1 v3 relay (almost-zero floor)
+V3_TIER_MIGRATING = 0.25    # >= 25% of relays on v3
+V3_TIER_MOSTLY = 0.75       # >= 75% of relays on v3
+V3_TIER_COMPLETE = 1.0      # 100% of relays on v3
+# Threshold used by binary surfaces (listing icons, search-index v3p
+# emission). Below this, no marker; at/above it, an operator is "migrating
+# enough" to be highlighted. Mirrors V3_TIER_MIGRATING by intent.
+V3_LISTING_ICON_THRESHOLD = V3_TIER_MIGRATING
+
+
+# Module-state for one-time schema warning logging.
+_warned_schema_versions = set()
+
+
+def check_schema_version(validation_data: Optional[Dict],
+                         progress_logger=None) -> Optional[int]:
+    """Inspect aroivalidator latest.json schema version and warn on unknown.
+
+    Per the upstream contract, ``metadata.aroivalidator_schema_version`` is
+    a small integer that bumps when the JSON shape changes in a way
+    consumers should notice. We log a single warning per unfamiliar schema
+    so we know to update Allium when upstream evolves, but we do NOT
+    reject the data — degrade gracefully.
+
+    Args:
+        validation_data: Parsed latest.json dict (or None when API down).
+        progress_logger: Optional logger callable; falls back to module
+            logger.warning when absent so warnings surface in build logs.
+
+    Returns:
+        The detected schema version as an int, or None when unavailable.
+    """
+    if not validation_data or not isinstance(validation_data, dict):
+        return None
+    metadata = validation_data.get('metadata') or {}
+    version = metadata.get('aroivalidator_schema_version')
+    if version is None:
+        return None
+    try:
+        version_int = int(version)
+    except (ValueError, TypeError):
+        return None
+    if version_int not in AROIVALIDATOR_TESTED_SCHEMAS and version_int not in _warned_schema_versions:
+        _warned_schema_versions.add(version_int)
+        msg = (
+            f"⚠️  AROI validator schema version {version_int} is newer than "
+            f"tested (max: {max(AROIVALIDATOR_TESTED_SCHEMAS)}). Some new "
+            f"fields may be ignored. Update Allium to consume them."
+        )
+        if progress_logger:
+            progress_logger(msg)
+        else:
+            logger.warning(msg)
+        _record_warning('schema_mismatch', version_int)
+    return version_int
+
+
+# =============================================================================
+# V3_CATEGORY_LABELS: error_category -> human title + pasteable-example hint
+# =============================================================================
+# Mirrored from the upstream aroivalidator's CATEGORY_INFO dict. Each entry:
+#   - 'title': short human description used in tooltips and lists
+#   - 'example': a single pasteable line the operator can literally use to fix
+#                the issue (NO prose, NO step-by-step instructions)
+#   - 'spec_link': optional anchor in the AROI spec for those wanting detail
+#
+# When upstream adds a new error_category, A.8 emits a one-time warning
+# until this dict is updated.
+# =============================================================================
+
+def _is_rsa_proof(proof_type):
+    """Return True if proof_type identifies a CIISS-v2 (RSA-fingerprint)
+    proof family. Helper for picking version-appropriate pasteable
+    examples / file paths."""
+    if not proof_type:
+        return False
+    pt = proof_type.lower()
+    return pt in ('dns-rsa', 'uri-rsa') or (
+        'rsa' in pt and 'familyid' not in pt and 'ed25519' not in pt
+    )
+
+
+def _resolve_example_for_proof(label, proof_type):
+    """Pick the version-appropriate example from a V3_CATEGORY_LABELS entry.
+
+    Categories like uri_file_missing / uri_content_mismatch / dns_txt_missing
+    can legitimately fire for BOTH v2 (RSA-fingerprint) and v3 (ed25519
+    happy-family) relays, but the file paths and TXT-record formats are
+    different per spec:
+
+      v2: /.well-known/tor-relay/rsa-fingerprint.txt
+          DNS TXT: "we-run-this-tor-relay <fingerprint>"
+      v3: /.well-known/tor-relay/ed25519-family-id.txt
+          DNS TXT: "we-run-this-tor-ed25519-family-id.<domain>" record
+
+    To avoid showing v3-flavored examples on a v2 relay (the user-reported
+    bug: "URI-RSA fingerprint not found" rendered the ed25519 path), each
+    label may declare an alternate 'example_v2' field. When the relay's
+    proof_type is RSA, we prefer 'example_v2' if present; otherwise we
+    fall back to 'example' (the v3 default) so existing v3-only categories
+    keep working.
+    """
+    if not isinstance(label, dict):
+        return None
+    if _is_rsa_proof(proof_type):
+        return label.get('example_v2') or label.get('example')
+    return label.get('example')
+
+
+def _render_pasteable_example(example, fingerprint=None, aroi_domain=None):
+    """Substitute placeholders in a V3_CATEGORY_LABELS example so the line is
+    literally pasteable for THIS relay/operator.
+
+    Replacements (case-sensitive, single-pass):
+      <fingerprint>   -> the relay's actual 40-char Onionoo fingerprint
+      <your-domain>   -> the operator's AROI domain (e.g. 'foo.bar')
+      foo.bar         -> the operator's AROI domain (used in shape examples)
+
+    The 'foo.bar' substitution is applied last so it doesn't clobber
+    earlier '<your-domain>' tokens. Keep the substitution conservative —
+    we only touch tokens we know exist in V3_CATEGORY_LABELS examples;
+    we do NOT try to mutate prose hints from upstream.
+    """
+    if not example:
+        return example
+    rendered = example
+    if fingerprint:
+        rendered = rendered.replace('<fingerprint>', fingerprint)
+    if aroi_domain and aroi_domain != 'none':
+        rendered = rendered.replace('<your-domain>', aroi_domain)
+        # 'foo.bar' is the placeholder used in shape examples (e.g.
+        # 'ContactInfo ... ciissversion:3 url:foo.bar ...'). Only
+        # substitute when the example contains that exact token to
+        # avoid surprising matches in prose.
+        if 'foo.bar' in rendered:
+            rendered = rendered.replace('foo.bar', aroi_domain)
+    return rendered
+
+
+V3_CATEGORY_LABELS: Dict[str, Dict[str, Optional[str]]] = {
+    'missing_family_ids': {
+        'title': 'Onionoo not yet refreshed',
+        # Pasteable diagnostic: operator can verify state without waiting blind.
+        'example': ('curl "https://onionoo.torproject.org/details?lookup=<fingerprint>'
+                    '&fields=family_ids" | jq   # should show your '
+                    '.public_family_id within 24h of restarting Tor'),
+        'spec_link': None,
+    },
+    'dns_txt_missing': {
+        'title': 'DNS TXT record missing',
+        # v3 (ed25519 happy-family) — DNS subdomain pattern.
+        'example': ('we-run-this-tor-ed25519-family-id.<your-domain> '
+                    'TXT "<contents of .public_family_id>"'),
+        # v2 (RSA-fingerprint) — TXT record at the bare domain. Per
+        # CIISS v2 the record value is "we-run-this-tor-relay <fp>".
+        'example_v2': ('<your-domain> TXT "we-run-this-tor-relay <fingerprint>"   '
+                       '# CIISS v2 (RSA-fingerprint proof)'),
+        'spec_link': None,
+    },
+    'dns_content_mismatch': {
+        'title': 'DNS TXT does not match family_id',
+        'example': ('# TXT must contain .public_family_id contents (43 chars, '
+                    'case-sensitive). Never paste .secret_family_key.'),
+        'example_v2': ('# v2 TXT record must contain '
+                       '"we-run-this-tor-relay <fingerprint>" '
+                       'for THIS relay (40-char fingerprint, uppercase hex)'),
+        'spec_link': None,
+    },
+    'uri_file_missing': {
+        'title': 'Proof file missing (HTTP 404)',
+        # v3 file: ed25519-family-id.txt (43-char family_ids, one/line)
+        'example': ('curl https://<your-domain>/.well-known/tor-relay/'
+                    'ed25519-family-id.txt   # must return 200'),
+        # v2 file: rsa-fingerprint.txt (40-char hex fingerprints, one/line)
+        'example_v2': ('curl https://<your-domain>/.well-known/tor-relay/'
+                       'rsa-fingerprint.txt   # must return 200'),
+        'spec_link': None,
+    },
+    'uri_content_mismatch': {
+        'title': 'Proof file does not contain fingerprint',
+        # v3 file: ed25519-family-id.txt (43-char family_id strings)
+        'example': ('# /.well-known/tor-relay/ed25519-family-id.txt must list '
+                    "this relay's 43-char family_id (one per line)"),
+        # v2 file: rsa-fingerprint.txt (40-char RSA fingerprints).
+        # User-reported bug: "URI-RSA: Fingerprint not found at <domain>"
+        # was rendering the ed25519 path. Now correctly points at
+        # rsa-fingerprint.txt with the actual relay's fingerprint
+        # substituted in by _render_pasteable_example.
+        'example_v2': ('curl https://<your-domain>/.well-known/tor-relay/'
+                       'rsa-fingerprint.txt   '
+                       "# must contain this relay's 40-char fingerprint "
+                       "<fingerprint>"),
+        'spec_link': None,
+    },
+    'wrong_proof_type_rsa': {
+        'title': 'v3 contact declares v2 proof type',
+        'example': ('ContactInfo ... ciissversion:3 url:foo.bar '
+                    'proof:uri-familyid-ed25519'),
+        'spec_link': None,
+    },
+    'missing_proof_field': {
+        'title': 'v3 with url: but no proof:',
+        'example': ('ContactInfo ... ciissversion:3 url:foo.bar '
+                    'proof:dns-familyid-ed25519'),
+        'spec_link': None,
+    },
+    'invalid_url': {
+        'title': 'url field is not a parseable domain',
+        'example': ('ContactInfo ... url:foo.bar   '
+                    '# plain hostname or https://foo.bar'),
+        'spec_link': None,
+    },
+    'unsafe_target': {
+        'title': 'url points at private/loopback IP',
+        # Pasteable: shows the right shape (public domain) and explicitly
+        # forbids IP-literal/loopback/RFC1918 targets.
+        'example': ('ContactInfo ... url:your-public-domain.example.com   '
+                    '# NOT 127.0.0.1, NOT 10.0.0.1, NOT IP literals'),
+        'spec_link': None,
+    },
+    'redirect_disallowed': {
+        'title': 'Proof URI returns HTTP redirect (3xx)',
+        # v3: serve ed25519-family-id.txt directly
+        'example': ('curl -sI https://<your-domain>/.well-known/tor-relay/'
+                    'ed25519-family-id.txt | head -1   '
+                    '# must be HTTP/2 200 (no 301/302/308 redirect)'),
+        # v2: serve rsa-fingerprint.txt directly
+        'example_v2': ('curl -sI https://<your-domain>/.well-known/tor-relay/'
+                       'rsa-fingerprint.txt | head -1   '
+                       '# must be HTTP/2 200 (no 301/302/308 redirect)'),
+        'spec_link': None,
+    },
+    'secret_key_leaked': {
+        'title': '🚨 SECURITY: .secret_family_key published',
+        'example': ('tor --keygen-family <newfile>   '
+                    '# rotate IMMEDIATELY, then publish new .public_family_id'),
+        'spec_link': None,
+    },
+    'ciissversion_unsupported': {
+        'title': 'ciissversion not 2 or 3',
+        'example': 'ContactInfo ... ciissversion:3 ...',
+        'spec_link': None,
+    },
+    'transport_error': {
+        'title': 'Network/TLS/HTTP error',
+        # Pasteable diagnostic: operator can reproduce the failure locally
+        # to see if it's an SSL cert, DNS, firewall, or connectivity issue.
+        # v3 file path:
+        'example': ('curl -v https://<your-domain>/.well-known/tor-relay/'
+                    'ed25519-family-id.txt   # check for SSL/timeout/refused'),
+        # v2 (URI-RSA) file path: rsa-fingerprint.txt
+        'example_v2': ('curl -v https://<your-domain>/.well-known/tor-relay/'
+                       'rsa-fingerprint.txt   '
+                       '# check for SSL/timeout/refused/HTTP errors'),
+        'spec_link': None,
+    },
+    # Allium-side categories (not from upstream) — used by Part B1 to render
+    # the v2/v3 mismatch and v3-informational cases the upstream validator
+    # would not see (these are pre-validator parse-time issues).
+    'version_proof_mismatch': {
+        'title': 'ciissversion and proof type disagree',
+        'example': ('# pick consistent pair: ciissversion:3 + '
+                    'proof:uri-familyid-ed25519, OR ciissversion:2 + '
+                    'proof:uri-rsa'),
+        'spec_link': None,
+    },
+    'v3_informational': {
+        'title': 'ciissversion:3 informational (no url)',
+        'example': ('# spec-legal: proof is required ONLY when url: is set. '
+                    'No action needed unless you want a domain-bound AROI.'),
+        'spec_link': None,
+    },
+}
+
+# Categories that ALWAYS apply to both v2 and v3 (same root cause, same fix
+# copy) -- consolidated by A.6's _build_error_rollup. Anything not listed
+# here is treated as version-specific.
+SHARED_ERROR_CATEGORIES = frozenset({
+    'transport_error',
+    'redirect_disallowed',
+    'unsafe_target',
+    'invalid_url',
+})
+
+# v3-only error categories (no v2 analog because v2 has no family_ids /
+# secret_family_key concepts).
+V3_ONLY_ERROR_CATEGORIES = frozenset({
+    'missing_family_ids',
+    'dns_txt_missing',
+    'dns_content_mismatch',
+    'uri_file_missing',
+    'uri_content_mismatch',
+    'wrong_proof_type_rsa',
+    'missing_proof_field',
+    'secret_key_leaked',
+    'ciissversion_unsupported',
+})
+
+
+def classify_v3_tier(v3_relay_count: int, total_relay_count: int) -> str:
+    """Classify an operator into a v3 migration tier.
+
+    Returns one of: 'none', 'explorer', 'migrating', 'mostly', 'complete'.
+
+    Single source of truth consumed by every surface (contact pages,
+    leaderboards, aggregate listings, search index, Prometheus). When
+    tweaking thresholds, change them in V3_TIER_* constants only.
+    """
+    if total_relay_count <= 0 or v3_relay_count <= 0:
+        return 'none'
+    pct = v3_relay_count / total_relay_count
+    if pct >= V3_TIER_COMPLETE:
+        return 'complete'
+    if pct >= V3_TIER_MOSTLY:
+        return 'mostly'
+    if pct >= V3_TIER_MIGRATING:
+        return 'migrating'
+    # >= 1 v3 relay but < 25%
+    return 'explorer'
 
 
 def _validate_structure(data):
@@ -29,65 +417,246 @@ def _calc_percentage(count: int, total: int) -> float:
     return (count / total * 100) if total > 0 else 0.0
 
 
-def _check_aroi_fields(contact: str) -> Dict[str, bool]:
+# Pre-compiled regexes for AROI-field detection. Module-level so v2- and
+# v3-aware parsers across the codebase share identical semantics.
+_CIISS_VERSION_RE = re.compile(
+    r'\bciissversion:(' + '|'.join(SUPPORTED_CIISSVERSIONS) + r')\b',
+    re.IGNORECASE,
+)
+# CIISS legacy: log when a v1 relay is observed (intentional ignore, not a crash).
+_CIISS_ANY_VERSION_RE = re.compile(r'\bciissversion:(\d+)\b', re.IGNORECASE)
+_PROOF_TYPE_RE = re.compile(
+    r'\bproof:(' + '|'.join(re.escape(p) for p in ALL_PROOF_TYPES) + r')\b',
+    re.IGNORECASE,
+)
+_PROOF_ANY_TYPE_RE = re.compile(r'\bproof:([A-Za-z0-9-]+)\b', re.IGNORECASE)
+_URL_FIELD_RE = re.compile(r'\burl:(?:https?://)?([^,\s]+)', re.IGNORECASE)
+
+# Module-state for one-time warning logs (deduplicates per build).
+_warned_unsupported_ciissversion = set()
+_warned_unsupported_proof_type = set()
+
+# Module-state for B6: track warnings fired during the current build so the
+# API diagnostics page can surface them as a "last warning" feed. Each entry
+# is a dict {kind, value, timestamp_iso, count} where:
+#   kind:    'unsupported_ciissversion' | 'unsupported_proof_type'
+#            | 'unknown_error_category' | 'schema_mismatch'
+#   value:   the offending value (e.g. '99', 'foo-proof', 'bar_category', '5')
+#   timestamp_iso: ISO timestamp of the FIRST occurrence this build
+#   count:   number of times observed this build
+# Captured in a list rather than dict-of-sets so the diagnostics
+# template can iterate without sorting.
+_aroi_warnings_log = []
+
+
+def _record_warning(kind, value):
+    """B6: append to _aroi_warnings_log so api-diagnostics can render
+    the per-build warning feed. Idempotent on (kind, value).
+
+    Uses datetime.now(timezone.utc) instead of the deprecated
+    datetime.utcnow() (deprecated in Python 3.12+).
     """
-    Check which AROI fields are present in contact string.
-    
-    Returns:
-        Dict with keys: 'has_ciissversion', 'has_proof', 'has_url', 'complete'
+    from datetime import datetime as _dt, timezone as _tz
+    for entry in _aroi_warnings_log:
+        if entry['kind'] == kind and entry['value'] == value:
+            entry['count'] += 1
+            return
+    # ISO format with Z suffix for UTC. timezone-aware now() ensures
+    # forward-compatibility with Python 3.12+ where utcnow() is deprecated.
+    _now = _dt.now(_tz.utc).replace(tzinfo=None).isoformat(timespec='seconds')
+    _aroi_warnings_log.append({
+        'kind': kind,
+        'value': str(value),
+        'timestamp_iso': _now + 'Z',
+        'count': 1,
+    })
+
+
+def get_aroi_warnings_log():
+    """B6: snapshot of warnings fired during the current build for the
+    api-diagnostics template. Returns a list of dicts, sorted by
+    timestamp (most recent last)."""
+    return list(_aroi_warnings_log)
+
+
+def reset_aroi_warnings_log():
+    """Test-only helper to clear the warning log between assertions."""
+    _aroi_warnings_log.clear()
+    _warned_unsupported_ciissversion.clear()
+    _warned_unsupported_proof_type.clear()
+    _warned_unknown_error_categories.clear()
+    _warned_schema_versions.clear()
+
+
+def _check_aroi_fields(contact: str) -> Dict:
     """
-    import re
-    
+    Check which AROI fields are present in a relay's contact string.
+
+    Recognises both CIISS spec v2 (ciissversion:2 + dns-rsa/uri-rsa) and
+    CIISS spec v3 (ciissversion:3 + dns-familyid-ed25519 / uri-familyid-ed25519).
+
+    Returns a dict with these keys (all boolean unless noted):
+      - has_ciissversion: True if a SUPPORTED ciissversion (2 or 3) is declared
+      - has_proof: True if a SUPPORTED proof type is declared
+      - has_url: True if a url:... field is present
+      - complete: True iff has_ciissversion AND has_proof AND has_url
+        (the historical "fully-configured AROI" predicate; preserved for
+        Prometheus + downstream consumers)
+      - version: '2' or '3' if a supported version is declared; else None
+      - proof_type: the lowercased proof type string; else None
+      - is_v3_no_proof_compliant: True if ciissversion:3 declared without
+        url: (CIISS v3 spec: proof is required only when url is set; an
+        operator may declare ciissversion:3 with informational fields
+        alone — that's spec-compliant, not "incomplete")
+      - version_proof_mismatch: True if a v2-version declares a v3 proof
+        type or vice versa (operator copy-paste error during migration)
+    """
     if not contact:
-        return {'has_ciissversion': False, 'has_proof': False, 'has_url': False, 'complete': False}
-    
-    has_ciissversion = bool(re.search(r'\bciissversion:2\b', contact, re.IGNORECASE))
-    has_proof = bool(re.search(r'\bproof:(dns-rsa|uri-rsa)\b', contact, re.IGNORECASE))
-    has_url = bool(re.search(r'\burl:(?:https?://)?([^,\s]+)', contact, re.IGNORECASE))
-    
+        return {
+            'has_ciissversion': False,
+            'has_proof': False,
+            'has_url': False,
+            'complete': False,
+            'version': None,
+            'proof_type': None,
+            'is_v3_no_proof_compliant': False,
+            'version_proof_mismatch': False,
+        }
+
+    # Supported version match. CIISS spec: keys MUST appear only once;
+    # re.search returns the FIRST match — matches upstream validator's
+    # "first wins" rule for duplicate fields.
+    ciiss_match = _CIISS_VERSION_RE.search(contact)
+    version = ciiss_match.group(1) if ciiss_match else None
+
+    # Detect (and remember) any unsupported ciissversion for one-time
+    # logging in A.8. We deliberately do NOT crash on these — older v1
+    # contacts and any future v4+ should be silently bucketed as
+    # "no AROI" until we explicitly support them.
+    if not version:
+        any_match = _CIISS_ANY_VERSION_RE.search(contact)
+        if any_match:
+            v = any_match.group(1)
+            if v not in SUPPORTED_CIISSVERSIONS and v not in _warned_unsupported_ciissversion:
+                _warned_unsupported_ciissversion.add(v)
+                logger.info(
+                    "AROI: encountered unsupported ciissversion:%s — ignoring "
+                    "(supported: %s)", v, ','.join(SUPPORTED_CIISSVERSIONS)
+                )
+                _record_warning('unsupported_ciissversion', v)
+
+    # Supported proof type match. Same first-wins semantics.
+    proof_match = _PROOF_TYPE_RE.search(contact)
+    proof_type = proof_match.group(1).lower() if proof_match else None
+
+    if not proof_type:
+        any_match = _PROOF_ANY_TYPE_RE.search(contact)
+        if any_match:
+            pt = any_match.group(1).lower()
+            if pt not in ALL_PROOF_TYPES and pt not in _warned_unsupported_proof_type:
+                _warned_unsupported_proof_type.add(pt)
+                logger.warning(
+                    "AROI: unknown proof type '%s' — update ALL_PROOF_TYPES "
+                    "in aroi_validation.py to recognise new proof types", pt
+                )
+                _record_warning('unsupported_proof_type', pt)
+
+    has_url = bool(_URL_FIELD_RE.search(contact))
+
+    # Detect version/proof mismatch (e.g. ciissversion:2 with
+    # proof:uri-familyid-ed25519). This is a real-world copy-paste error
+    # during migration and we want to surface it as "incomplete /
+    # version-proof mismatch" rather than silently accepting it.
+    version_proof_mismatch = False
+    if version and proof_type:
+        expected_version = PROOF_TYPE_VERSION.get(proof_type)
+        if expected_version and expected_version != version:
+            version_proof_mismatch = True
+
+    has_ciissversion = bool(version)
+    has_proof = bool(proof_type)
+    # 'complete' AROI semantics: all 3 fields present, version+proof
+    # match (mismatched pairs DO NOT count as complete).
+    complete = (has_ciissversion and has_proof and has_url
+                and not version_proof_mismatch)
+    is_v3_no_proof_compliant = (version == '3' and not has_url)
+
     return {
         'has_ciissversion': has_ciissversion,
         'has_proof': has_proof,
         'has_url': has_url,
-        'complete': has_ciissversion and has_proof and has_url
+        'complete': complete,
+        'version': version,
+        'proof_type': proof_type,
+        'is_v3_no_proof_compliant': is_v3_no_proof_compliant,
+        'version_proof_mismatch': version_proof_mismatch,
     }
 
 
-def _categorize_by_missing_fields(aroi_fields: Dict[str, bool], has_contact: bool) -> str:
+def _categorize_by_missing_fields(aroi_fields: Dict, has_contact: bool) -> str:
     """
-    Helper function to categorize relay based on which AROI fields are missing.
-    Eliminates code duplication.
-    
+    Categorize a relay's AROI configuration based on which fields are
+    missing or inconsistent.
+
     Args:
-        aroi_fields: Dict from _check_aroi_fields() with has_ciissversion, has_proof, has_url
-        has_contact: Boolean indicating if relay has a contact field at all
-        
-    Returns:
-        Category string based on missing fields
+        aroi_fields: Dict from _check_aroi_fields() with at least
+            has_ciissversion, has_proof, has_url, version_proof_mismatch,
+            is_v3_no_proof_compliant.
+        has_contact: True if relay has a non-empty contact field.
+
+    Returns one of:
+      - 'no_contact':            relay has no contact field
+      - 'no_aroi_info':          contact present, 0 AROI fields
+      - 'missing_two_aroi':      contact + 1 AROI field; missing 2
+      - 'no_proof':              has ciissversion + url; missing proof
+      - 'no_domain':             has ciissversion + proof; missing url
+      - 'no_ciissversion':       has proof + url; missing ciissversion
+      - 'version_proof_mismatch': has all 3 BUT proof type doesn't match
+                                  declared ciissversion (e.g. v2 +
+                                  uri-familyid-ed25519). Operator
+                                  copy-paste error during migration.
+      - 'v3_informational':      ciissversion:3 declared without url:.
+                                  Spec-legal (proof not required when
+                                  url is absent); not an issue.
+      - 'no_aroi':               defensive fallback (shouldn't reach)
     """
-    fields_present = sum([aroi_fields['has_ciissversion'], 
-                         aroi_fields['has_proof'], 
-                         aroi_fields['has_url']])
-    
-    # First check: No contact field at all
+    # Check version/proof mismatch BEFORE missing-fields check; a relay
+    # with all 3 fields-present but mismatched proof is qualitatively
+    # different from "no AROI" and gets its own actionable category.
+    if aroi_fields.get('version_proof_mismatch'):
+        return 'version_proof_mismatch'
+
+    # CIISS v3 spec-compliant url-less informational case: ciissversion:3
+    # may appear with informational fields (email, donations, etc.) and
+    # no url. proof is required only when url is set, so absence of
+    # both is spec-legal — not "incomplete".
+    if aroi_fields.get('is_v3_no_proof_compliant'):
+        return 'v3_informational'
+
+    fields_present = sum([
+        aroi_fields['has_ciissversion'],
+        aroi_fields['has_proof'],
+        aroi_fields['has_url'],
+    ])
+
     if not has_contact:
         return 'no_contact'  # Empty/missing contact field
-    
-    # Has contact, now check AROI field presence
+
     if fields_present == 0:
         return 'no_aroi_info'  # Has contact but no AROI fields at all
-    elif fields_present == 1:
+    if fields_present == 1:
         return 'missing_two_aroi'  # Has 1 AROI field, missing 2
-    
+
     # Has exactly 2 fields (missing exactly 1) - be specific
     if not aroi_fields['has_proof']:
         return 'no_proof'
-    elif not aroi_fields['has_url']:
+    if not aroi_fields['has_url']:
         return 'no_domain'
-    elif not aroi_fields['has_ciissversion']:
+    if not aroi_fields['has_ciissversion']:
         return 'no_ciissversion'
-    
-    # Shouldn't reach here if logic is correct, but defensive
+
+    # Shouldn't reach here if upstream callers already handled
+    # `complete=True` — defensive fallback.
     return 'no_aroi'
 
 
@@ -197,25 +766,31 @@ def _simplify_and_categorize_errors(errors: Dict[str, int]) -> Dict[str, Dict[st
 
 def _categorize_relay_by_validation(relay: Dict, validation_map: Dict) -> str:
     """
-    Categorize a relay by its validation status.
-    
-    AROI Standard: A relay must have all 3 required fields for AROI validation:
-    1. ciissversion:2
-    2. proof:dns-rsa or proof:uri-rsa
-    3. url:<domain>
-    
+    Categorize a relay by its AROI validation status (v2 + v3 aware).
+
+    A relay needs all 3 required fields with a CONSISTENT (version, proof)
+    pair to count as "complete AROI":
+      - CIISS v2: ciissversion:2 + proof:(dns-rsa|uri-rsa) + url:<domain>
+      - CIISS v3: ciissversion:3 + proof:(dns-familyid-ed25519
+                                          |uri-familyid-ed25519) + url:<domain>
+
     Args:
         relay: Relay dictionary from Onionoo API
-        validation_map: Map of fingerprint -> validation result
-        
-    Returns:
-        Category string:
-        - 'validated': Has all 3 AROI fields and validation succeeded
-        - 'unvalidated': Has all 3 AROI fields but validation failed (SSL, DNS, etc.)
-        - 'no_proof': Has ciissversion + url but missing proof (exactly 1 field missing)
-        - 'no_domain': Has ciissversion + proof but missing url (exactly 1 field missing)
-        - 'no_ciissversion': Has proof + url but missing ciissversion (exactly 1 field missing)
-        - 'no_aroi': Missing 2+ fields or no contact at all
+        validation_map: Map of fingerprint -> upstream validation result
+
+    Returns one of:
+        - 'validated':              has complete AROI + upstream said valid
+        - 'unvalidated':            has complete AROI + upstream said invalid
+        - 'no_proof', 'no_domain', 'no_ciissversion':
+                                    has 2-of-3 fields, missing the named one
+        - 'missing_two_aroi':       has 1 field, missing 2
+        - 'no_aroi_info':           has contact but 0 AROI fields
+        - 'no_contact':             no contact field at all
+        - 'version_proof_mismatch': 3 fields present but proof type
+                                    disagrees with declared ciissversion
+                                    (e.g. ciissversion:2 + proof:uri-familyid-ed25519)
+        - 'v3_informational':       ciissversion:3 with no url: (spec-legal,
+                                    not "incomplete")
     """
     fingerprint = relay.get('fingerprint')
     aroi_domain = relay.get('aroi_domain', 'none')
@@ -256,6 +831,110 @@ def _categorize_relay_by_validation(relay: Dict, validation_map: Dict) -> str:
         return _categorize_by_missing_fields(aroi_fields, has_contact)
 
 
+# Module-state for one-time error-category warnings.
+_warned_unknown_error_categories = set()
+
+
+def _warn_unknown_error_categories(category_counts: Dict[str, int]) -> None:
+    """A.8 helper: log once per unknown error_category seen in upstream data.
+
+    When upstream aroivalidator adds a new failure category we don't yet
+    have a V3_CATEGORY_LABELS entry for, surface it as a build-time
+    warning so we know to update the labels dict.
+    """
+    for category, count in (category_counts or {}).items():
+        if count <= 0:
+            continue
+        if category in V3_CATEGORY_LABELS:
+            continue
+        if category in _warned_unknown_error_categories:
+            continue
+        _warned_unknown_error_categories.add(category)
+        logger.warning(
+            "AROI: unknown error_category '%s' (count=%d) — update "
+            "V3_CATEGORY_LABELS in aroi_validation.py", category, count
+        )
+        _record_warning('unknown_error_category', category)
+
+
+def _build_error_rollup(
+    relay_results: List[Dict],
+) -> Tuple[List[Tuple[str, str, int]], List[Tuple[str, str, int]], List[Tuple[str, str, int]]]:
+    """A.6: Consolidate v2 and v3 error counts into shared / v2_only / v3_only.
+
+    Args:
+        relay_results: List of per-relay validation result dicts (each dict
+            ideally has 'valid', 'ciissversion', 'error_category', 'error').
+
+    Returns:
+        Three lists of (category, title, count) tuples sorted by count desc:
+          - shared: error categories that apply to BOTH v2 and v3 with the
+                    same root cause and same fix copy (consolidated).
+          - v2_only: errors observed only on v2 relays.
+          - v3_only: errors observed only on v3 relays.
+
+    Categories without an entry in V3_CATEGORY_LABELS get a synthetic
+    title from the raw category string. Relays with no error_category
+    (older cached upstream responses, before schema v2) are ignored —
+    the legacy substring rollup in `_simplify_and_categorize_errors`
+    still handles those.
+    """
+    shared_counts: Dict[str, int] = defaultdict(int)
+    v2_counts: Dict[str, int] = defaultdict(int)
+    v3_counts: Dict[str, int] = defaultdict(int)
+
+    for r in relay_results or ():
+        if r.get('valid'):
+            continue
+        category = r.get('error_category')
+        if not category:
+            continue  # Pre-schema-v2 cached entry, fall through to legacy path.
+        version = r.get('ciissversion') or ''
+        if category in SHARED_ERROR_CATEGORIES:
+            shared_counts[category] += 1
+        elif version == '3' or category in V3_ONLY_ERROR_CATEGORIES:
+            v3_counts[category] += 1
+        elif version == '2':
+            v2_counts[category] += 1
+        else:
+            # No version info: bucket as v2_only (today's heuristic).
+            v2_counts[category] += 1
+
+    def _format(counts: Dict[str, int]) -> List[Tuple[str, str, int]]:
+        rows = []
+        for cat, cnt in counts.items():
+            label = V3_CATEGORY_LABELS.get(cat) or {}
+            title = label.get('title') or cat.replace('_', ' ').title()
+            rows.append((cat, title, cnt))
+        rows.sort(key=lambda x: x[2], reverse=True)
+        return rows
+
+    return _format(shared_counts), _format(v2_counts), _format(v3_counts)
+
+
+def _log_aroi_build_summary(metrics: Dict, progress_logger=None) -> None:
+    """A.8: Emit a one-line summary of v2 + v3 stats during the build.
+
+    Helps catch regressions and silently dropped relays at a glance.
+    """
+    msg = (
+        f"\u2713 AROI: schema v{metrics.get('aroi_schema_version', '?')}, "
+        f"{metrics.get('v2_valid', 0)}/{metrics.get('v2_total', 0)} v2 valid, "
+        f"{metrics.get('v3_valid', 0)}/{metrics.get('v3_total', 0)} v3 valid"
+    )
+    declared = metrics.get('ciissversion_declared') or {}
+    if declared:
+        parts = [
+            f"v{k}:{declared[k]}" if k != 'none' else f"none:{declared[k]}"
+            for k in sorted(declared)
+        ]
+        msg += f" \u2014 declared {', '.join(parts)}"
+    if progress_logger:
+        progress_logger(msg)
+    else:
+        logger.info(msg)
+
+
 def calculate_aroi_validation_metrics(relays: List[Dict], validation_data: Optional[Dict] = None, 
                                        calculate_operator_metrics: bool = True) -> Dict:
     """
@@ -275,7 +954,9 @@ def calculate_aroi_validation_metrics(relays: List[Dict], validation_data: Optio
     Returns:
         Dict containing validation metrics for health dashboard (relay + operator level)
     """
-    # Initialize metrics with safe defaults
+    # Initialize metrics with safe defaults. Per-proof-type and per-version
+    # keys are seeded in a single loop so adding a future proof type is one
+    # PROOF_TYPE_STAT_KEYS line, not 3 lines per type.
     metrics = {
         'aroi_validated_count': 0,
         'aroi_unvalidated_count': 0,
@@ -285,6 +966,8 @@ def calculate_aroi_validation_metrics(relays: List[Dict], validation_data: Optio
         'relays_no_contact': 0,
         'relays_no_aroi_info': 0,
         'relays_missing_two_aroi': 0,
+        'relays_version_proof_mismatch': 0,
+        'relays_v3_informational': 0,
         'aroi_validated_percentage': 0.0,
         'aroi_unvalidated_percentage': 0.0,
         'aroi_no_proof_percentage': 0.0,
@@ -293,22 +976,39 @@ def calculate_aroi_validation_metrics(relays: List[Dict], validation_data: Optio
         'relays_no_contact_percentage': 0.0,
         'relays_no_aroi_info_percentage': 0.0,
         'relays_missing_two_aroi_percentage': 0.0,
+        'relays_version_proof_mismatch_percentage': 0.0,
+        'relays_v3_informational_percentage': 0.0,
         'aroi_validation_success_rate': 0.0,
-        'dns_rsa_success_rate': 0.0,
-        'uri_rsa_success_rate': 0.0,
-        'dns_rsa_total': 0,
-        'dns_rsa_valid': 0,
-        'uri_rsa_total': 0,
-        'uri_rsa_valid': 0,
         'validation_data_available': False,
         'validation_timestamp': 'Unknown',
-        'top_3_aroi_countries': [],  # Default empty list for template
-        'relay_error_top5': [],  # Top 5 relay error reasons (simplified)
-        'operator_error_top5': [],  # Top 5 operator error reasons (simplified)
-        'dns_error_top5': [],  # Top 5 DNS-RSA specific errors
-        'uri_error_top5': [],  # Top 5 URI-RSA specific errors
-        'no_aroi_reasons_top5': []  # Top reasons relays have no AROI
+        'top_3_aroi_countries': [],
+        'relay_error_top5': [],
+        'operator_error_top5': [],
+        'dns_error_top5': [],
+        'uri_error_top5': [],
+        'no_aroi_reasons_top5': [],
+        # ciissversion adoption (sourced directly from upstream when present)
+        'ciissversion_declared': {},
+        'ciissversion_validated': {},
+        # v3 failure-category counts (from upstream's v3_failure_categories
+        # statistic; aggregated across all v3 relays in a single batch)
+        'v3_failure_categories': {},
+        # Aggregate v2 + v3 totals (computed below from per-proof-type counts)
+        'v2_total': 0, 'v2_valid': 0, 'v2_success_rate': 0.0,
+        'v3_total': 0, 'v3_valid': 0, 'v3_success_rate': 0.0,
+        # v2/v3 consolidated error rollup (from _build_error_rollup)
+        'error_rollup_shared': [],
+        'error_rollup_v2_only': [],
+        'error_rollup_v3_only': [],
     }
+    # Seed per-proof-type *_total / *_valid / *_success_rate keys for ALL
+    # known proof types (4 today: dns_rsa, uri_rsa, dns_familyid_ed25519,
+    # uri_familyid_ed25519). Pre-seeded so templates can iterate without
+    # defensive .get() everywhere.
+    for stat_key in PROOF_TYPE_STAT_KEYS:
+        metrics[f'{stat_key}_total'] = 0
+        metrics[f'{stat_key}_valid'] = 0
+        metrics[f'{stat_key}_success_rate'] = 0.0
     
     if not relays:
         return metrics
@@ -346,6 +1046,10 @@ def calculate_aroi_validation_metrics(relays: List[Dict], validation_data: Optio
                     metrics['relays_no_aroi_info'] += 1
                 elif category == 'missing_two_aroi':
                     metrics['relays_missing_two_aroi'] += 1
+                elif category == 'version_proof_mismatch':
+                    metrics['relays_version_proof_mismatch'] += 1
+                elif category == 'v3_informational':
+                    metrics['relays_v3_informational'] += 1
         
         # Calculate percentages using helper function
         metrics['aroi_unvalidated_percentage'] = _calc_percentage(metrics['aroi_unvalidated_count'], total_relays)
@@ -375,20 +1079,49 @@ def calculate_aroi_validation_metrics(relays: List[Dict], validation_data: Optio
     metrics['validation_data_available'] = True
     metrics['validation_timestamp'] = metadata.get('timestamp', 'Unknown')
     
-    # Extract proof type statistics from validation data
+    # Extract per-proof-type statistics for ALL supported proof types
+    # (dns_rsa + uri_rsa for v2; dns_familyid_ed25519 + uri_familyid_ed25519
+    # for v3). Loop over PROOF_TYPE_STAT_KEYS so adding a future proof
+    # type is one constant line, not 3 lines of extraction per type.
     proof_types = statistics.get('proof_types', {})
-    
-    # DNS-RSA statistics
-    dns_rsa_stats = proof_types.get('dns_rsa', {})
-    metrics['dns_rsa_total'] = dns_rsa_stats.get('total', 0)
-    metrics['dns_rsa_valid'] = dns_rsa_stats.get('valid', 0)
-    metrics['dns_rsa_success_rate'] = dns_rsa_stats.get('success_rate', 0.0)
-    
-    # URI-RSA statistics
-    uri_rsa_stats = proof_types.get('uri_rsa', {})
-    metrics['uri_rsa_total'] = uri_rsa_stats.get('total', 0)
-    metrics['uri_rsa_valid'] = uri_rsa_stats.get('valid', 0)
-    metrics['uri_rsa_success_rate'] = uri_rsa_stats.get('success_rate', 0.0)
+    for stat_key in PROOF_TYPE_STAT_KEYS:
+        type_stats = proof_types.get(stat_key, {})
+        metrics[f'{stat_key}_total'] = type_stats.get('total', 0)
+        metrics[f'{stat_key}_valid'] = type_stats.get('valid', 0)
+        metrics[f'{stat_key}_success_rate'] = type_stats.get('success_rate', 0.0)
+
+    # Aggregate v2/v3 totals from the per-proof-type values just extracted.
+    # This is what the dashboard's "v2 success rate" / "v3 success rate"
+    # tiles read.
+    metrics['v2_total'] = sum(
+        metrics[f'{p.replace("-", "_")}_total'] for p in V2_PROOF_TYPES
+    )
+    metrics['v2_valid'] = sum(
+        metrics[f'{p.replace("-", "_")}_valid'] for p in V2_PROOF_TYPES
+    )
+    metrics['v3_total'] = sum(
+        metrics[f'{p.replace("-", "_")}_total'] for p in V3_PROOF_TYPES
+    )
+    metrics['v3_valid'] = sum(
+        metrics[f'{p.replace("-", "_")}_valid'] for p in V3_PROOF_TYPES
+    )
+    metrics['v2_success_rate'] = _calc_percentage(metrics['v2_valid'], metrics['v2_total'])
+    metrics['v3_success_rate'] = _calc_percentage(metrics['v3_valid'], metrics['v3_total'])
+
+    # ciissversion adoption — passthrough of upstream stats when present.
+    # ciissversion_declared: what relays declared in ContactInfo.
+    # ciissversion_validated: what the validator actually processed.
+    metrics['ciissversion_declared'] = statistics.get('ciissversion_declared', {}) or {}
+    metrics['ciissversion_validated'] = statistics.get('ciissversion_validated', {}) or {}
+
+    # v3 failure categories — already aggregated by upstream into 13
+    # canonical categories. Pass through directly so the dashboard's
+    # error-rollup table reads them without re-deriving.
+    metrics['v3_failure_categories'] = statistics.get('v3_failure_categories', {}) or {}
+
+    # A.8 build-time observability: warn once when upstream reports an
+    # error_category we don't have a V3_CATEGORY_LABELS entry for.
+    _warn_unknown_error_categories(metrics['v3_failure_categories'])
     
     # Build fingerprint -> validation result mapping for O(1) lookup
     validation_map = {}
@@ -426,6 +1159,10 @@ def calculate_aroi_validation_metrics(relays: List[Dict], validation_data: Optio
             metrics['relays_no_aroi_info'] += 1
         elif category == 'missing_two_aroi':
             metrics['relays_missing_two_aroi'] += 1
+        elif category == 'version_proof_mismatch':
+            metrics['relays_version_proof_mismatch'] += 1
+        elif category == 'v3_informational':
+            metrics['relays_v3_informational'] += 1
         
         # Operator-level tracking (in same loop for efficiency)
         if calculate_operator_metrics:
@@ -462,17 +1199,23 @@ def calculate_aroi_validation_metrics(relays: List[Dict], validation_data: Optio
                         # (relays with "Missing AROI fields" shouldn't have aroi_domain set, but defensive check)
                         if error not in ('Missing AROI fields', 'No contact information'):
                             domain_failure_reasons[aroi_domain][error] = domain_failure_reasons[aroi_domain].get(error, 0) + 1
-    
-        # Calculate percentages using helper function
-        metrics['aroi_validated_percentage'] = _calc_percentage(metrics['aroi_validated_count'], total_relays)
-        metrics['aroi_unvalidated_percentage'] = _calc_percentage(metrics['aroi_unvalidated_count'], total_relays)
-        metrics['aroi_no_proof_percentage'] = _calc_percentage(metrics['aroi_no_proof_count'], total_relays)
-        metrics['aroi_no_domain_percentage'] = _calc_percentage(metrics['aroi_no_domain_count'], total_relays)
-        metrics['aroi_no_ciissversion_percentage'] = _calc_percentage(metrics['aroi_no_ciissversion_count'], total_relays)
-        metrics['relays_no_contact_percentage'] = _calc_percentage(metrics['relays_no_contact'], total_relays)
-        metrics['relays_no_aroi_info_percentage'] = _calc_percentage(metrics['relays_no_aroi_info'], total_relays)
-        metrics['relays_missing_two_aroi_percentage'] = _calc_percentage(metrics['relays_missing_two_aroi'], total_relays)
-    
+
+    # Phase 2.1: Calculate percentages ONCE after the per-relay loop
+    # completes (previously these were inside the loop, computed
+    # ~10,867 times per build = ~108k redundant _calc_percentage calls).
+    # Counts are stable after the loop; no reason to recompute on every
+    # iteration. Net: O(N) → O(1) for percentage calculation.
+    metrics['aroi_validated_percentage'] = _calc_percentage(metrics['aroi_validated_count'], total_relays)
+    metrics['aroi_unvalidated_percentage'] = _calc_percentage(metrics['aroi_unvalidated_count'], total_relays)
+    metrics['aroi_no_proof_percentage'] = _calc_percentage(metrics['aroi_no_proof_count'], total_relays)
+    metrics['aroi_no_domain_percentage'] = _calc_percentage(metrics['aroi_no_domain_count'], total_relays)
+    metrics['aroi_no_ciissversion_percentage'] = _calc_percentage(metrics['aroi_no_ciissversion_count'], total_relays)
+    metrics['relays_no_contact_percentage'] = _calc_percentage(metrics['relays_no_contact'], total_relays)
+    metrics['relays_no_aroi_info_percentage'] = _calc_percentage(metrics['relays_no_aroi_info'], total_relays)
+    metrics['relays_missing_two_aroi_percentage'] = _calc_percentage(metrics['relays_missing_two_aroi'], total_relays)
+    metrics['relays_version_proof_mismatch_percentage'] = _calc_percentage(metrics['relays_version_proof_mismatch'], total_relays)
+    metrics['relays_v3_informational_percentage'] = _calc_percentage(metrics['relays_v3_informational'], total_relays)
+
     # Build no_aroi_reasons_top5 from the category counts
     no_aroi_reasons = [
         ("No contact info", metrics['relays_no_contact']),
@@ -489,11 +1232,19 @@ def calculate_aroi_validation_metrics(relays: List[Dict], validation_data: Optio
         reverse=True
     )[:5]
     
-    # Calculate overall validation success rate
-    # Success rate = valid relays / (valid + invalid with AROI attempts)
-    total_aroi_attempts = metrics['dns_rsa_total'] + metrics['uri_rsa_total']
-    total_aroi_valid = metrics['dns_rsa_valid'] + metrics['uri_rsa_valid']
-    
+    # Calculate overall validation success rate.
+    # FIXED: previously this only summed v2 totals (dns_rsa + uri_rsa),
+    # silently ignoring v3 (dns_familyid_ed25519 + uri_familyid_ed25519).
+    # That made the metric meaningless once any operator had v3 relays.
+    # Now it sums ALL four proof types so the rate reflects the whole
+    # AROI-attempting population.
+    total_aroi_attempts = sum(
+        metrics.get(f'{pt}_total', 0) for pt in PROOF_TYPE_STAT_KEYS
+    )
+    total_aroi_valid = sum(
+        metrics.get(f'{pt}_valid', 0) for pt in PROOF_TYPE_STAT_KEYS
+    )
+
     if total_aroi_attempts > 0:
         metrics['aroi_validation_success_rate'] = (total_aroi_valid / total_aroi_attempts * 100)
     else:
@@ -574,7 +1325,18 @@ def calculate_aroi_validation_metrics(relays: List[Dict], validation_data: Optio
     
     # Store validation_map for reuse by contact pages (avoids rebuilding 3,000+ times)
     metrics['_validation_map'] = validation_map
-    
+
+    # A.6: consolidated v2/v3 error rollup keyed by upstream error_category.
+    # Templates render this as 3 sections (shared / v2-only / v3-only) so
+    # operators see "X common errors apply to both versions; Y are v2-only;
+    # Z are v3-only" without having to mentally cross-reference.
+    shared_rollup, v2_rollup, v3_rollup = _build_error_rollup(
+        validation_data.get('results', []) if validation_data else []
+    )
+    metrics['error_rollup_shared'] = shared_rollup
+    metrics['error_rollup_v2_only'] = v2_rollup
+    metrics['error_rollup_v3_only'] = v3_rollup
+
     return metrics
 
 
@@ -591,66 +1353,106 @@ def _format_timestamp(timestamp_str):
 
 def get_contact_validation_status(relays: List[Dict], validation_data: Optional[Dict] = None, validation_map: Optional[Dict] = None) -> Dict:
     """
-    Get validation status for a specific contact's relays.
-    
-    Categorizes relays into:
-    - validated: All 3 AROI fields + validation passed
-    - unauthorized: All 3 AROI fields + "fingerprint not found" error
-    - misconfigured: All 3 AROI fields + DNS/SSL/timeout errors
-    - incomplete_*: Missing 1-2 AROI fields (granular sub-categories)
-    - not_configured_*: No AROI fields (granular sub-categories)
-    
-    Operator status cascade:
-    - validated: At least 1 relay passes validation
-    - unauthorized: 0 validated AND at least 1 unauthorized
-    - misconfigured: 0 validated AND 0 unauthorized AND at least 1 misconfigured/incomplete
-    - not_configured: All relays have no AROI info
-    
+    Get AROI validation status for a specific contact's relays (v2 + v3 aware).
+
+    Cascade logic (highest-precedence label first; ties picked top-down):
+      - validated:     >=1 relay passes upstream validation
+      - unauthorized:  0 validated AND >=1 dns/uri content_mismatch
+                       (relay claims domain but proof says it doesn't)
+      - misconfigured: 0 validated AND 0 unauthorized AND >=1 transport
+                       error / SSL / etc.
+      - incomplete:    0 validated AND 0 unauthorized/misconfigured AND
+                       >=1 relay missing 1-2 AROI fields
+      - not_configured: all relays have 0 AROI fields
+
+    NEW peer issue categories (added to plain operator pages alongside the
+    cascade categories — they do NOT change top-level validation_status):
+      - security_incident_relays: error_category=='secret_key_leaked'
+      - pending_onionoo_relays:   error_category=='missing_family_ids'
+                                  (operator changed torrc but Onionoo
+                                   hasn't refreshed family_ids yet)
+
+    NEW operator-level migration metadata:
+      - is_mixed_migration: True iff operator has BOTH v2 AND v3 declaring
+                            relays under the same contact
+      - v3_relay_count / v2_relay_count / v3_relay_percentage
+      - v3_tier: 'none'|'explorer'|'migrating'|'mostly'|'complete'
+        (consumed by leaderboards, listing icons, and the operator
+         header pill in B1)
+      - is_v3_adopter: v3_relay_percentage >= V3_LISTING_ICON_THRESHOLD
+
+    A.4 changes: when val_result['error_category'] is set, prefer it over
+    today's substring heuristic for cascade decisions; passthrough the
+    upstream `hint` field so templates can render pasteable fix copy
+    inline.
+
     Args:
         relays: List of relay dictionaries for this contact
         validation_data: Optional validation data from aroivalidator.1aeo.com
-        validation_map: Optional pre-built fingerprint -> validation result map (avoids rebuilding)
-        
-    Returns:
-        Dict containing contact-level validation information
+        validation_map: Optional pre-built fingerprint -> validation result
+            map (avoids rebuilding 3,000+ times)
     """
     result = {
         'has_aroi': False,
-        'validation_status': 'not_configured',  # validated | unauthorized | misconfigured | not_configured
-        
-        # Complete AROI relays (all 3 fields present)
+        'validation_status': 'not_configured',  # validated | unauthorized | misconfigured | incomplete | not_configured
+
+        # Complete AROI relays (all 3 fields present, version+proof match)
         'validated_relays': [],
-        'unauthorized_relays': [],    # "fingerprint not found" errors
-        'misconfigured_relays': [],   # DNS/SSL/timeout errors
-        
-        # Incomplete AROI relays (1-2 fields) - combined for display
+        'unauthorized_relays': [],    # dns/uri content_mismatch
+        'misconfigured_relays': [],   # SSL / timeout / 404 / transport
+
+        # Incomplete AROI relays (1-2 fields)
         'incomplete_relays': [],
-        
-        # No AROI relays (0 fields) - combined for display
+        # No AROI relays (0 fields)
         'not_configured_relays': [],
-        
+
+        # NEW peer issue categories (A.5): rendered alongside the cascade,
+        # NOT replacing it. Empty when count == 0.
+        'security_incident_relays': [],
+        'pending_onionoo_relays': [],
+
         # Fingerprint sets for O(1) lookups in templates
         'validated_fingerprints': set(),
         'unauthorized_fingerprints': set(),
         'misconfigured_fingerprints': set(),
-        
+        'security_incident_fingerprints': set(),
+        'pending_onionoo_fingerprints': set(),
+
         'validation_summary': {
             'total_relays': len(relays),
             'validated_count': 0,
             'unauthorized_count': 0,
             'misconfigured_count': 0,
-            'incomplete_count': 0,        # Sum of all incomplete_* counts
-            'not_configured_count': 0,    # Sum of all not_configured_* counts
+            'incomplete_count': 0,
+            'not_configured_count': 0,
+            # NEW: peer-category counts
+            'security_incident_count': 0,
+            'pending_onionoo_count': 0,
+            # NEW: operator-level v2/v3 migration tally
+            'v2_relay_count': 0,
+            'v3_relay_count': 0,
+            'v3_relay_percentage': 0.0,
+            'is_mixed_migration': False,
+            'is_v3_adopter': False,
+            'v3_tier': 'none',      # none|explorer|migrating|mostly|complete
+            # B1.1 (final): per-version validated counts for the
+            # success-rate pills in the v3_migration_summary section.
+            'v2_validated_count': 0,
+            'v3_validated_count': 0,
+            'v2_success_rate': 0.0,
+            'v3_success_rate': 0.0,
             # Granular counts for troubleshooting tooltips
             'incomplete_no_proof_count': 0,
             'incomplete_no_domain_count': 0,
             'incomplete_no_ciissversion_count': 0,
             'incomplete_missing_two_count': 0,
+            'incomplete_version_proof_mismatch_count': 0,
+            'incomplete_v3_informational_count': 0,
             'not_configured_no_aroi_info_count': 0,
             'not_configured_no_contact_count': 0,
         },
         'validation_available': False,
-        'show_detailed_errors': True
+        'show_detailed_errors': True,
     }
     
     if not relays:
@@ -670,57 +1472,151 @@ def get_contact_validation_status(relays: List[Dict], validation_data: Optional[
         result['validation_available'] = len(validation_map) > 0
     
     # Single pass through relays - categorize each one
+    summary = result['validation_summary']
     for relay in relays:
         fingerprint = relay.get('fingerprint')
         aroi_domain = relay.get('aroi_domain', 'none')
+        # New per-relay fields from A.2.1 (set by _simple_aroi_parsing).
+        relay_aroi_version = relay.get('aroi_version')
+        relay_aroi_proof_type = relay.get('aroi_proof_type')
         nickname = relay.get('nickname', 'Unnamed')
         contact = relay.get('contact', '')
         first_seen = relay.get('first_seen', 'Unknown')
-        
-        # Check if relay has complete AROI setup (all 3 required fields)
+
+        # A.5 operator-level v2/v3 tally (any AROI-declaring relay
+        # contributes, even if validation fails).
+        if relay_aroi_version == '2':
+            summary['v2_relay_count'] += 1
+        elif relay_aroi_version == '3':
+            summary['v3_relay_count'] += 1
+
+        # Check if relay has complete AROI setup (all 3 fields, consistent
+        # version+proof). aroi_domain is "none" when _simple_aroi_parsing
+        # detected a mismatch, so this also rejects copy-paste errors.
         has_complete_aroi = aroi_domain and aroi_domain != 'none'
-        
+
         if has_complete_aroi:
-            # Relay has all 3 AROI fields - check validation result
+            # Relay has all 3 AROI fields - check upstream validation result
             result['has_aroi'] = True
-            
+
             if fingerprint not in validation_map:
-                # Has AROI but not in validation data - treat as misconfigured (unknown status)
-                result['validation_summary']['misconfigured_count'] += 1
+                # Has AROI but not in validation data - treat as misconfigured
+                # (unknown status, often a brand-new relay).
+                summary['misconfigured_count'] += 1
                 result['misconfigured_relays'].append({
                     'fingerprint': fingerprint,
                     'nickname': nickname,
                     'aroi_domain': aroi_domain,
                     'error': 'Not yet processed by validator (relay may be new)',
-                    'proof_type': 'unknown',
+                    'proof_type': relay_aroi_proof_type or 'unknown',
+                    'aroi_version': relay_aroi_version,
                     'first_seen': first_seen,
-                    'relay': relay,  # Include full relay for table display
+                    'relay': relay,
+                    'hint': None,
+                    'error_category': None,
                 })
                 continue
-            
+
             val_result = validation_map[fingerprint]
-            
+
             if val_result.get('valid', False):
-                # VALIDATED: Validation passed
-                result['validation_summary']['validated_count'] += 1
+                # VALIDATED: upstream validation passed.
+                summary['validated_count'] += 1
+                # B1.1 (final): per-version validated tally for success-rate pills.
+                _val_version = val_result.get('ciissversion') or relay_aroi_version
+                if _val_version == '2':
+                    summary['v2_validated_count'] += 1
+                elif _val_version == '3':
+                    summary['v3_validated_count'] += 1
                 result['validated_relays'].append({
                     'fingerprint': fingerprint,
                     'nickname': nickname,
                     'aroi_domain': aroi_domain,
-                    'proof_type': val_result.get('proof_type', 'unknown'),
+                    'proof_type': val_result.get('proof_type') or relay_aroi_proof_type or 'unknown',
                     'proof_uri': val_result.get('proof_uri', ''),
+                    'aroi_version': _val_version,
                     'first_seen': first_seen,
                     'relay': relay,
                 })
+                continue
+
+            # Validation failed -> categorize by error_category (A.4) with
+            # fallback to substring heuristic (older cached pre-schema-v2
+            # responses don't have error_category).
+            error = val_result.get('error', 'Unknown error')
+            error = _deduplicate_fingerprint_not_found_error(error)
+            error_category = val_result.get('error_category')
+
+            # B-final: surface V3_CATEGORY_LABELS pasteable example as
+            # 'pasteable_example' alongside the upstream `hint` so the
+            # template can render BOTH:
+            #   - upstream hint (current best guidance, may be prose)
+            #   - our pasteable example (single line, copy-paste-able)
+            # This strengthens the pasteable-examples contract from the
+            # plan: operators always see at least one literally-pasteable
+            # line, even when upstream hint is mostly prose.
+            _label = (V3_CATEGORY_LABELS.get(error_category) or {}) if error_category else {}
+            # The relay's actual proof_type drives version-aware example
+            # selection (URI-RSA → rsa-fingerprint.txt, URI-FamilyID-Ed25519
+            # → ed25519-family-id.txt). User-reported bug fix:
+            # "URI-RSA fingerprint not found" was rendering the v3 file
+            # path because the example was hard-coded to ed25519.
+            _resolved_proof_type = (
+                val_result.get('proof_type') or relay_aroi_proof_type or 'unknown'
+            )
+            relay_info = {
+                'fingerprint': fingerprint,
+                'nickname': nickname,
+                'aroi_domain': aroi_domain,
+                'error': error,
+                'proof_type': _resolved_proof_type,
+                'aroi_version': val_result.get('ciissversion') or relay_aroi_version,
+                'first_seen': first_seen,
+                'relay': relay,
+                # A.4: pass through upstream's actionable hint verbatim.
+                'hint': val_result.get('hint'),
+                'error_category': error_category,
+                # B-final: pasteable one-line example from V3_CATEGORY_LABELS.
+                # Distinct from `hint` (which may be prose). Templates render
+                # this as a code block when present.
+                # UX-fix: substitute <fingerprint> / <your-domain> with this
+                # relay's actual values so the operator can copy-paste
+                # the line verbatim and run it without manual editing.
+                'pasteable_example': _render_pasteable_example(
+                    _resolve_example_for_proof(_label, _resolved_proof_type),
+                    fingerprint, aroi_domain
+                ),
+            }
+
+            # A.5: peer issue categories — first because they should appear
+            # alongside the cascade, not be hidden by it.
+            if error_category == 'secret_key_leaked':
+                summary['security_incident_count'] += 1
+                result['security_incident_relays'].append(relay_info)
+                # secret_key_leaked is also a misconfiguration; surface it
+                # in the cascade-misconfigured list so the operator status
+                # cascade reflects "something is wrong" (not "validated").
+                summary['misconfigured_count'] += 1
+                result['misconfigured_relays'].append(relay_info)
+                continue
+            if error_category == 'missing_family_ids':
+                # Onionoo lag — actionable but transient. Bucket as
+                # peer "pending" AND in the cascade as misconfigured
+                # so cascade still detects the operator has issues.
+                summary['pending_onionoo_count'] += 1
+                result['pending_onionoo_relays'].append(relay_info)
+                summary['misconfigured_count'] += 1
+                result['misconfigured_relays'].append(relay_info)
+                continue
+
+            # A.4: prefer error_category for cascade decisions; fall back
+            # to today's substring heuristic when the category is absent.
+            if error_category in ('uri_content_mismatch', 'dns_content_mismatch'):
+                is_unauthorized = True
+            elif error_category is not None:
+                is_unauthorized = False
             else:
-                # Validation failed - categorize by error type
-                error = val_result.get('error', 'Unknown error')
-                error = _deduplicate_fingerprint_not_found_error(error)
-                
-                # Check if unauthorized error (fingerprint/record not found) -> unauthorized
-                # These indicate the relay is NOT in the operator's proof file
-                # NXDOMAIN stays as misconfigured (domain doesn't exist = config error, not unauthorized claim)
-                # HTTP 404 stays as misconfigured (proof file doesn't exist = setup error)
+                # Pre-schema-v2 fallback heuristic (preserved verbatim).
                 error_lower = error.lower()
                 is_http_error = '404' in error_lower or 'http error' in error_lower
                 is_unauthorized = (
@@ -729,24 +1625,13 @@ def get_contact_validation_status(relays: List[Dict], validation_data: Optional[
                         ('not found' in error_lower and ('dns' in error_lower or 'txt' in error_lower or 'record' in error_lower) and 'nxdomain' not in error_lower)
                     )
                 )
-                
-                relay_info = {
-                    'fingerprint': fingerprint,
-                    'nickname': nickname,
-                    'aroi_domain': aroi_domain,
-                    'error': error,  # Show full error from API
-                    'proof_type': val_result.get('proof_type', 'unknown'),
-                    'first_seen': first_seen,
-                    'relay': relay,
-                }
-                
-                if is_unauthorized:
-                    result['validation_summary']['unauthorized_count'] += 1
-                    result['unauthorized_relays'].append(relay_info)
-                else:
-                    # SSL/timeout/connection/other errors -> misconfigured
-                    result['validation_summary']['misconfigured_count'] += 1
-                    result['misconfigured_relays'].append(relay_info)
+
+            if is_unauthorized:
+                summary['unauthorized_count'] += 1
+                result['unauthorized_relays'].append(relay_info)
+            else:
+                summary['misconfigured_count'] += 1
+                result['misconfigured_relays'].append(relay_info)
         else:
             # Relay does NOT have complete AROI - categorize as incomplete or not_configured
             aroi_fields = _check_aroi_fields(contact)
@@ -765,33 +1650,52 @@ def get_contact_validation_status(relays: List[Dict], validation_data: Optional[
             
             if category in ('no_contact',):
                 # Not configured: no contact at all
-                result['validation_summary']['not_configured_count'] += 1
-                result['validation_summary']['not_configured_no_contact_count'] += 1
+                summary['not_configured_count'] += 1
+                summary['not_configured_no_contact_count'] += 1
                 relay_info['missing'] = 'No contact info'
                 result['not_configured_relays'].append(relay_info)
             elif category == 'no_aroi_info':
                 # Not configured: has contact but no AROI fields
-                result['validation_summary']['not_configured_count'] += 1
-                result['validation_summary']['not_configured_no_aroi_info_count'] += 1
+                summary['not_configured_count'] += 1
+                summary['not_configured_no_aroi_info_count'] += 1
                 relay_info['missing'] = 'Has contact, no AROI fields'
                 result['not_configured_relays'].append(relay_info)
+            elif category == 'v3_informational':
+                # CIISS v3 spec-legal: ciissversion:3 with informational
+                # fields and no url. NOT incomplete; treat as
+                # "not_configured" because there's no domain claim to
+                # validate against.
+                summary['not_configured_count'] += 1
+                summary['not_configured_no_aroi_info_count'] += 1
+                relay_info['missing'] = (
+                    "ciissversion:3 with no url (spec-legal informational only)"
+                )
+                # Surface the pasteable-example hint for operators who
+                # actually wanted a domain-bound AROI.
+                v3_info_label = V3_CATEGORY_LABELS.get('v3_informational', {})
+                _v3i_example = _render_pasteable_example(
+                    v3_info_label.get('example'), fingerprint, aroi_domain
+                )
+                relay_info['hint'] = _v3i_example
+                relay_info['pasteable_example'] = _v3i_example
+                relay_info['error_category'] = 'v3_informational'
+                result['not_configured_relays'].append(relay_info)
             else:
-                # Incomplete: has 1-2 AROI fields
-                result['has_aroi'] = True  # Has some AROI info
-                result['validation_summary']['incomplete_count'] += 1
-                
+                # Incomplete: 1-2 AROI fields, OR version/proof mismatch
+                result['has_aroi'] = True
+                summary['incomplete_count'] += 1
+
                 if category == 'no_proof':
-                    result['validation_summary']['incomplete_no_proof_count'] += 1
+                    summary['incomplete_no_proof_count'] += 1
                     relay_info['missing'] = 'Missing proof field (has domain + ciissversion)'
                 elif category == 'no_domain':
-                    result['validation_summary']['incomplete_no_domain_count'] += 1
+                    summary['incomplete_no_domain_count'] += 1
                     relay_info['missing'] = 'Missing domain/URL field (has proof + ciissversion)'
                 elif category == 'no_ciissversion':
-                    result['validation_summary']['incomplete_no_ciissversion_count'] += 1
+                    summary['incomplete_no_ciissversion_count'] += 1
                     relay_info['missing'] = 'Missing ciissversion (has proof + domain)'
                 elif category == 'missing_two_aroi':
-                    result['validation_summary']['incomplete_missing_two_count'] += 1
-                    # Identify which 2 fields are missing (only 1 is present)
+                    summary['incomplete_missing_two_count'] += 1
                     missing_fields = []
                     if not aroi_fields['has_proof']:
                         missing_fields.append('proof')
@@ -800,13 +1704,34 @@ def get_contact_validation_status(relays: List[Dict], validation_data: Optional[
                     if not aroi_fields['has_ciissversion']:
                         missing_fields.append('ciissversion')
                     relay_info['missing'] = f"Missing {' and '.join(missing_fields)}"
+                elif category == 'version_proof_mismatch':
+                    # Operator copy-paste error during migration. All 3
+                    # fields present but proof type doesn't match declared
+                    # ciissversion. Surface pasteable fix.
+                    summary['incomplete_version_proof_mismatch_count'] += 1
+                    relay_info['missing'] = (
+                        f"ciissversion:{aroi_fields.get('version')} declared but "
+                        f"proof:{aroi_fields.get('proof_type')} is for the "
+                        f"other version"
+                    )
+                    mismatch_label = V3_CATEGORY_LABELS.get('version_proof_mismatch', {})
+                    _vpm_example = _render_pasteable_example(
+                        mismatch_label.get('example'), fingerprint, aroi_domain
+                    )
+                    relay_info['hint'] = _vpm_example
+                    relay_info['pasteable_example'] = _vpm_example
+                    relay_info['error_category'] = 'version_proof_mismatch'
                 else:
                     relay_info['missing'] = 'Incomplete AROI configuration'
-                
+
                 result['incomplete_relays'].append(relay_info)
     
-    # Determine operator status using cascade logic
-    summary = result['validation_summary']
+    # Determine operator status using cascade logic. The peer issue
+    # categories (security_incident, pending_onionoo) DO NOT take
+    # precedence; they're rendered alongside whatever the cascade picks
+    # so a v3 operator with 1 leaked-key relay still gets "validated"
+    # cascade if their other relays validated. Templates are responsible
+    # for surfacing the peer alerts independently.
     if summary['validated_count'] > 0:
         result['validation_status'] = 'validated'
     elif summary['unauthorized_count'] > 0:
@@ -817,10 +1742,43 @@ def get_contact_validation_status(relays: List[Dict], validation_data: Optional[
         result['validation_status'] = 'incomplete'
     else:
         result['validation_status'] = 'not_configured'
-    
+
+    # A.5 operator-level migration metadata. Computed once, consumed by
+    # every B-phase surface (operator pill, leaderboard tier, search
+    # index, listing icons).
+    total_aroi_relays = summary['v2_relay_count'] + summary['v3_relay_count']
+    if total_aroi_relays > 0:
+        summary['v3_relay_percentage'] = (
+            summary['v3_relay_count'] / total_aroi_relays * 100
+        )
+    summary['is_mixed_migration'] = (
+        summary['v2_relay_count'] > 0 and summary['v3_relay_count'] > 0
+    )
+    # Tier classification uses TOTAL relay count so 1-of-50 is "explorer"
+    # not "complete" (matches plan's intent: recognise scale of effort).
+    summary['v3_tier'] = classify_v3_tier(
+        summary['v3_relay_count'], summary['total_relays']
+    )
+    summary['is_v3_adopter'] = (
+        summary['total_relays'] > 0
+        and summary['v3_relay_count'] / summary['total_relays']
+        >= V3_LISTING_ICON_THRESHOLD
+    )
+    # B1.1 (final): per-version success rates for v3_migration_summary
+    # success-rate pills. Mirrors the network-wide v2_success_rate /
+    # v3_success_rate emitted in the dashboard but at operator scope.
+    summary['v2_success_rate'] = _calc_percentage(
+        summary['v2_validated_count'], summary['v2_relay_count']
+    )
+    summary['v3_success_rate'] = _calc_percentage(
+        summary['v3_validated_count'], summary['v3_relay_count']
+    )
+
     # Build fingerprint sets for O(1) lookups in templates
     result['validated_fingerprints'] = {r['fingerprint'] for r in result['validated_relays']}
     result['unauthorized_fingerprints'] = {r['fingerprint'] for r in result['unauthorized_relays']}
     result['misconfigured_fingerprints'] = {r['fingerprint'] for r in result['misconfigured_relays']}
-    
+    result['security_incident_fingerprints'] = {r['fingerprint'] for r in result['security_incident_relays']}
+    result['pending_onionoo_fingerprints'] = {r['fingerprint'] for r in result['pending_onionoo_relays']}
+
     return result

--- a/allium/lib/aroi_validation.py
+++ b/allium/lib/aroi_validation.py
@@ -528,43 +528,52 @@ def _check_aroi_fields(contact: str) -> Dict:
             'version_proof_mismatch': False,
         }
 
-    # Supported version match. CIISS spec: keys MUST appear only once;
-    # re.search returns the FIRST match — matches upstream validator's
-    # "first wins" rule for duplicate fields.
-    ciiss_match = _CIISS_VERSION_RE.search(contact)
-    version = ciiss_match.group(1) if ciiss_match else None
-
-    # Detect (and remember) any unsupported ciissversion for one-time
-    # logging in A.8. We deliberately do NOT crash on these — older v1
-    # contacts and any future v4+ should be silently bucketed as
-    # "no AROI" until we explicitly support them.
-    if not version:
-        any_match = _CIISS_ANY_VERSION_RE.search(contact)
-        if any_match:
-            v = any_match.group(1)
-            if v not in SUPPORTED_CIISSVERSIONS and v not in _warned_unsupported_ciissversion:
-                _warned_unsupported_ciissversion.add(v)
+    # CIISS spec: keys MUST appear only once; if duplicates exist,
+    # FIRST wins (matches upstream validator).
+    #
+    # Reviewer-flagged: previous implementation searched with
+    # _CIISS_VERSION_RE first (matches only SUPPORTED versions: 2 or 3)
+    # and only fell back to _CIISS_ANY_VERSION_RE when no supported
+    # match existed. That hid the case where the FIRST declared token
+    # is unsupported (e.g. 'ciissversion:99 ciissversion:2 ...') —
+    # the supported-only search would skip the v99 and silently use
+    # v2, violating first-wins semantics.
+    #
+    # New logic: find the FIRST declared ciissversion regardless of
+    # support. If the first token is supported, use it. Otherwise log
+    # the unsupported value once (for A.8 observability) and leave
+    # version=None so the relay gets bucketed as "no AROI" until the
+    # operator fixes the contact string.
+    version = None
+    any_match = _CIISS_ANY_VERSION_RE.search(contact)
+    if any_match:
+        first_v = any_match.group(1)
+        if first_v in SUPPORTED_CIISSVERSIONS:
+            version = first_v
+        else:
+            if first_v not in _warned_unsupported_ciissversion:
+                _warned_unsupported_ciissversion.add(first_v)
                 logger.info(
                     "AROI: encountered unsupported ciissversion:%s — ignoring "
-                    "(supported: %s)", v, ','.join(SUPPORTED_CIISSVERSIONS)
+                    "(supported: %s)", first_v, ','.join(SUPPORTED_CIISSVERSIONS)
                 )
-                _record_warning('unsupported_ciissversion', v)
+                _record_warning('unsupported_ciissversion', first_v)
 
-    # Supported proof type match. Same first-wins semantics.
-    proof_match = _PROOF_TYPE_RE.search(contact)
-    proof_type = proof_match.group(1).lower() if proof_match else None
-
-    if not proof_type:
-        any_match = _PROOF_ANY_TYPE_RE.search(contact)
-        if any_match:
-            pt = any_match.group(1).lower()
-            if pt not in ALL_PROOF_TYPES and pt not in _warned_unsupported_proof_type:
-                _warned_unsupported_proof_type.add(pt)
+    # Same first-wins logic for proof_type.
+    proof_type = None
+    any_match = _PROOF_ANY_TYPE_RE.search(contact)
+    if any_match:
+        first_pt = any_match.group(1).lower()
+        if first_pt in ALL_PROOF_TYPES:
+            proof_type = first_pt
+        else:
+            if first_pt not in _warned_unsupported_proof_type:
+                _warned_unsupported_proof_type.add(first_pt)
                 logger.warning(
                     "AROI: unknown proof type '%s' — update ALL_PROOF_TYPES "
-                    "in aroi_validation.py to recognise new proof types", pt
+                    "in aroi_validation.py to recognise new proof types", first_pt
                 )
-                _record_warning('unsupported_proof_type', pt)
+                _record_warning('unsupported_proof_type', first_pt)
 
     has_url = bool(_URL_FIELD_RE.search(contact))
 
@@ -1682,14 +1691,19 @@ def get_contact_validation_status(relays: List[Dict], validation_data: Optional[
                 # fields and no url. NOT incomplete; treat as
                 # "not_configured" because there's no domain claim to
                 # validate against.
+                #
+                # Reviewer-flagged: a v3_informational relay HAS declared
+                # ciissversion:3 — it is NOT a zero-AROI-field contact.
+                # Set result['has_aroi'] = True so downstream code that
+                # filters on 'operators with any AROI declaration' sees
+                # these relays. Drop the not_configured_no_aroi_info_count
+                # bump (that bucket is reserved for relays with NO AROI
+                # fields at all). Keep the not_configured_count and
+                # incomplete_v3_informational_count bumps so the cascade
+                # still flags 'no domain claim to validate' but the
+                # dedicated counter accurately reflects v3-informational.
+                result['has_aroi'] = True
                 summary['not_configured_count'] += 1
-                summary['not_configured_no_aroi_info_count'] += 1
-                # Reviewer-flagged: also bump the dedicated counter so
-                # the validation_summary's incomplete_v3_informational_count
-                # field (initialised to 0 at construction time) reflects
-                # the actual number of v3-informational-only relays.
-                # Without this, the field was always 0 even when v3
-                # informational relays existed.
                 summary['incomplete_v3_informational_count'] += 1
                 relay_info['missing'] = (
                     "ciissversion:3 with no url (spec-legal informational only)"

--- a/allium/lib/aroileaders.py
+++ b/allium/lib/aroileaders.py
@@ -13,6 +13,8 @@ import html
 
 # Import centralized IP parsing from ip_utils (canonical home)
 from .ip_utils import safe_parse_ip_address as _safe_parse_ip_address
+# B4.1: shared classifier so leaderboard tier matches contact-page pill tier.
+from .aroi_validation import classify_v3_tier as _classify_v3_tier_local
 
 # Import centralized country utilities
 from .country_utils import (
@@ -501,6 +503,11 @@ def _collect_operator_metrics(relays_instance):
         validated_bandwidth = 0
         validated_consensus_weight = 0.0
         validated_countries = set()
+        # B4.1: per-version split (used by leaderboard tier badge + new columns)
+        validated_v2_relay_count = 0
+        validated_v3_relay_count = 0
+        v2_relay_count = 0  # ANY ciissversion:2 declaration (valid or not)
+        v3_relay_count = 0  # ANY ciissversion:3 declaration
         td_sums = {'1_month': 0, '6_months': 0, '1_year': 0, '5_years': 0}
         
         for relay in operator_relays:
@@ -571,6 +578,15 @@ def _collect_operator_metrics(relays_instance):
             
             # Validation tracking (merged into same loop)
             fp = relay.get('fingerprint')
+            # B4.1: tally per-version DECLARATIONS (any v2 or v3 contact)
+            # so we can compute v3_relay_percentage even for operators
+            # whose v3 relays haven't been validated yet.
+            relay_aroi_version = relay.get('aroi_version')
+            if relay_aroi_version == '2':
+                v2_relay_count += 1
+            elif relay_aroi_version == '3':
+                v3_relay_count += 1
+
             if fp in validation_map:
                 result = validation_map[fp]
                 if result.get('valid', False):
@@ -578,12 +594,20 @@ def _collect_operator_metrics(relays_instance):
                     validated_relay_count += 1
                     validated_bandwidth += relay_bandwidth
                     validated_consensus_weight += relay_consensus_weight
-                    
+
+                    # B4.1: per-version validated counts so the leaderboard
+                    # can show "v2: N validated, v3: N validated".
+                    val_version = result.get('ciissversion') or relay_aroi_version
+                    if val_version == '2':
+                        validated_v2_relay_count += 1
+                    elif val_version == '3':
+                        validated_v3_relay_count += 1
+
                     # Track country for validated relays
                     country = relay.get('country', '')
                     if country:
                         validated_countries.add(country)
-                    
+
                     # Count by role (Exit > Guard > Middle priority)
                     if 'Exit' in relay_flags:
                         validated_exit_count += 1
@@ -847,6 +871,16 @@ def _collect_operator_metrics(relays_instance):
             'validated_bandwidth': validated_bandwidth,
             'validated_consensus_weight': validated_consensus_weight,
             'validated_country_count': validated_country_count,
+
+            # === B4.1: v2/v3 migration metadata for tier badge + columns ===
+            'validated_v2_relay_count': validated_v2_relay_count,
+            'validated_v3_relay_count': validated_v3_relay_count,
+            'v2_relay_count': v2_relay_count,
+            'v3_relay_count': v3_relay_count,
+            'v3_relay_percentage': (
+                v3_relay_count / total_relays * 100 if total_relays > 0 else 0.0
+            ),
+            'v3_tier': _classify_v3_tier_local(v3_relay_count, total_relays),
             
             # === TOTAL DATA TRANSFERRED (NEW) ===
             'total_data_transferred': operator_total_data,
@@ -1317,6 +1351,15 @@ def _format_leaderboard_entries(leaderboards, aroi_operators, relays_instance):
                 'validated_consensus_weight': metrics['validated_consensus_weight'],
                 'validated_consensus_weight_pct': f"{metrics['validated_consensus_weight'] * 100:.2f}%",
                 'validated_country_count': metrics['validated_country_count'],
+
+                # === B4.1: v2/v3 migration metadata propagated to row dict ===
+                'validated_v2_relay_count': metrics['validated_v2_relay_count'],
+                'validated_v3_relay_count': metrics['validated_v3_relay_count'],
+                'v2_relay_count': metrics['v2_relay_count'],
+                'v3_relay_count': metrics['v3_relay_count'],
+                'v3_relay_percentage': metrics['v3_relay_percentage'],
+                'v3_relay_pct_str': f"{metrics['v3_relay_percentage']:.0f}%",
+                'v3_tier': metrics['v3_tier'],
                 
                 # === TOTAL DATA TRANSFERRED (NEW) ===
                 'total_data_transferred': formatted_total_data_transferred,

--- a/allium/lib/categorization.py
+++ b/allium/lib/categorization.py
@@ -256,6 +256,21 @@ def sort_relay(relay_set, relay, idx, k, v, cw, cw_fraction):
         relay_set.json["sorted"][k][v]["contact"] = relay.get("contact", "")
         relay_set.json["sorted"][k][v]["contact_md5"] = relay.get("contact_md5", "")
         relay_set.json["sorted"][k][v]["aroi_domain"] = relay.get("aroi_domain", "")
+
+        # Item 3 (variant-aware list views): track distinct raw ContactInfo
+        # strings per contact group so list-view tooltips can stop showing
+        # one representative string and instead say "N distinct ContactInfo
+        # strings — see operator page". A single set.add() per relay is
+        # the cheapest way to count without a second pass; we keep it
+        # ONLY for contact groups (the only listing where the operator-
+        # detail page is the authoritative variant view).
+        if k == "contact":
+            cv_set = relay_set.json["sorted"][k][v].get("_contact_variant_set")
+            if cv_set is None:
+                cv_set = set()
+                relay_set.json["sorted"][k][v]["_contact_variant_set"] = cv_set
+            cv_set.add(relay.get("contact", "") or "")
+            relay_set.json["sorted"][k][v]["contact_variant_count"] = len(cv_set)
         
         # Track country counts for contacts (primary country calculation)
         # relay["country"] is already UPPERCASE from _preprocess_template_data()

--- a/allium/lib/categorization.py
+++ b/allium/lib/categorization.py
@@ -271,6 +271,13 @@ def sort_relay(relay_set, relay, idx, k, v, cw, cw_fraction):
                 relay_set.json["sorted"][k][v]["_contact_variant_set"] = cv_set
             cv_set.add(relay.get("contact", "") or "")
             relay_set.json["sorted"][k][v]["contact_variant_count"] = len(cv_set)
+            # NOTE: _contact_variant_set is a Python set — not JSON-
+            # serialisable. It's removed by calculate_contact_derived_data()
+            # in a single finalisation pass after categorisation completes,
+            # so the long-lived sorted.contact data structure never carries
+            # the live set. Keeping it ONLY across the categorisation loop
+            # is what lets us count distinct contacts in O(N) without
+            # rescanning members.
         
         # Track country counts for contacts (primary country calculation)
         # relay["country"] is already UPPERCASE from _preprocess_template_data()
@@ -690,6 +697,13 @@ def calculate_contact_derived_data(relay_set):
             
         # Clean up temporary country_counts to save memory
         del contact_data["country_counts"]
+
+        # Drop the temporary _contact_variant_set inserted by sort_relay()
+        # so downstream code can json.dumps(sorted.contact) — Python sets
+        # are not JSON-serialisable. The accumulated count survives in
+        # contact_data["contact_variant_count"]; the set itself is no
+        # longer needed.
+        contact_data.pop("_contact_variant_set", None)
         
         # BANDWIDTH MEANS CALCULATION (optimized from _calculate_bandwidth_means)
         relays = contact_data.get("relays", [])

--- a/allium/lib/network_health.py
+++ b/allium/lib/network_health.py
@@ -252,20 +252,93 @@ def _integrate_aroi_validation(health_metrics, relay_set, total_relays_count):
     Extracted from calculate_network_health_metrics for readability.
     """
     try:
-        from .aroi_validation import calculate_aroi_validation_metrics
-        
+        from .aroi_validation import (
+            calculate_aroi_validation_metrics,
+            check_schema_version,
+            _log_aroi_build_summary,
+        )
+
         # Get pre-fetched validation data (attached by coordinator)
         validation_data = getattr(relay_set, 'aroi_validation_data', None)
-        
-        # Calculate validation metrics (relay AND operator level in single pass)
-        validation_metrics = calculate_aroi_validation_metrics(
-            relay_set.json.get('relays', []), 
-            validation_data,
-            calculate_operator_metrics=True
+
+        # Phase 2.2: cache AROI validation metrics across multiple
+        # _calculate_network_health_metrics() invocations within a
+        # single build. The metrics are derived from
+        # aroi_validation_data + relay aroi_domain/version/proof_type
+        # fields, neither of which changes between the
+        # uptime/bandwidth/dns-health enrichment phases. Recomputing
+        # them ~4× per build (matching the number of
+        # _calculate_network_health_metrics calls in
+        # Relays.enrich_with_api_data) wastes work and produces
+        # duplicate build-summary log lines.
+        _cached = getattr(relay_set, '_aroi_metrics_cache', None)
+        # Cache key: id of validation_data (changes only when the
+        # upstream data is replaced, never within a build).
+        _cache_key = id(validation_data) if validation_data is not None else 0
+        if _cached is not None and _cached.get('cache_key') == _cache_key:
+            # Cache hit — reuse previously-computed metrics.
+            validation_metrics = _cached['metrics']
+            schema_version = _cached['schema_version']
+            health_metrics['aroi_schema_version'] = schema_version
+            # NOTE: deliberately skip _log_aroi_build_summary on cache
+            # hits to satisfy Phase 2.3 (dedup the duplicate build log).
+        else:
+            # Cache miss — compute fresh.
+
+            # Schema-version handshake: warn once on unknown schemas;
+            # expose the version downstream so the dashboard can render
+            # a footnote. progress_logger may be a ProgressLogger
+            # instance (with .log()) or None — wrap into a plain
+            # callable so check_schema_version /
+            # _log_aroi_build_summary can stay logger-agnostic.
+            _logger_obj = getattr(relay_set, 'progress_logger', None)
+            if _logger_obj is not None and hasattr(_logger_obj, 'log'):
+                log_callable = lambda m: _logger_obj.log(m, increment_step=False)
+            elif relay_set.progress:
+                log_callable = print
+            else:
+                log_callable = None
+            schema_version = check_schema_version(validation_data, log_callable)
+            health_metrics['aroi_schema_version'] = schema_version
+
+            # Calculate validation metrics (relay AND operator level in single pass)
+            validation_metrics = calculate_aroi_validation_metrics(
+                relay_set.json.get('relays', []),
+                validation_data,
+                calculate_operator_metrics=True
+            )
+            # Forward schema version into metrics so the build-summary log
+            # references it.
+            validation_metrics['aroi_schema_version'] = schema_version
+
+            # A.8: emit build-time summary line — only on first compute.
+            _log_aroi_build_summary(validation_metrics, log_callable)
+
+            # Pop _validation_map BEFORE caching so the cached metrics
+            # dict is the "clean" one that gets merged into health_metrics
+            # downstream (the same as before Phase 2 caching). Cache the
+            # validation_map separately for restoration on cache hits.
+            _validation_map = validation_metrics.pop('_validation_map', {}) or {}
+
+            # Cache for subsequent calls.
+            relay_set._aroi_metrics_cache = {
+                'cache_key': _cache_key,
+                'metrics': validation_metrics,
+                'schema_version': schema_version,
+                'validation_map': _validation_map,
+            }
+
+        # Store validation_map for reuse by contact pages. On the first
+        # call we populated it from the freshly-computed metrics dict
+        # above; on subsequent cache hits we restore from the cache.
+        # WITHOUT this restore step, the cache-hit path was overwriting
+        # relay_set.validation_map with {} (the .pop() default), which
+        # then made every contact-page validation lookup return "not in
+        # map" → all relays rendering as 0% valid even when upstream
+        # said 100% valid. Fixed in commit following 119687b33e.
+        relay_set.validation_map = relay_set._aroi_metrics_cache.get(
+            'validation_map', {}
         )
-        
-        # Store validation_map for reuse by contact pages (avoids rebuilding 3,000+ times)
-        relay_set.validation_map = validation_metrics.pop('_validation_map', {})
         
         # Add validation metrics to health_metrics
         health_metrics.update(validation_metrics)
@@ -313,12 +386,20 @@ def _integrate_aroi_validation(health_metrics, relay_set, total_relays_count):
         # Get IPv6 status dict from earlier calculation
         operator_ipv6_status = health_metrics.pop('_temp_operator_ipv6_status', {})
         
-        # Count IPv6 support ONLY among validated operators (mutually exclusive)
-        both_ipv4_ipv6_aroi_operators = sum(1 for domain in validated_domain_set 
-                                        if domain in operator_ipv6_status and operator_ipv6_status[domain]['has_dual_stack'])
-        ipv4_only_aroi_operators = sum(1 for domain in validated_domain_set
-                                   if domain in operator_ipv6_status and not operator_ipv6_status[domain]['has_dual_stack'] and operator_ipv6_status[domain]['has_ipv4_only'])
-        
+        # Count IPv6 support among validated operators (mutually exclusive
+        # buckets). Single-pass loop over validated_domain_set to avoid
+        # walking the same set twice (item C in optimization feedback).
+        both_ipv4_ipv6_aroi_operators = 0
+        ipv4_only_aroi_operators = 0
+        for domain in validated_domain_set:
+            status = operator_ipv6_status.get(domain)
+            if not status:
+                continue
+            if status.get('has_dual_stack'):
+                both_ipv4_ipv6_aroi_operators += 1
+            elif status.get('has_ipv4_only'):
+                ipv4_only_aroi_operators += 1
+
         health_metrics['ipv4_only_aroi_operators'] = ipv4_only_aroi_operators
         health_metrics['both_ipv4_ipv6_aroi_operators'] = both_ipv4_ipv6_aroi_operators
         
@@ -340,23 +421,39 @@ def _integrate_aroi_validation(health_metrics, relay_set, total_relays_count):
             health_metrics['avg_relays_per_aroi_operator'] = 0.0
                 
     except Exception as e:
-        # Graceful fallback if validation data unavailable
+        # Graceful fallback if validation data unavailable. Templates
+        # iterate over per-proof-type keys, so we must seed all of them
+        # (4 proof types * 3 stats = 12 keys) even when the metrics
+        # path errored out.
         if relay_set.progress:
             print(f"⚠️  AROI Validation: Error loading data: {e}")
-        health_metrics.update({
+        from .aroi_validation import PROOF_TYPE_STAT_KEYS
+        fallback = {
             'aroi_validated_count': 0,
             'aroi_unvalidated_count': 0,
             'aroi_no_proof_count': 0,
+            'aroi_no_domain_count': 0,
+            'aroi_no_ciissversion_count': 0,
             'relays_no_aroi': 0,
+            'relays_no_contact': 0,
+            'relays_no_aroi_info': 0,
+            'relays_missing_two_aroi': 0,
+            'relays_version_proof_mismatch': 0,
+            'relays_v3_informational': 0,
             'relays_without_aroi': total_relays_count,
             'relays_without_aroi_percentage': 100.0 if total_relays_count > 0 else 0.0,
             'aroi_validated_percentage': 0.0,
             'aroi_unvalidated_percentage': 0.0,
             'aroi_no_proof_percentage': 0.0,
+            'aroi_no_domain_percentage': 0.0,
+            'aroi_no_ciissversion_percentage': 0.0,
+            'relays_no_contact_percentage': 0.0,
+            'relays_no_aroi_info_percentage': 0.0,
+            'relays_missing_two_aroi_percentage': 0.0,
+            'relays_version_proof_mismatch_percentage': 0.0,
+            'relays_v3_informational_percentage': 0.0,
             'relays_no_aroi_percentage': 0.0,
             'aroi_validation_success_rate': 0.0,
-            'dns_rsa_success_rate': 0.0,
-            'uri_rsa_success_rate': 0.0,
             'validation_data_available': False,
             'total_relays_with_aroi': 0,
             'total_relays_with_aroi_percentage': 0.0,
@@ -377,8 +474,24 @@ def _integrate_aroi_validation(health_metrics, relay_set, total_relays_count):
             'ipv4_only_aroi_operators': 0,
             'both_ipv4_ipv6_aroi_operators': 0,
             'ipv4_only_aroi_operators_percentage': 0.0,
-            'both_ipv4_ipv6_aroi_operators_percentage': 0.0
-        })
+            'both_ipv4_ipv6_aroi_operators_percentage': 0.0,
+            'aroi_schema_version': None,
+            # v2/v3 aggregates and adoption (added in A.3)
+            'v2_total': 0, 'v2_valid': 0, 'v2_success_rate': 0.0,
+            'v3_total': 0, 'v3_valid': 0, 'v3_success_rate': 0.0,
+            'ciissversion_declared': {},
+            'ciissversion_validated': {},
+            'v3_failure_categories': {},
+            'error_rollup_shared': [],
+            'error_rollup_v2_only': [],
+            'error_rollup_v3_only': [],
+        }
+        # Seed per-proof-type keys for ALL known proof types (4 today).
+        for stat_key in PROOF_TYPE_STAT_KEYS:
+            fallback[f'{stat_key}_total'] = 0
+            fallback[f'{stat_key}_valid'] = 0
+            fallback[f'{stat_key}_success_rate'] = 0.0
+        health_metrics.update(fallback)
 
 
 def _integrate_exit_dns_health(health_metrics, relay_set):

--- a/allium/lib/network_health.py
+++ b/allium/lib/network_health.py
@@ -434,7 +434,16 @@ def _integrate_aroi_validation(health_metrics, relay_set, total_relays_count):
         # path errored out.
         if relay_set.progress:
             print(f"⚠️  AROI Validation: Error loading data: {e}")
-        from .aroi_validation import PROOF_TYPE_STAT_KEYS
+        # Protect the fallback import too — the original error may have
+        # been raised from inside aroi_validation itself, in which case
+        # re-importing here would re-raise and skip the rest of the
+        # zeroed fallback. Default PROOF_TYPE_STAT_KEYS to () so the
+        # subsequent comprehension simply produces no per-proof-type
+        # entries (callers tolerate missing keys via .get() with 0).
+        try:
+            from .aroi_validation import PROOF_TYPE_STAT_KEYS
+        except Exception:
+            PROOF_TYPE_STAT_KEYS = ()
         fallback = {
             'aroi_validated_count': 0,
             'aroi_unvalidated_count': 0,

--- a/allium/lib/network_health.py
+++ b/allium/lib/network_health.py
@@ -293,7 +293,14 @@ def _integrate_aroi_validation(health_metrics, relay_set, total_relays_count):
             # _log_aroi_build_summary can stay logger-agnostic.
             _logger_obj = getattr(relay_set, 'progress_logger', None)
             if _logger_obj is not None and hasattr(_logger_obj, 'log'):
-                log_callable = lambda m: _logger_obj.log(m, increment_step=False)
+                # Wrap the ProgressLogger.log(msg, increment_step=False)
+                # call in a named function instead of a lambda — Ruff E731
+                # flags the lambda assignment, and a def is just as
+                # readable while playing nicer with traceback output if
+                # the wrapped call ever raises.
+                def _progress_log(m, _logger=_logger_obj):
+                    _logger.log(m, increment_step=False)
+                log_callable = _progress_log
             elif relay_set.progress:
                 log_callable = print
             else:

--- a/allium/lib/operator_analysis.py
+++ b/allium/lib/operator_analysis.py
@@ -120,15 +120,20 @@ def _build_contact_rankings_index(relay_set):
 def _get_contact_rankings_index(relay_set):
     """Lazy-build and cache the rankings index on the relay_set.
 
-    The cache key is the id() of the leaderboards object — invalidates
-    automatically if leaderboards are recomputed mid-build (defensive,
-    in practice they're built once and then read-only).
+    Cache key is a deterministic monotonic counter
+    (relay_set.leaderboards_version) instead of id(leaderboards_obj).
+    Reviewer-flagged: id()-based keys can theoretically collide if an
+    old leaderboards dict is GC'd and a new one happens to land at the
+    same memory address. Switching to a monotonic counter makes
+    invalidation explicit: every code path that rebuilds or replaces
+    aroi_leaderboards (the only call site is _generate_aroi_leaderboards
+    in relays.py) bumps relay_set.leaderboards_version, which guarantees
+    the cached index is rebuilt from the fresh leaderboards.
     """
-    leaderboards_obj = (
-        relay_set.json.get('aroi_leaderboards', {}).get('leaderboards', {})
-        if hasattr(relay_set, 'json') else None
-    )
-    cache_key = id(leaderboards_obj) if leaderboards_obj is not None else 0
+    if not hasattr(relay_set, 'json') or not relay_set.json.get('aroi_leaderboards'):
+        cache_key = 0
+    else:
+        cache_key = getattr(relay_set, 'leaderboards_version', 0)
 
     cached = getattr(relay_set, '_contact_rankings_index_cache', None)
     if cached is not None and cached.get('key') == cache_key:

--- a/allium/lib/operator_analysis.py
+++ b/allium/lib/operator_analysis.py
@@ -654,9 +654,11 @@ def compute_contact_display_data(i, bandwidth_unit, operator_reliability, v, mem
         td_sums['5_years'] += td.get('5_years', 0)
 
     # Sort variants by count desc, then raw string for stable output.
+    # Lambda parameter is renamed from 'v' to 'variant' to avoid shadowing
+    # the outer 'v' (contact_hash) function parameter.
     contact_variants = sorted(
         variants.values(),
-        key=lambda v: (-v['count'], v['raw']),
+        key=lambda variant: (-variant['count'], variant['raw']),
     )
     display_data['contact_variants'] = contact_variants
     display_data['contact_variant_count'] = len(contact_variants)

--- a/allium/lib/operator_analysis.py
+++ b/allium/lib/operator_analysis.py
@@ -23,46 +23,151 @@ from .bandwidth_utils import (
 )
 
 
+def _build_contact_rankings_index(relay_set):
+    """Build a contact_hash -> rankings list dict in a SINGLE pass over the
+    leaderboard categories.
+
+    Optimization (item A from feedback): the legacy
+    generate_contact_rankings(contact_hash, relay_set) scans every
+    category × every top-25 entry per contact, costing
+    O(N_contacts * N_categories * 25). For ~3,000 contacts × ~14
+    categories that's ~1M iterations of category scanning per build,
+    even though the underlying leaderboard data only changes once
+    when the leaderboards are computed.
+
+    This helper inverts the iteration: ONE pass over (category, top-25
+    entries) builds the full {contact_hash: [ranking dict, ...]} map.
+    Each contact's rankings list is already pre-sorted by rank ascending
+    because we visit ranks 1..25 in order.
+
+    Returns:
+        dict: contact_hash -> list of ranking dicts (same shape as the
+              legacy output)
+    """
+    if not hasattr(relay_set, 'json') or not relay_set.json.get('aroi_leaderboards'):
+        return {}
+
+    leaderboards = relay_set.json['aroi_leaderboards'].get('leaderboards', {})
+    # Cache get_leaderboard_category_info() results — same category info
+    # is reused across all contacts that win that category.
+    _category_info_cache = {}
+
+    def _category_info(category):
+        info = _category_info_cache.get(category)
+        if info is None:
+            info = get_leaderboard_category_info(category)
+            _category_info_cache[category] = info
+        return info
+
+    index = {}
+    for category, leaders in leaderboards.items():
+        # Bind once per category to avoid repeated dict lookups inside
+        # the inner loop.
+        info = _category_info(category)
+        category_name = info['name']
+        emoji = info['emoji']
+        title = info['title']
+        link = f"aroi-leaderboards.html#{category}"
+
+        # P2 (legacy-parity dedupe): the legacy
+        # generate_contact_rankings() called `break` after the first
+        # match per (contact, category) so a malformed leaderboard
+        # repeating the same contact within one category never
+        # produced duplicate rankings. Mirror that contract here with
+        # a per-category seen-set; the FIRST (lowest rank) occurrence
+        # wins because we visit in rank-ascending order.
+        seen_in_category = set()
+
+        for rank, entry in enumerate(leaders, 1):
+            if rank > 25:
+                # Same cap as the legacy implementation. Stop early.
+                break
+            # Entry can be a dict (formatted) or a (contact_hash, data)
+            # tuple — handle both shapes.
+            if isinstance(entry, dict):
+                leader_contact = entry.get('contact_hash')
+            else:
+                leader_contact = entry[0] if entry else None
+            if not leader_contact:
+                continue
+            if leader_contact in seen_in_category:
+                # Legacy `break`-after-first-match equivalent for the
+                # corner case where one contact appears multiple times
+                # in the SAME category's top-25.
+                continue
+            seen_in_category.add(leader_contact)
+
+            ranking = {
+                'category': category,
+                'category_name': category_name,
+                'rank': rank,
+                'emoji': emoji,
+                'title': title,
+                'statement': f"#{rank} {category_name}",
+                'link': link,
+            }
+            bucket = index.setdefault(leader_contact, [])
+            bucket.append(ranking)
+
+    # Each contact's bucket is sorted by category-iteration order; the
+    # legacy implementation sorted by rank ascending. Apply the same
+    # final sort to preserve identical output for downstream templates.
+    for rankings in index.values():
+        rankings.sort(key=lambda x: x['rank'])
+    return index
+
+
+def _get_contact_rankings_index(relay_set):
+    """Lazy-build and cache the rankings index on the relay_set.
+
+    The cache key is the id() of the leaderboards object — invalidates
+    automatically if leaderboards are recomputed mid-build (defensive,
+    in practice they're built once and then read-only).
+    """
+    leaderboards_obj = (
+        relay_set.json.get('aroi_leaderboards', {}).get('leaderboards', {})
+        if hasattr(relay_set, 'json') else None
+    )
+    cache_key = id(leaderboards_obj) if leaderboards_obj is not None else 0
+
+    cached = getattr(relay_set, '_contact_rankings_index_cache', None)
+    if cached is not None and cached.get('key') == cache_key:
+        return cached['index']
+
+    index = _build_contact_rankings_index(relay_set)
+    relay_set._contact_rankings_index_cache = {
+        'key': cache_key,
+        'index': index,
+    }
+    return index
+
+
 def generate_contact_rankings(contact_hash, relay_set):
     """
     Generate AROI leaderboard rankings for a specific contact hash.
     Returns list of ranking achievements for display on contact pages.
+
+    Uses the precomputed contact_hash -> rankings index from
+    _get_contact_rankings_index. The first call per build does the
+    full O(N_categories * 25) walk; subsequent calls are O(1) per
+    contact (dict lookup + list/dict copy).
+
+    Mutation-safety contract (P1):
+      Callers receive a fresh list AND fresh dict copies of each
+      ranking, so neither list-level nor dict-level mutation can
+      leak back into the cached index. Cost: ~14 small dict copies
+      per call worst-case (one per ranking); cheap relative to the
+      template render that consumes them.
     """
     if not hasattr(relay_set, 'json') or not relay_set.json.get('aroi_leaderboards'):
         return []
-    
-    leaderboards = relay_set.json['aroi_leaderboards'].get('leaderboards', {})
-    rankings = []
-    
-    # Check each leaderboard category for this contact
-    for category, leaders in leaderboards.items():
-        for rank, entry in enumerate(leaders, 1):
-            # Handle both formatted entries (dict) and raw tuples
-            if isinstance(entry, dict):
-                leader_contact = entry.get('contact_hash')
-            else:
-                # Handle tuple format (leader_contact, data)
-                leader_contact, data = entry
-            
-            if leader_contact == contact_hash:
-                # Only show top 25 rankings
-                if rank <= 25:
-                    category_info = get_leaderboard_category_info(category)
-                    rankings.append({
-                        'category': category,
-                        'category_name': category_info['name'],
-                        'rank': rank,
-                        'emoji': category_info['emoji'],
-                        'title': category_info['title'],
-                        'statement': f"#{rank} {category_info['name']}",
-                        'link': f"aroi-leaderboards.html#{category}"
-                    })
-                break
-    
-    # Sort rankings by rank (1st place first, 25th place last)
-    rankings.sort(key=lambda x: x['rank'])
-    
-    return rankings
+    index = _get_contact_rankings_index(relay_set)
+    cached = index.get(contact_hash, [])
+    # P1: shallow-copy each ranking dict so dict-level mutation
+    # (e.g. callers adding a 'highlighted: True' flag) doesn't
+    # reach the cached index. Each ranking is a flat dict of
+    # primitives — shallow copy is sufficient (no nested objects).
+    return [dict(r) for r in cached]
 
 def get_leaderboard_category_info(category):
     """
@@ -512,20 +617,59 @@ def compute_contact_display_data(i, bandwidth_unit, operator_reliability, v, mem
         dict: Contact-specific display data for template rendering
     """
     display_data = {}
-    
-    # 1. Bandwidth breakdown by role
-    display_data['bandwidth_breakdown'] = _format_bandwidth_breakdown(i, bandwidth_unit, relay_set)
-    
-    # 2. Consensus weight breakdown by role
-    display_data['consensus_weight_breakdown'] = _format_cw_breakdown(i)
-    
-    # 2b. Total data transferred (single-pass period sums + best-period selection)
-    from .bandwidth_formatter import format_data_volume_with_unit, compute_total_data_pct, pick_best_period
+
+    # 0+2b. Single-pass over members[] for BOTH:
+    #   - source-faithful ContactInfo variants (Phase 1) — distinct raw
+    #     contact strings + per-string relay count + parsed version/proof
+    #   - total_data sums per period (1mo / 6mo / 1y / 5y)
+    #
+    # Optimization (item B): merging the two former passes eliminates a
+    # second iteration over every relay in the operator. For ~3,000
+    # operators × an average of ~3 relays each, that's ~9k fewer dict
+    # lookups; for the largest operators (1aeo.com with 952 relays)
+    # the saving is ~952 dict accesses per page render.
+    variants = {}
     td_sums = {'1_month': 0, '6_months': 0, '1_year': 0, '5_years': 0}
     for r in members:
+        # Variant collection
+        raw = r.get('contact', '') or ''
+        v_entry = variants.get(raw)
+        if v_entry is None:
+            variants[raw] = {
+                'raw': raw,
+                'count': 1,
+                'aroi_version': r.get('aroi_version'),
+                'aroi_proof_type': r.get('aroi_proof_type'),
+                'aroi_domain': r.get('aroi_domain') or 'none',
+                'has_complete_aroi': bool(r.get('aroi_configured')),
+            }
+        else:
+            v_entry['count'] += 1
+
+        # Total-data period sums (folded in from the former second loop)
         td = r.get('total_data', {})
-        for p in td_sums:
-            td_sums[p] += td.get(p, 0)
+        td_sums['1_month'] += td.get('1_month', 0)
+        td_sums['6_months'] += td.get('6_months', 0)
+        td_sums['1_year'] += td.get('1_year', 0)
+        td_sums['5_years'] += td.get('5_years', 0)
+
+    # Sort variants by count desc, then raw string for stable output.
+    contact_variants = sorted(
+        variants.values(),
+        key=lambda v: (-v['count'], v['raw']),
+    )
+    display_data['contact_variants'] = contact_variants
+    display_data['contact_variant_count'] = len(contact_variants)
+
+    # 1. Bandwidth breakdown by role
+    display_data['bandwidth_breakdown'] = _format_bandwidth_breakdown(i, bandwidth_unit, relay_set)
+
+    # 2. Consensus weight breakdown by role
+    display_data['consensus_weight_breakdown'] = _format_cw_breakdown(i)
+
+    # 2b. Total data transferred — best-period selection from the sums
+    # we already accumulated in the merged pass above.
+    from .bandwidth_formatter import format_data_volume_with_unit, compute_total_data_pct, pick_best_period
     td_total, td_period = pick_best_period(td_sums)
     display_data['total_data_formatted'] = format_data_volume_with_unit(td_total)
     net_by_period = relay_set.json.get('network_health', {}).get('network_total_data_by_period', {}) if hasattr(relay_set, 'json') else {}

--- a/allium/lib/page_writer.py
+++ b/allium/lib/page_writer.py
@@ -467,6 +467,15 @@ def write_misc(
                 contact_data["aroi_validation_status"] = validation_status["validation_status"]
                 # Store full validation status for operator pages to reuse
                 contact_data["aroi_validation_full"] = validation_status
+                # B1.6: surface peer-issue counts + v3 tier on the listing
+                # row so misc-contacts.html can render \U0001f6a8 / \u23f3 / \U0001f3c6
+                # markers without re-loading the full validation_status.
+                _summary = validation_status.get('validation_summary', {}) or {}
+                contact_data['aroi_security_count'] = _summary.get('security_incident_count', 0)
+                contact_data['aroi_pending_count'] = _summary.get('pending_onionoo_count', 0)
+                contact_data['aroi_v3_tier'] = _summary.get('v3_tier', 'none')
+                contact_data['aroi_is_v3_adopter'] = _summary.get('is_v3_adopter', False)
+                contact_data['aroi_v3_pct'] = _summary.get('v3_relay_percentage', 0.0)
     
     # Pre-compute family statistics for misc-families templates
     template_vars = {
@@ -487,6 +496,29 @@ def write_misc(
             'large_family_count': 0
         })
         template_vars.update(family_stats)
+
+        # B5.2: precompute v3 tier per family so misc-families.html can
+        # render a tier badge inline. Compute once here (vs. doing it
+        # in the template loop) — ~6,300 families × 1 tier classifier
+        # call beats inline Jinja arithmetic, and matches the
+        # precompute pattern already used for misc-contacts.
+        from .aroi_validation import classify_v3_tier
+        all_relays_list = relay_set.json.get('relays', [])
+        for fam_hash, fam_data in (relay_set.json.get('sorted', {})
+                                                  .get('family', {}).items()):
+            if 'aroi_v3_tier' in fam_data:
+                continue  # already computed
+            relay_idxs = fam_data.get('relays', [])
+            total = len(relay_idxs)
+            if total == 0:
+                fam_data['aroi_v3_tier'] = 'none'
+                fam_data['aroi_v3_pct'] = 0.0
+                continue
+            v3 = sum(1 for ix in relay_idxs
+                     if ix < len(all_relays_list)
+                     and all_relays_list[ix].get('aroi_version') == '3')
+            fam_data['aroi_v3_tier'] = classify_v3_tier(v3, total)
+            fam_data['aroi_v3_pct'] = (v3 / total * 100) if total else 0.0
     elif template.name == "misc-authorities.html":
         # Reuse existing authority uptime data from consolidated processing
         authorities_data = get_directory_authorities_data(relay_set)

--- a/allium/lib/prometheus_metrics.py
+++ b/allium/lib/prometheus_metrics.py
@@ -170,7 +170,7 @@ def _build_aroi_relay_rows(relays: List[dict], fp_to_family: Callable[[str], str
     state_counts = {state: 0 for state in _AROI_STATE_VALUES}
     configured_count = 0
     # B7.1: per-version state count (state, ciissversion) -> count.
-    # Cardinality bounded: |state| × |ciissversion| ≤ 4 × 5 = 20 series.
+    # Cardinality bounded: |state| x |ciissversion| <= 4 x 5 = 20 series.
     version_state_counts: Dict[tuple, int] = {}
 
     for relay in sorted(relays, key=lambda r: r.get("fingerprint", "")):
@@ -546,7 +546,7 @@ def _write_aroi_section(lines: _LineAppender, relay_set,
 
     # B7.2: New aggregate metric — per-version split of state counts so
     # dashboards can chart migration progress without scraping label
-    # cardinality. Cardinality bound: 4 states × 5 ciissversion values
+    # cardinality. Cardinality bound: 4 states x 5 ciissversion values
     # = 20 series (plus the 4 we already have, = 24 max).
     _emit_help_type(lines, "aeo1_aroi_relays_count_by_version",
                     "Relay count by AROI state and declared ciissversion. "

--- a/allium/lib/prometheus_metrics.py
+++ b/allium/lib/prometheus_metrics.py
@@ -169,6 +169,9 @@ def _build_aroi_relay_rows(relays: List[dict], fp_to_family: Callable[[str], str
     rows = []
     state_counts = {state: 0 for state in _AROI_STATE_VALUES}
     configured_count = 0
+    # B7.1: per-version state count (state, ciissversion) -> count.
+    # Cardinality bounded: |state| × |ciissversion| ≤ 4 × 5 = 20 series.
+    version_state_counts: Dict[tuple, int] = {}
 
     for relay in sorted(relays, key=lambda r: r.get("fingerprint", "")):
         fp = relay.get("fingerprint", "")
@@ -196,7 +199,34 @@ def _build_aroi_relay_rows(relays: List[dict], fp_to_family: Callable[[str], str
             domain = aroi_entry.get("domain", "") or relay_domain
             proof_type = aroi_entry.get("proof_type", "")
 
+        # B7.1: derive ciissversion + proof_type_family for new labels.
+        # Bounded enums to keep label cardinality flat:
+        #   ciissversion       ∈ {none, 2, 3, unknown}
+        #   proof_type_family  ∈ {none, rsa, familyid, unknown}
+        relay_version = relay.get("aroi_version")
+        if relay_version in ("2", "3"):
+            ciissversion_label = relay_version
+        elif relay_version is None and not configured:
+            ciissversion_label = "none"
+        else:
+            ciissversion_label = "unknown"
+
+        # Prefer validator's reported proof_type when present; fall back to
+        # locally-parsed aroi_proof_type from _simple_aroi_parsing.
+        effective_pt = proof_type or relay.get("aroi_proof_type") or ""
+        if not effective_pt:
+            proof_type_family = "none"
+        elif effective_pt in ("dns-rsa", "uri-rsa"):
+            proof_type_family = "rsa"
+        elif effective_pt in ("dns-familyid-ed25519", "uri-familyid-ed25519"):
+            proof_type_family = "familyid"
+        else:
+            proof_type_family = "unknown"
+
         state_counts[state] += 1
+        version_state_counts[(state, ciissversion_label)] = (
+            version_state_counts.get((state, ciissversion_label), 0) + 1
+        )
         rows.append({
             "fingerprint": fp,
             "familyid": familyid,
@@ -205,9 +235,11 @@ def _build_aroi_relay_rows(relays: List[dict], fp_to_family: Callable[[str], str
             "configured": configured,
             "domain": domain,
             "proof_type": proof_type,
+            "ciissversion": ciissversion_label,
+            "proof_type_family": proof_type_family,
         })
 
-    return rows, state_counts, configured_count
+    return rows, state_counts, configured_count, version_state_counts
 
 
 def _get_verified_aroi(relay: dict, aroi_map: Dict[str, dict],
@@ -488,16 +520,21 @@ def _write_aroi_section(lines: _LineAppender, relay_set,
 
     # --- Relay-state classification (single pass precompute) ---
     all_relays = relay_set.json.get("relays", [])
-    relay_rows, state_counts, configured_count = _build_aroi_relay_rows(
-        all_relays, fp_to_family, aroi_map)
+    relay_rows, state_counts, configured_count, version_state_counts = (
+        _build_aroi_relay_rows(all_relays, fp_to_family, aroi_map)
+    )
 
     _emit_help_type(lines, "aeo1_aroi_relay_state",
-                    "Canonical AROI relay state in schema v2 (always 1 for emitted state)")
+                    "Canonical AROI relay state in schema v2 (always 1 for emitted state). "
+                    "ciissversion ∈ {none,2,3,unknown}; proof_type_family ∈ {none,rsa,familyid,unknown}")
     for row in relay_rows:
         _emit(lines, "aeo1_aroi_relay_state", {
             "fingerprint": row["fingerprint"],
             "familyid": row["familyid"],
             "state": row["state"],
+            # B7.1: bounded-cardinality version labels.
+            "ciissversion": row["ciissversion"],
+            "proof_type_family": row["proof_type_family"],
         }, 1)
     lines.append("")
 
@@ -505,6 +542,23 @@ def _write_aroi_section(lines: _LineAppender, relay_set,
                     "Relay count by canonical AROI state in schema v2")
     for state in _AROI_STATE_VALUES:
         _emit(lines, "aeo1_aroi_relays_count", {"state": state}, state_counts[state])
+    lines.append("")
+
+    # B7.2: New aggregate metric — per-version split of state counts so
+    # dashboards can chart migration progress without scraping label
+    # cardinality. Cardinality bound: 4 states × 5 ciissversion values
+    # = 20 series (plus the 4 we already have, = 24 max).
+    _emit_help_type(lines, "aeo1_aroi_relays_count_by_version",
+                    "Relay count by AROI state and declared ciissversion. "
+                    "ciissversion ∈ {none,2,3,unknown}")
+    # Emit ALL combinations (not just observed) so consumers don't have
+    # to rate() to handle the absence-→-presence transition.
+    _ciissversion_values = ("none", "2", "3", "unknown")
+    for state in _AROI_STATE_VALUES:
+        for cv in _ciissversion_values:
+            _emit(lines, "aeo1_aroi_relays_count_by_version",
+                  {"state": state, "ciissversion": cv},
+                  version_state_counts.get((state, cv), 0))
     lines.append("")
 
     # Scan timestamp

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -34,10 +34,16 @@ from datetime import datetime, timedelta, timezone
 
 ABS_PATH = os.path.dirname(os.path.abspath(__file__))
 
-# Pre-compiled AROI parsing regexes (called ~7000 times per relay set)
-_AROI_URL_RE = re.compile(r'\burl:(?:https?://)?([^,\s]+)', re.IGNORECASE)
-_AROI_CIISS_RE = re.compile(r'\bciissversion:2\b', re.IGNORECASE)
-_AROI_PROOF_RE = re.compile(r'\bproof:(dns-rsa|uri-rsa)\b', re.IGNORECASE)
+# AROI parsing — share regex pair with aroi_validation.py to keep parsing
+# semantics identical across the codebase. Both v2 and v3 ciissversions
+# are accepted; all 4 supported proof types (dns-rsa, uri-rsa,
+# dns-familyid-ed25519, uri-familyid-ed25519) match. Hot path: called
+# ~7000 times per relay set, so module-level pre-compile.
+from .aroi_validation import (
+    _CIISS_VERSION_RE as _AROI_CIISS_RE,
+    _PROOF_TYPE_RE as _AROI_PROOF_RE,
+    _URL_FIELD_RE as _AROI_URL_RE,
+)
 
 # Page writing infrastructure imported from page_writer.py
 from .page_writer import (
@@ -261,49 +267,59 @@ class Relays:
 
     def _simple_aroi_parsing(self, contact):
         """
-        Extract AROI domain from contact information if conditions are met.
+        Extract AROI domain + version + proof type from a contact string.
         For display purposes only - does not affect the stored/hashed contact info.
-        More details: https://nusenu.github.io/ContactInfo-Information-Sharing-Specification/
-        
-        According to the AROI spec, a valid contact string must have ALL 3:
-        - ciissversion:2
-        - proof:dns-rsa or proof:uri-rsa  
-        - url:<domain>
-        
-        Args:
-            contact: The contact string to process
+        Spec: https://nusenu.github.io/ContactInfo-Information-Sharing-Specification/
+
+        Recognises both CIISS v2 (ciissversion:2 + dns-rsa|uri-rsa) and
+        CIISS v3 (ciissversion:3 + dns-familyid-ed25519|uri-familyid-ed25519).
+        Both versions need all 3 fields present (ciissversion, proof, url)
+        AND a matching proof type for the declared version.
+
+        Hot path: called ~7000 times per relay set. Uses module-level
+        pre-compiled regexes shared with aroi_validation.py.
+
         Returns:
-            Tuple of (domain, aroi_field_status) where:
-            - domain: extracted domain or "none" if incomplete
-            - aroi_field_status: dict with presence of each field
+            Tuple of (domain, version, proof_type) where:
+              - domain: extracted domain string (e.g. 'example.com'), or
+                        'none' if the relay's contact does not declare a
+                        complete AROI (or has version/proof mismatch).
+              - version: '2' | '3' | None
+              - proof_type: full proof type string ('uri-rsa',
+                            'dns-familyid-ed25519', etc.) or None
         """
         if not contact:
-            return "none"
-            
-        # Check if ALL required patterns are present (ciissversion, proof, and url)
-        # Uses pre-compiled regexes for performance (called ~7000 times)
+            return ("none", None, None)
+
         url_match = _AROI_URL_RE.search(contact)
         ciiss_match = _AROI_CIISS_RE.search(contact)
         proof_match = _AROI_PROOF_RE.search(contact)
-        
-        if url_match and ciiss_match and proof_match:
-            # All 3 fields present - extract domain and clean it up
-            domain = url_match.group(1)
-            
-            # Handle protocol URLs (e.g. https://domain.com/path)
-            if '://' in domain:
-                domain = domain.split('://', 1)[1]
-            
-            # Remove www. prefix if present
-            if domain.startswith('www.'):
-                domain = domain[4:]
-                
-            # Remove trailing slash and anything after first /
-            domain = domain.split('/')[0]
-            
-            return domain
-        
-        return "none"
+
+        version = ciiss_match.group(1) if ciiss_match else None
+        proof_type = proof_match.group(1).lower() if proof_match else None
+
+        if not (url_match and version and proof_type):
+            return ("none", version, proof_type)
+
+        # Reject version/proof mismatches (e.g. ciissversion:2 +
+        # proof:uri-familyid-ed25519). This is a real-world operator
+        # copy-paste error during migration; we surface it as "no
+        # complete AROI" so it bubbles up to the contact page's
+        # incomplete bucket where the operator is told what to fix.
+        from .aroi_validation import PROOF_TYPE_VERSION
+        expected_version = PROOF_TYPE_VERSION.get(proof_type)
+        if expected_version and expected_version != version:
+            return ("none", version, proof_type)
+
+        # All 3 fields present and consistent — extract the domain.
+        domain = url_match.group(1)
+        if '://' in domain:
+            domain = domain.split('://', 1)[1]
+        if domain.startswith('www.'):
+            domain = domain[4:]
+        domain = domain.split('/')[0]
+
+        return (domain, version, proof_type)
 
     def _add_hashed_contact(self):
         """
@@ -318,11 +334,17 @@ class Relays:
         
         for idx, relay in enumerate(self.json["relays"]):
             contact = relay.get("contact", "")
-            aroi_domain = self._simple_aroi_parsing(contact)
-            
-            # Store AROI domain on relay (extracted during contact hashing for efficiency)
+            aroi_domain, aroi_version, aroi_proof_type = self._simple_aroi_parsing(contact)
+
+            # Store AROI domain + version + proof type on relay (extracted
+            # during contact hashing for efficiency). aroi_domain is "none"
+            # unless ALL fields are present and consistent. aroi_version /
+            # aroi_proof_type may be set independently for diagnostic use
+            # (e.g. an operator who declared ciissversion but not url).
             relay["aroi_domain"] = aroi_domain
             relay["aroi_configured"] = aroi_domain not in ("none", "", None)
+            relay["aroi_version"] = aroi_version            # '2' | '3' | None
+            relay["aroi_proof_type"] = aroi_proof_type      # full string or None
             
             # Use AROI domain as key if available, otherwise use contact hash as key
             if aroi_domain and aroi_domain != "none" and contact.strip():

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -1240,6 +1240,12 @@ class Relays:
         """
         self._log_progress("Generating AROI operator leaderboards...")
         self.json['aroi_leaderboards'] = _calculate_aroi_leaderboards(self)
+        # Bump the deterministic version counter consumed by
+        # operator_analysis._get_contact_rankings_index so any cached
+        # rankings index is invalidated and rebuilt from the fresh
+        # leaderboards. Cheaper + more reliable than id()-based
+        # invalidation (no risk of address reuse on GC'd dicts).
+        self.leaderboards_version = getattr(self, 'leaderboards_version', 0) + 1
         contact_count = len(self.json.get('sorted', {}).get('contact', {}))
         self._log_progress(f"AROI leaderboards generated for {contact_count} operators")
 

--- a/allium/lib/search_index.py
+++ b/allium/lib/search_index.py
@@ -117,8 +117,12 @@ def compact_relay_entry(
 ) -> Dict[str, Any]:
     """
     Create a compact relay entry for the search index.
-    
-    Only includes non-empty fields to minimize JSON size.
+
+    Only includes non-empty fields to minimize JSON size. Schema version
+    1.6 adds the optional `vn` field (CIISS ContactInfo declared
+    ciissversion: '2' or '3') so the search frontend (Cloudflare Pages
+    Function in the separate allium-deploy repo) can show version
+    indicators in disambiguation pages without a separate API call.
     """
     entry = {
         'f': relay['fingerprint'],
@@ -148,6 +152,12 @@ def compact_relay_entry(
 
     if family_id:
         entry['fam'] = family_id
+
+    # B5.1 (v1.6): CIISS spec version this relay declares. Only emitted
+    # when present (sparse-field convention). Values: '2' or '3'.
+    aroi_version = relay.get('aroi_version')
+    if aroi_version:
+        entry['vn'] = aroi_version
 
     return entry
 
@@ -183,12 +193,20 @@ def compact_family_entry(
     # (avoids 300k+ .lower() calls per search query)
     nickname_counts = dict(Counter(name.lower() for name in nicknames))
 
+    # B5.1 (v1.6): tally v3 declarations across the family's relays so
+    # the search frontend can show a tier badge without per-relay scan.
+    v3_count = sum(1 for m in members if m.get('aroi_version') == '3')
+
     # Build base entry
     entry: Dict[str, Any] = {
         'id': family_id,
         'sz': len(members),
         'nn': nickname_counts,  # {nickname: count} format for compactness
     }
+
+    # v3 percentage as int 0-100. Sparse: only emitted when > 0.
+    if v3_count > 0 and len(members) > 0:
+        entry['v3p'] = int(round(v3_count / len(members) * 100))
 
     # Add prefix if detected (non-generic preferred for search relevance)
     prefix = extract_common_prefix(nicknames)
@@ -418,7 +436,11 @@ def generate_search_index(
             'generated_at': relays_data.get('relays_published', ''),
             'relay_count': len(relays),
             'family_count': len(valid_family_ids),
-            'version': '1.5'  # 1.1: nn->dict, 1.2: pxg sparse, 1.3: nn keys lowercase, 1.4: v (validated) field, 1.5: validated_aroi_domains in lookups
+            # 1.1: nn->dict, 1.2: pxg sparse, 1.3: nn keys lowercase,
+            # 1.4: v (validated) field, 1.5: validated_aroi_domains in lookups,
+            # 1.6: per-relay 'vn' (ciissversion) + per-family 'v3p'
+            #      (v3 percentage int 0-100) + lookups.v3_thresholds
+            'version': '1.6'
         },
         'relays': relay_entries,
         'families': family_entries,
@@ -427,7 +449,18 @@ def generate_search_index(
             'country_names': country_names,
             'platforms': sorted(platforms),
             'flags': sorted(flags),
-            'validated_aroi_domains': validated_aroi_list
+            'validated_aroi_domains': validated_aroi_list,
+            # B5.1 (v1.6): tier thresholds for the Cloudflare Pages Function
+            # to use without hardcoding. Mirrors V3_TIER_* constants in
+            # aroi_validation.py exactly so contact-page pills, listing
+            # icons, leaderboard badges, and search-frontend badges
+            # all agree.
+            'v3_thresholds': {
+                'explorer': 1,    # >=1 v3 relay (special: count, not pct)
+                'migrating': 25,
+                'mostly': 75,
+                'complete': 100,
+            },
         }
     }
 

--- a/allium/templates/api-diagnostics.html
+++ b/allium/templates/api-diagnostics.html
@@ -108,6 +108,93 @@ API Diagnostics
             </div>
             {% endif %}
 
+            {# B6: AROI-specific extended diagnostics block. Helps
+               non-developer operators diagnose upstream regressions.
+               Uses a CSS grid for clean label-on-left/value-on-right
+               layout that doesn't break when content wraps (the prior
+               dt/dd inline-display approach broke with line wrap). #}
+            {% if api.aroi_extras %}
+            <div style="margin-top: 12px; padding: 10px; background-color: #f8f9fa; border-radius: 4px; font-size: 12px;">
+                <strong style="color: #495057;">AROI extended diagnostics</strong>
+                <table style="width: 100%; margin-top: 6px; font-size: 12px; border-collapse: collapse;">
+                    {% if api.aroi_extras.schema_version is not none %}
+                    <tr>
+                        <td style="vertical-align: top; padding: 3px 8px 3px 0; font-weight: bold; white-space: nowrap; width: 1%;">Schema version:</td>
+                        <td style="vertical-align: top; padding: 3px 0;">v{{ api.aroi_extras.schema_version }}{% if api.aroi_extras.schema_version > 2 %} <span style="color: #c82333;">⚠ newer than tested</span>{% endif %}</td>
+                    </tr>
+                    {% endif %}
+                    {# Item D: ciissversion_declared_rows is pre-formatted in
+                       api_diagnostics.py (_format_ciissversion_rows) so the
+                       template just iterates ready-to-render rows with
+                       stable badge_color/is_none flags. #}
+                    {% if api.aroi_extras.ciissversion_declared_rows %}
+                    <tr>
+                        <td style="vertical-align: top; padding: 3px 8px 3px 0; font-weight: bold; white-space: nowrap; width: 1%;">ciissversion declared:</td>
+                        <td style="vertical-align: top; padding: 3px 0;">
+                        {% for row in api.aroi_extras.ciissversion_declared_rows -%}
+                        {%- if not loop.first %} {% endif -%}
+                        {%- if row.is_none -%}<span style="color: #6c757d; margin-right: 4px;">none: {{ row.count }}</span>
+                        {%- else -%}<span style="background-color: {{ row.badge_color }}; color: white; padding: 1px 4px; border-radius: 2px; margin-right: 4px;">v{{ row.key }}: {{ row.count }}</span>
+                        {%- endif -%}
+                        {% endfor %}
+                        </td>
+                    </tr>
+                    {% endif %}
+                    {# Item D: proof_types_rows is pre-formatted in
+                       api_diagnostics.py (_format_proof_type_rows) so the
+                       template doesn't need to do dictsort + 'familyid in
+                       pt' string classification + bucket exclusion in
+                       Jinja. Each row already carries version + badge_color. #}
+                    {% if api.aroi_extras.proof_types_rows %}
+                    <tr>
+                        <td style="vertical-align: top; padding: 3px 8px 3px 0; font-weight: bold; white-space: nowrap; width: 1%;">Proof types:</td>
+                        <td style="vertical-align: top; padding: 3px 0;">
+                        {% for row in api.aroi_extras.proof_types_rows -%}
+                        <span style="display: inline-block; margin-right: 4px; margin-bottom: 2px;">
+                            <span style="font-size: 10px; padding: 1px 4px; background-color: {{ row.badge_color }}; color: white; border-radius: 2px;">v{{ row.version }}</span>
+                            <code style="background: #fff; padding: 1px 4px; border-radius: 2px;">{{ row.proof_type }}: {{ row.valid }}/{{ row.total }}</code>
+                        </span>
+                        {% endfor %}
+                        </td>
+                    </tr>
+                    {% endif %}
+                    {% if api.aroi_extras.top_error_categories %}
+                    <tr>
+                        <td style="vertical-align: top; padding: 3px 8px 3px 0; font-weight: bold; white-space: nowrap; width: 1%;">Top v3 error categories:</td>
+                        <td style="vertical-align: top; padding: 3px 0;">
+                        {% for cat, count in api.aroi_extras.top_error_categories -%}
+                        <code style="background: #fff3cd; padding: 1px 4px; border-radius: 2px; margin-right: 4px; display: inline-block;">{{ cat }}: {{ count }}</code>
+                        {%- endfor %}
+                        </td>
+                    </tr>
+                    {% endif %}
+                </table>
+
+                {# B6 (final): warning feed from this build's
+                   aroi_validation module. Plan called for last-warning
+                   timestamps so operators can spot upstream regressions. #}
+                {% if api.aroi_extras.warnings %}
+                <div style="margin-top: 8px; padding-top: 8px; border-top: 1px dashed #dee2e6;">
+                    <strong style="color: #495057; font-size: 11px;">⚠️ Build-time warnings ({{ api.aroi_extras.warnings|length }}):</strong>
+                    <ul style="margin: 4px 0 0 0; padding-left: 20px; font-size: 11px;">
+                        {% for w in api.aroi_extras.warnings -%}
+                        <li>
+                            <code style="background: #fff3cd; padding: 1px 3px; border-radius: 2px;">{{ w.kind }}</code>
+                            =
+                            <code style="background: #fff; padding: 1px 3px; border-radius: 2px; border: 1px solid #dee2e6;">{{ w.value|escape }}</code>
+                            <span style="color: #6c757d;">(first seen {{ w.timestamp_iso }}{% if w.count > 1 %}, ×{{ w.count }}{% endif %})</span>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+                {% else %}
+                <div style="margin-top: 8px; padding-top: 8px; border-top: 1px dashed #dee2e6; font-size: 11px; color: #6c757d;">
+                    ✓ No build-time AROI warnings (no unknown error_categories, proof_types, or schema mismatches).
+                </div>
+                {% endif %}
+            </div>
+            {% endif %}
+
             <div class="diag-affected {% if api.freshness == 'stale' %}diag-affected-stale{% endif %}">
                 {% if api.freshness == 'stale' %}
                 <strong>Affected sections (may show stale data):</strong>

--- a/allium/templates/aroi_macros.html
+++ b/allium/templates/aroi_macros.html
@@ -51,7 +51,7 @@
                         {% elif category_key == "ipv6_leaders" %}
                             <span title="Number of unique IPv6 addresses across relay infrastructure">{{ champion.unique_ipv6_count }} unique IPv6</span>
                         {% elif category_key == "validated_relays" %}
-                            <span title="Number of relays with valid AROI cryptographic proofs">{{ champion.validated_relay_count }} validated relays</span>
+                            <span title="Number of relays with valid AROI cryptographic proofs (v2 + v3 combined)">{{ champion.validated_relay_count }} validated relays</span>
                         {% elif category_key == "total_data_champions" %}
                             <span title="Total cumulative data transferred (read + write)">{{ champion.total_data_transferred }}{% if champion.total_data_pct %} ({{ champion.total_data_pct }}){% endif %}</span>
                         {% endif %}
@@ -770,7 +770,11 @@
                 <tr>
                     <th title="Position in AROI validation champions leaderboard">Rank</th>
                     <th title="Authenticated Relay Operator Identifier following ContactInfo specification">Operator (AROI)</th>
-                    <th title="Number of relays with valid AROI cryptographic proofs (DNS-RSA or URI-RSA)">Validated Relays</th>
+                    <th title="Number of relays with valid AROI cryptographic proofs (CIISS v2 dns-rsa/uri-rsa or CIISS v3 ed25519 family-id)">Validated Relays</th>
+                    {# B4.1: v2/v3 split columns. #}
+                    <th title="Validated relays declaring CIISS v2 (RSA-fingerprint proofs)">v2 Valid</th>
+                    <th title="Validated relays declaring CIISS v3 (ed25519 happy-family proofs)">v3 Valid</th>
+                    <th title="Percentage of operator's relays that declare ciissversion:3.">v3 Migration</th>
                     <th title="Number of guard/middle/exit relays with valid AROI proofs">Guard/Middle/Exit Validated</th>
                     <th title="Total bandwidth capacity on validated relays in {% if use_bits %}bits per second{% else %}bytes per second{% endif %}">Bandwidth Capacity Validated</th>
                     <th title="Consensus weight percentage on validated relays">Consensus Weight Validated</th>
@@ -787,6 +791,12 @@
                         {% if entry.invalid_relay_count > 0 %}
                             <small class="text-muted" title="Relays with failed AROI validation">({{ entry.invalid_relay_count }} invalid)</small>
                         {% endif %}
+                    </td>
+                    {# B4.1: v2/v3 split + tier badge cells. #}
+                    <td title="v2 (RSA-fingerprint) validated relays for this operator"><span style="font-size: 11px; padding: 1px 5px; background-color: #6c757d; color: white; border-radius: 2px;">{{ entry.validated_v2_relay_count }}</span></td>
+                    <td title="v3 (ed25519 happy-family) validated relays for this operator"><span style="font-size: 11px; padding: 1px 5px; background-color: #007bff; color: white; border-radius: 2px;">{{ entry.validated_v3_relay_count }}</span></td>
+                    <td title="{{ entry.v3_relay_count }} of operator's relays declare ciissversion:3 ({{ entry.v3_relay_pct_str }}). Tier: {{ entry.v3_tier|capitalize }}.">
+                        {{ entry.v3_relay_pct_str }}
                     </td>
                     <td>
                         <span title="Guard: {{ entry.validated_guard_count }} | Exit: {{ entry.validated_exit_count }} | Middle: {{ entry.validated_middle_count }}">

--- a/allium/templates/contact-relay-list.html
+++ b/allium/templates/contact-relay-list.html
@@ -35,6 +35,9 @@
 {% set validated_fps = contact_validation_status.validated_fingerprints if contact_validation_status else {} -%}
 {% set unauthorized_fps = contact_validation_status.unauthorized_fingerprints if contact_validation_status else {} -%}
 {% set misconfigured_fps = contact_validation_status.misconfigured_fingerprints if contact_validation_status else {} -%}
+{# B1.5: peer-issue fingerprint sets for inline icons #}
+{% set security_fps = contact_validation_status.security_incident_fingerprints if contact_validation_status else {} -%}
+{% set pending_fps = contact_validation_status.pending_onionoo_fingerprints if contact_validation_status else {} -%}
 
 {# Determine if we should use the 4-section layout #}
 {% set use_sections = contact_validation_status and contact_validation_status.has_aroi and contact_validation_status.validation_status != 'not_configured' -%}
@@ -132,7 +135,7 @@
             {% elif validation_icon_type == 'not_configured' -%}
                 <span class="al-status-muted" style="margin-left: 4px;" title="Not Configured: No AROI validation configured for this relay">○</span>
             {% else -%}
-                {{- aroi_validation_icon(relay['fingerprint'], relay['aroi_domain'], validated_fps, unauthorized_fps, misconfigured_fps) }}
+                {{- aroi_validation_icon(relay['fingerprint'], relay['aroi_domain'], validated_fps, unauthorized_fps, misconfigured_fps, security_fps, pending_fps, relay.get('aroi_version')) }}
             {% endif -%}
         {% endif -%}
     </td>
@@ -312,6 +315,167 @@
 {%- endmacro %}
 
 {% if use_sections %}
+{# =============================================================================
+   B5.3: v2 \u2192 v3 UPGRADE NUDGE for v2-only validated operators.
+   Rendered ONLY when:
+     - operator status == 'validated' (v2 setup is working today)
+     - v3_relay_count == 0 (haven't started migrating yet)
+     - has_aroi (operator declared AROI in the first place)
+   Goal: keep the migration funnel moving without nagging operators
+   with active issues.
+   ============================================================================= #}
+{%- set _summary = contact_validation_status.validation_summary -%}
+{%- if contact_validation_status.validation_status == 'validated'
+        and _summary.v3_relay_count == 0
+        and _summary.v2_relay_count > 0 %}
+{%- set _all_relays = (contact_validation_status.validated_relays or []) -%}
+{%- set _example_domain = (_all_relays[0].aroi_domain if _all_relays else 'yourdomain.com') -%}
+<div style="margin-top: 30px; padding: 15px; background-color: #fff3cd; border-left: 3px solid #ffc107; border-radius: 4px; font-size: 13px;">
+    <h3 style="margin: 0 0 10px 0; font-size: 14px; color: #856404;">💡 Want to upgrade to ciissversion:3?</h3>
+    <p style="margin: 0 0 8px 0; color: #856404;">
+        All {{ _summary.v2_relay_count }} of your relays validate cleanly on CIISS v2 (RSA fingerprint proofs). The new <strong>CIISS v3</strong> spec replaces per-relay RSA proofs with a single shared ed25519 family-id proof — same url, one published file for the whole family.
+    </p>
+    <p style="margin: 0 0 6px 0; color: #856404;"><strong>To migrate, change torrc ContactInfo to:</strong></p>
+    <code style="display: block; padding: 8px; background-color: #fff; border: 1px solid #ffe69c; border-radius: 3px; font-size: 12px; word-break: break-all;">ciissversion:3 url:{{ _example_domain|escape }} proof:uri-familyid-ed25519</code>
+    <p style="margin: 8px 0 6px 0; color: #856404;"><strong>And on a secure host, generate the happy-family key:</strong></p>
+    <code style="display: block; padding: 8px; background-color: #fff; border: 1px solid #ffe69c; border-radius: 3px; font-size: 12px;">tor --keygen-family /path/to/myfamily   # then deploy myfamily.secret_family_key to every relay's KeyDir</code>
+    <p style="margin: 8px 0 0 0; font-size: 12px; color: #856404;">
+        Publish <code>.public_family_id</code> at <code>/.well-known/tor-relay/ed25519-family-id.txt</code>.
+        Allow ~24h after restarting Tor for Onionoo to refresh family_ids.
+        Full guide: <a href="https://github.com/1aeo/aroivalidator#operator-setup-guide-building-a-ciissversion3-aroi-from-scratch" target="_blank" rel="noopener">aroivalidator setup guide</a>.
+    </p>
+</div>
+{%- endif %}
+
+{# =============================================================================
+   B1.4: PER-OPERATOR ERROR ROLLUP TABLE
+   For operators with >= 3 failing relays, render a small grouped summary
+   so they see the "what's wrong" pattern at a glance without scanning
+   each per-relay detail box. Sourced from each operator's OWN
+   error_category counts; does not duplicate the network-wide rollup
+   that B2.4 will surface on the dashboard.
+   ============================================================================= #}
+{%- set error_relays = (contact_validation_status.unauthorized_relays or [])
+    + (contact_validation_status.misconfigured_relays or [])
+    + (contact_validation_status.pending_onionoo_relays or [])
+    + (contact_validation_status.security_incident_relays or []) -%}
+{%- if error_relays|length >= 3 -%}
+    {%- set ns = namespace(rollup={}) -%}
+    {%- for r in error_relays -%}
+        {%- set cat = r.error_category or 'unknown' -%}
+        {%- if cat in ns.rollup -%}
+            {%- set _ = ns.rollup.update({cat: ns.rollup[cat] + 1}) -%}
+        {%- else -%}
+            {%- set _ = ns.rollup.update({cat: 1}) -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {%- if ns.rollup -%}
+<div style="margin-top: 30px; padding: 15px; background-color: #f8f9fa; border-left: 3px solid #6c757d; border-radius: 4px;">
+    <h3 style="margin: 0 0 10px 0; font-size: 14px; color: #495057;">📋 Issues Across This Operator's Relays ({{ error_relays|length }} affected)</h3>
+    <table style="width: 100%; font-size: 13px; border-collapse: collapse;">
+        <thead>
+            <tr style="border-bottom: 1px solid #dee2e6;">
+                <th style="text-align: left; padding: 4px 6px;">Issue</th>
+                <th style="text-align: right; padding: 4px 6px;">Affected relays</th>
+            </tr>
+        </thead>
+        <tbody>
+        {%- for cat, count in ns.rollup|dictsort(by='value', reverse=true) %}
+            <tr style="border-bottom: 1px solid #f1f3f5;">
+                <td style="padding: 4px 6px;">{{ cat|replace('_', ' ')|capitalize|escape }}</td>
+                <td style="text-align: right; padding: 4px 6px;"><strong>{{ count }}</strong></td>
+            </tr>
+        {%- endfor %}
+        </tbody>
+    </table>
+    <p style="margin: 8px 0 0 0; color: #6c757d; font-size: 11px;">See per-relay details with pasteable fix examples in the sections below.</p>
+</div>
+    {%- endif -%}
+{%- endif %}
+
+{# =============================================================================
+   B1.1: PEER ISSUE SECTIONS (rendered above the cascade so urgent
+   problems surface first regardless of operator-level status).
+   ============================================================================= #}
+
+{# PEER 1: Security incident (highest urgency) — leaked .secret_family_key. #}
+{% if contact_validation_status.security_incident_relays %}
+{% set sec_relays = contact_validation_status.security_incident_relays|map(attribute='relay')|list %}
+{% set sec_has_ipv6 = sec_relays|selectattr('ipv6_support', 'equalto', 'both')|list|length > 0 or sec_relays|selectattr('ipv6_support', 'equalto', 'ipv6_only')|list|length > 0 %}
+{{ aroi_section_header('SECURITY INCIDENT — ROTATE FAMILY KEY', contact_validation_status.security_incident_relays|length, 'security_incident') }}
+<table class="table table-condensed" style="border-left: 4px solid #c82333;">
+{{ relay_table_header(sec_has_ipv6) }}
+<tbody>
+    {% for relay_info in contact_validation_status.security_incident_relays -%}
+        {{ relay_row(relay_info.relay, show_validation_icon=true, validation_icon_type='security_incident', table_has_ipv6=sec_has_ipv6) }}
+    {% endfor -%}
+</tbody>
+</table>
+{{ aroi_relay_detail_box(contact_validation_status.security_incident_relays, 'security_incident', page_ctx, aroi_validation_timestamp) }}
+</div>
+{% endif %}
+
+{# PEER 2: Pending Onionoo refresh — transient (< 24h after torrc change). #}
+{% if contact_validation_status.pending_onionoo_relays %}
+{% set pend_relays = contact_validation_status.pending_onionoo_relays|map(attribute='relay')|list %}
+{% set pend_has_ipv6 = pend_relays|selectattr('ipv6_support', 'equalto', 'both')|list|length > 0 or pend_relays|selectattr('ipv6_support', 'equalto', 'ipv6_only')|list|length > 0 %}
+{{ aroi_section_header('PENDING ONIONOO REFRESH', contact_validation_status.pending_onionoo_relays|length, 'pending_onionoo') }}
+<table class="table table-condensed" style="border-left: 3px dotted #17a2b8;">
+{{ relay_table_header(pend_has_ipv6) }}
+<tbody>
+    {% for relay_info in contact_validation_status.pending_onionoo_relays -%}
+        {{ relay_row(relay_info.relay, show_validation_icon=true, validation_icon_type='pending_onionoo', table_has_ipv6=pend_has_ipv6) }}
+    {% endfor -%}
+</tbody>
+</table>
+{{ aroi_relay_detail_box(contact_validation_status.pending_onionoo_relays, 'pending_onionoo', page_ctx, aroi_validation_timestamp) }}
+</div>
+{% endif %}
+
+{# PEER 3: v3 migration summary — informational. Operator has both v2
+   and v3 declarations. Help text shows pasteable v3 example using the
+   operator's actual url so they can finish the migration. #}
+{% if contact_validation_status.validation_summary.is_mixed_migration %}
+{%- set summary = contact_validation_status.validation_summary -%}
+{# Pull aroi_domain from validation_status (parent template variable name
+   differs between contact.html and family.html contexts). #}
+{%- set _all_validated_or_failed = (contact_validation_status.validated_relays or [])
+    + (contact_validation_status.unauthorized_relays or [])
+    + (contact_validation_status.misconfigured_relays or []) -%}
+{%- set _example_domain = (_all_validated_or_failed[0].aroi_domain if _all_validated_or_failed else 'yourdomain.com') -%}
+{{ aroi_section_header('v2 → v3 MIGRATION IN PROGRESS', summary.v3_relay_count|string + '/' + summary.total_relays|string + ' on v3', 'v3_migration') }}
+<div style="padding: 15px; background-color: #d1ecf1; border-left: 3px dotted #007bff; border-radius: 4px; font-size: 13px;">
+    {# B1.1 (final): per-version success-rate pills side-by-side, as plan
+       called for. Visualizes where each version is failing for THIS
+       operator (e.g. v2 100% but v3 25% means v3 setup not yet propagated). #}
+    <div style="margin-bottom: 10px;">
+        <span style="display: inline-block; padding: 4px 10px; background-color: #fff; border: 1px solid #6c757d; border-radius: 3px; margin-right: 8px;">
+            <strong style="color: #495057;">v2:</strong>
+            <span style="color: #28a745;">{{ summary.v2_validated_count }}</span> /
+            {{ summary.v2_relay_count }}
+            <small style="color: #6c757d;">({{ '%.0f'|format(summary.v2_success_rate) }}%)</small>
+        </span>
+        <span style="display: inline-block; padding: 4px 10px; background-color: #fff; border: 1px solid #007bff; border-radius: 3px;">
+            <strong style="color: #007bff;">v3:</strong>
+            <span style="color: #28a745;">{{ summary.v3_validated_count }}</span> /
+            {{ summary.v3_relay_count }}
+            <small style="color: #6c757d;">({{ '%.0f'|format(summary.v3_success_rate) }}%)</small>
+        </span>
+    </div>
+    <p style="margin: 0 0 8px 0;">
+        <strong>{{ '%.0f'|format(summary.v3_relay_percentage) }}%</strong> of this operator's relays already declare ciissversion:3
+        ({{ summary.v3_relay_count }} of {{ summary.total_relays }}).
+        Tier: <strong>{{ summary.v3_tier|capitalize }}</strong>.
+    </p>
+    <p style="margin: 0 0 8px 0;">To finish the migration, change v2 relays' ContactInfo to:</p>
+    <code style="display: block; padding: 8px; background-color: #fff; border: 1px solid #b8daff; border-radius: 3px; font-size: 12px;">ciissversion:3 url:{{ _example_domain|escape }} proof:uri-familyid-ed25519</code>
+    <p style="margin: 8px 0 0 0; color: #0c5460; font-size: 12px;">
+        💡 The same url and family key apply across all relays — one shared proof, not per-relay RSA fingerprints.
+    </p>
+</div>
+</div>
+{% endif %}
+
 {# =============================================================================
    4-SECTION LAYOUT (for operators with AROI: validated/unauthorized/misconfigured)
    ============================================================================= #}

--- a/allium/templates/contact-relay-list.html
+++ b/allium/templates/contact-relay-list.html
@@ -355,10 +355,26 @@
    error_category counts; does not duplicate the network-wide rollup
    that B2.4 will surface on the dashboard.
    ============================================================================= #}
-{%- set error_relays = (contact_validation_status.unauthorized_relays or [])
+{# Dedupe by fingerprint: pending_onionoo_relays is intentionally
+   dual-bucketed into misconfigured_relays for cascade purposes, and a
+   secret-key-leaked relay also lands in misconfigured. Naïvely
+   concatenating those four lists therefore double- or triple-counts
+   the same relay in this rollup table and inflates the
+   "N affected" header. Fix: collect unique relay objects keyed by
+   fingerprint before counting. #}
+{%- set _all_error_relays = (contact_validation_status.unauthorized_relays or [])
     + (contact_validation_status.misconfigured_relays or [])
     + (contact_validation_status.pending_onionoo_relays or [])
     + (contact_validation_status.security_incident_relays or []) -%}
+{%- set _seen_fps = namespace(s=[]) -%}
+{%- set error_relays = [] -%}
+{%- for r in _all_error_relays -%}
+    {%- set _fp = r.fingerprint -%}
+    {%- if _fp and _fp not in _seen_fps.s -%}
+        {%- set _ = _seen_fps.s.append(_fp) -%}
+        {%- set _ = error_relays.append(r) -%}
+    {%- endif -%}
+{%- endfor -%}
 {%- if error_relays|length >= 3 -%}
     {%- set ns = namespace(rollup={}) -%}
     {%- for r in error_relays -%}

--- a/allium/templates/contact.html
+++ b/allium/templates/contact.html
@@ -1,5 +1,5 @@
 {% extends "contact-relay-list.html" %}
-{% from "macros.html" import navigation, detail_summary, aroi_validation_badge, aroi_sub_bullets, family_support_inline, dns_health_bullet %}
+{% from "macros.html" import navigation, detail_summary, aroi_validation_badge, aroi_sub_bullets, aroi_v2v3_pills, family_support_inline, dns_health_bullet %}
 {% set contact_hash = relay_subset[0]['contact_md5'] %}
 {% if relay_subset[0]['contact'] %}
     {% set contact = relay_subset[0]['contact']|escape %}
@@ -60,9 +60,41 @@
                         {{ aroi_sub_bullets(contact_validation_status) }}
                     </li>
                     {% endif %}
-                    {% if contact != 'none' %}
+                    {# Phase 1: source-faithful ContactInfo display.
+                       Single variant → keep the simple Contact: line.
+                       Multiple variants → render an explicit
+                       "ContactInfo variants" block so operators (and
+                       reviewers) can see exactly what each subset of
+                       relays publishes. #}
+                    {%- set _variants = (contact_display_data.get('contact_variants') if contact_display_data else None) or [] -%}
+                    {%- set _variant_count = (contact_display_data.get('contact_variant_count') if contact_display_data else None) or 0 -%}
+                    {%- if _variant_count <= 1 %}
+                        {%- if contact != 'none' %}
                     <li><strong>Contact:</strong> {{ contact }}</li>
-                    {% endif %}
+                        {%- endif %}
+                    {%- else %}
+                    <li><strong>ContactInfo variants:</strong>
+                        {{ _variant_count }} distinct ContactInfo strings across this operator's
+                        {{ contact_validation_status.validation_summary.total_relays if contact_validation_status else 'all' }} relays
+                        (grouped by AROI domain).
+                        <ul style="list-style-type: circle; padding-left: 20px; margin-top: 4px; margin-bottom: 4px;">
+                        {%- for v in _variants %}
+                            <li style="margin-bottom: 6px;">
+                                <strong>{{ v.count }}</strong> relay{{ 's' if v.count != 1 else '' }}
+                                {%- if v.aroi_version %}
+                                    <code style="font-size: 11px; padding: 1px 5px; background-color: {{ '#007bff' if v.aroi_version == '3' else '#6c757d' }}; color: white; border-radius: 2px; margin: 0 4px;">v{{ v.aroi_version }}{%- if v.aroi_proof_type %} {{ v.aroi_proof_type }}{% endif %}</code>
+                                {%- elif v.has_complete_aroi %}
+                                    <code style="font-size: 11px; padding: 1px 5px; background-color: #6c757d; color: white; border-radius: 2px; margin: 0 4px;">AROI</code>
+                                {%- else %}
+                                    <code style="font-size: 11px; padding: 1px 5px; background-color: #adb5bd; color: white; border-radius: 2px; margin: 0 4px;">no AROI</code>
+                                {%- endif %}
+                                <br>
+                                <code style="display: block; margin-top: 3px; padding: 6px 8px; background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; font-size: 11px; word-break: break-all;">{% if v.raw %}{{ v.raw|escape }}{% else %}<em style="color: #6c757d;">(no contact info)</em>{% endif %}</code>
+                            </li>
+                        {%- endfor %}
+                        </ul>
+                    </li>
+                    {%- endif %}
                     <li><strong>Hash:</strong> {{ contact_hash }}</li>
                     {% if primary_country_data %}
                     <li><strong>Countries:</strong> 

--- a/allium/templates/contact.html
+++ b/allium/templates/contact.html
@@ -75,7 +75,13 @@
                     {%- else %}
                     <li><strong>ContactInfo variants:</strong>
                         {{ _variant_count }} distinct ContactInfo strings across this operator's
-                        {{ contact_validation_status.validation_summary.total_relays if contact_validation_status else 'all' }} relays
+                        {# Reviewer-flagged grammar fix: when
+                           contact_validation_status is falsy, the prior
+                           literal 'all' produced "across this operator's
+                           all relays" which is ungrammatical. Fall back
+                           to the count derived from the variants
+                           collection itself instead. #}
+                        {{ contact_validation_status.validation_summary.total_relays if contact_validation_status else (_variants|sum(attribute='count')) }} relays
                         (grouped by AROI domain).
                         <ul style="list-style-type: circle; padding-left: 20px; margin-top: 4px; margin-bottom: 4px;">
                         {%- for v in _variants %}

--- a/allium/templates/macros.html
+++ b/allium/templates/macros.html
@@ -246,15 +246,25 @@
 </ul>
 {%- endmacro %}
 
-{% macro aroi_validation_icon(fingerprint, aroi_domain, validated_fps, unauthorized_fps, misconfigured_fps) -%}
-    {% if fingerprint in validated_fps -%}
-        <span class="al-status-success" style="margin-left: 4px;" title="AROI Validated: This relay's fingerprint has been cryptographically verified via the operator's AROI proof">✓</span>
+{% macro aroi_validation_icon(fingerprint, aroi_domain, validated_fps, unauthorized_fps, misconfigured_fps, security_fps=none, pending_fps=none, aroi_version=none) -%}
+    {# B1.5: peer issue icons take visual precedence over cascade icons —
+       a leaked-key relay shows 🚨 even if the operator's other relays
+       validated. aroi_version (str|None) appended as a small label. #}
+    {% if security_fps and fingerprint in security_fps -%}
+        <a href="#security_incident-relays" class="al-status-danger al-link-plain" style="margin-left: 4px;" title="🚨 SECURITY: This relay appears to have published .secret_family_key. Rotate the family key immediately.">🚨</a>
+    {% elif pending_fps and fingerprint in pending_fps -%}
+        <a href="#pending_onionoo-relays" class="al-status-info al-link-plain" style="margin-left: 4px;" title="⏳ Pending: Onionoo hasn't refreshed family_ids yet. Typically resolves within 24h after restarting Tor with the happy-family directive.">⏳</a>
+    {% elif fingerprint in validated_fps -%}
+        <span class="al-status-success" style="margin-left: 4px;" title="AROI Validated: This relay's identity has been cryptographically verified via the operator's AROI proof">✓</span>
     {% elif fingerprint in unauthorized_fps -%}
-        <a href="#unauthorized-relays" class="al-status-danger al-link-plain" style="margin-left: 4px;" title="Unauthorized Relay: This relay claims the domain but fingerprint is NOT in the AROI proof file">🚫</a>
+        <a href="#unauthorized-relays" class="al-status-danger al-link-plain" style="margin-left: 4px;" title="Unauthorized Relay: This relay claims the domain but is NOT in the AROI proof">🚫</a>
     {% elif fingerprint in misconfigured_fps -%}
         <a href="#misconfigured-relays" class="al-status-warning al-link-plain" style="margin-left: 4px;" title="AROI Misconfigured: Validation failed due to DNS/SSL/connection errors - see details below">⚠</a>
     {% elif aroi_domain and aroi_domain != 'none' -%}
         <span class="al-status-danger" style="margin-left: 4px;" title="No AROI Validation: This relay has AROI configured but no validation data is available">✗</span>
+    {% endif -%}
+    {%- if aroi_version and aroi_domain and aroi_domain != 'none' %}
+        <span style="font-size: 9px; padding: 0px 3px; border-radius: 2px; background-color: {{ '#007bff' if aroi_version == '3' else '#6c757d' }}; color: white; vertical-align: middle; margin-left: 2px;" title="ciissversion:{{ aroi_version }}">v{{ aroi_version }}</span>
     {% endif -%}
 {%- endmacro %}
 
@@ -274,6 +284,13 @@
 {% if contact_validation_status -%}
     {%- set summary = contact_validation_status.validation_summary -%}
     {%- set status = contact_validation_status.validation_status -%}
+    {# B1.1: peer security badge ALWAYS rendered first when present, regardless of cascade.
+       It does not replace the cascade badge below — both surface concurrently
+       so a "validated" operator with one leaked-key relay still shows
+       "✓ Validated" but ALSO sees "🚨 SECURITY" right next to it. #}
+    {% if summary.security_incident_count > 0 -%}
+        <a href="#security_incident-relays" class="al-status-danger-bold al-link-plain" style="margin-left: 5px; padding: 1px 6px; background-color: #f8d7da; border-radius: 3px;" title="{{ summary.security_incident_count }} relay{{ 's' if summary.security_incident_count != 1 else '' }} appear to have leaked .secret_family_key. Rotate the family key immediately.">🚨 SECURITY{% if show_count %} ({{ summary.security_incident_count }}){% endif %}</a>
+    {% endif -%}
     {% if status == 'validated' -%}
         <span class="al-status-success-bold"{% if not show_count %} style="margin-left: 5px;"{% endif %} title="{{ summary.validated_count }} relays validated{% if summary.unauthorized_count > 0 %}, {{ summary.unauthorized_count }} unauthorized claims{% endif %}{% if summary.misconfigured_count > 0 %}, {{ summary.misconfigured_count }} misconfigured{% endif %}">✓ Validated{% if show_count %} ({{ summary.validated_count }} relays){% endif %}</span>
     {% elif status == 'unauthorized' -%}
@@ -284,6 +301,41 @@
         <a href="#not_configured-relays" class="al-status-muted al-link-plain" style="font-weight: bold;{% if not show_count %} margin-left: 5px;{% endif %}" title="{{ summary.incomplete_count }} relays with incomplete AROI configuration - see details below">Incomplete{% if show_count %} ({{ summary.incomplete_count }} relays){% endif %}</a>
     {# not_configured status shows no badge #}
     {% endif -%}
+    {# UX-fix: pending_onionoo peer badge REMOVED from the header.
+       Per UX feedback ('it's confusing to say validated and pending at
+       the same time'), pending-Onionoo is dual-bucketed in cascade as
+       'misconfigured' already, so the cascade badge already conveys
+       "something needs attention". Operators can drill into
+       #misconfigured-relays to see the per-relay error category. #}
+{% endif -%}
+{%- endmacro %}
+
+{# =============================================================================
+   AROI v2/v3 STATUS PILLS (B1.2)
+   Compact dual-version summary rendered above the validation badge.
+   Only shown when operator has at least one v2 or v3 declaring relay.
+   ============================================================================= #}
+{% macro aroi_v2v3_pills(contact_validation_status) -%}
+{% if contact_validation_status and contact_validation_status.validation_summary -%}
+{%- set summary = contact_validation_status.validation_summary -%}
+{%- set v2_count = summary.v2_relay_count -%}
+{%- set v3_count = summary.v3_relay_count -%}
+{% if v2_count > 0 or v3_count > 0 -%}
+<span style="font-size: 11px; margin-left: 6px;">
+    {%- if v2_count > 0 -%}
+    <span title="ciissversion:2 (RSA-fingerprint proofs, legacy)" style="padding: 1px 5px; background-color: #6c757d; color: white; border-radius: 3px;">v2: {{ v2_count }}</span>
+    {%- endif -%}
+    {%- if v2_count > 0 and v3_count > 0 %} {% endif -%}
+    {%- if v3_count > 0 -%}
+    <span title="ciissversion:3 (ed25519 happy-family proofs, recommended)" style="padding: 1px 5px; background-color: #007bff; color: white; border-radius: 3px;">v3: {{ v3_count }}</span>
+    {%- endif -%}
+    {%- if summary.is_mixed_migration %}
+    <span title="Migration in progress: {{ '%.0f'|format(summary.v3_relay_percentage) }}% of relays on v3" style="padding: 1px 5px; background-color: #17a2b8; color: white; border-radius: 3px;">🔁 {{ '%.0f'|format(summary.v3_relay_percentage) }}% v3</span>
+    {%- elif summary.v3_tier == 'complete' %}
+    <span title="100% v3 — all relays on ciissversion:3" style="padding: 1px 5px; background-color: #ffc107; color: #212529; border-radius: 3px;">🏆 v3 complete</span>
+    {%- endif -%}
+</span>
+{%- endif -%}
 {% endif -%}
 {%- endmacro %}
 
@@ -295,13 +347,48 @@
 {% if contact_validation_status -%}
 {% set summary = contact_validation_status.validation_summary -%}
 {% set status = contact_validation_status.validation_status -%}
-{# Only show sub-bullets for categories OTHER than the main status #}
+{# UX-fix (condensed v2/v3 line): merge what used to be two sub-bullets
+   ('ciissversion:2: N relays (X% valid)' + 'ciissversion:3: M relays
+   (Y% valid) — v3 Mostly') into ONE summary line of the form:
+     'N total relays, X% valid, Y% v3, Z% v2'
+   For v3-only operators we collapse to just 'N relays, X% valid, 100% v3'.
+   For v2-only we use 'N relays, X% valid, 100% v2'.
+   The v3-tier label (Explorer/Migrating/Mostly/Complete) is dropped
+   from the operator overview because the percentage already conveys
+   the same meaning more concisely; tier is still surfaced on listings
+   and leaderboards where ranking is relevant. #}
+{% set v2_count = summary.v2_relay_count -%}
+{% set v3_count = summary.v3_relay_count -%}
+{% set v_total = v2_count + v3_count -%}
+{% set show_v2v3 = (v_total > 0) -%}
+{# Show peer issue categories (B1.1) FIRST when present — they
+   represent active problems regardless of cascade. #}
+{% set show_security = summary.security_incident_count > 0 -%}
+{# UX-fix: pending_onionoo sub-bullet REMOVED. Pending relays are
+   dual-bucketed into 'misconfigured' already, so the misconfigured
+   sub-bullet (or section header) covers the same relays. #}
+{# Only show cascade sub-bullets for categories OTHER than the main status #}
 {% set show_unauthorized = summary.unauthorized_count > 0 and status != 'unauthorized' -%}
 {% set show_misconfigured = summary.misconfigured_count > 0 and status != 'misconfigured' -%}
 {% set show_incomplete = summary.incomplete_count > 0 and status != 'incomplete' -%}
 {% set show_not_configured = summary.not_configured_count > 0 -%}
-{% if show_unauthorized or show_misconfigured or show_incomplete or show_not_configured -%}
+{% if show_v2v3 or show_security or show_unauthorized or show_misconfigured or show_incomplete or show_not_configured -%}
 <ul style="list-style-type: circle; padding-left: 20px; margin-top: 0; margin-bottom: 0;">
+{# Condensed single-line v2/v3 summary. #}
+{% if show_v2v3 -%}
+{% set _validated_total = (summary.v2_validated_count|default(0)) + (summary.v3_validated_count|default(0)) -%}
+{% set _valid_pct = (100.0 * _validated_total / v_total) if v_total > 0 else 0.0 -%}
+{% set _v3_pct = (100.0 * v3_count / v_total) if v_total > 0 else 0.0 -%}
+{% set _v2_pct = (100.0 * v2_count / v_total) if v_total > 0 else 0.0 -%}
+<li>{{ v_total }} relay{{ 's' if v_total != 1 else '' }}, {{ '%.0f'|format(_valid_pct) }}% valid,
+{%- if v3_count > 0 and v2_count > 0 %} {{ '%.0f'|format(_v3_pct) }}% v3, {{ '%.0f'|format(_v2_pct) }}% v2
+{%- elif v3_count > 0 %} 100% v3
+{%- elif v2_count > 0 %} 100% v2
+{%- endif -%}</li>
+{% endif -%}
+{% if show_security -%}
+<li><a href="#security_incident-relays" class="al-status-danger al-link-plain">🚨 SECURITY: {{ summary.security_incident_count }} relay{{ 's' if summary.security_incident_count != 1 else '' }} — rotate family key now</a></li>
+{% endif -%}
 {% if show_unauthorized -%}
 <li><a href="#unauthorized-relays" class="al-status-danger al-link-plain">🚫 Unauthorized: {{ summary.unauthorized_count }} relay{{ 's' if summary.unauthorized_count != 1 else '' }}</a></li>
 {% endif -%}
@@ -324,7 +411,8 @@
    Shows per-relay status details in a styled box below each table
    ============================================================================= #}
 {% macro aroi_relay_detail_box(relays, box_type, page_ctx, aroi_validation_timestamp) -%}
-{# box_type: 'misconfigured' | 'unauthorized' | 'not_configured' #}
+{# box_type: 'misconfigured' | 'unauthorized' | 'not_configured'
+            | 'security_incident' | 'pending_onionoo' #}
 {% if relays %}
     {# Style configuration based on box type #}
     {% if box_type == 'misconfigured' -%}
@@ -343,6 +431,24 @@
         {% set title = 'UNAUTHORIZED RELAY DETAILS' -%}
         {% set description = 'These relays claim this domain but their fingerprints are NOT in the AROI proof file. This could be someone falsely claiming your domain.' -%}
         {% set help_text = 'If this is YOUR relay: Add the fingerprint to your AROI proof file.' -%}
+    {% elif box_type == 'security_incident' -%}
+        {# B1.1: secret_family_key leaked. Highest urgency. #}
+        {% set box_class = 'al-box-danger' -%}
+        {% set border_color = '#c82333' -%}
+        {% set text_color = '#721c24' -%}
+        {% set icon = '🚨' -%}
+        {% set title = 'SECURITY INCIDENT — KEY ROTATION REQUIRED' -%}
+        {% set description = 'These relays appear to have published .secret_family_key contents instead of .public_family_id. The key MUST be rotated immediately.' -%}
+        {% set help_text = 'Rotate now: tor --keygen-family /path/newfile  → publish the new .public_family_id, then redeploy newfile.secret_family_key to every relay.' -%}
+    {% elif box_type == 'pending_onionoo' -%}
+        {# B1.1: missing_family_ids — Onionoo lag, transient. #}
+        {% set box_class = 'al-box-info' -%}
+        {% set border_color = '#17a2b8' -%}
+        {% set text_color = '#0c5460' -%}
+        {% set icon = '⏳' -%}
+        {% set title = 'WAITING FOR ONIONOO TO REFRESH' -%}
+        {% set description = "These relays declared ciissversion:3 but Onionoo hasn't picked up family_ids yet. This is transient — Onionoo refreshes hourly; expect resolution within 24 hours of restarting Tor with the happy-family directive." -%}
+        {% set help_text = 'No action needed if you recently changed torrc; wait < 24h. If still pending after 24h: verify FamilyId line in torrc and that .secret_family_key is in Tor KeyDir.' -%}
     {% else -%}
         {% set box_class = 'al-box-muted' -%}
         {% set border_color = '#6c757d' -%}
@@ -350,7 +456,8 @@
         {% set icon = '○' -%}
         {% set title = 'NOT CONFIGURED RELAY DETAILS' -%}
         {% set description = 'These relays have no AROI configuration or incomplete setup.' -%}
-        {% set help_text = 'To add AROI: Set contact info with ciissversion:2, proof:dns-rsa or proof:uri-rsa, and url:yourdomain.com' -%}
+        {# B1.3: pasteable v2 + v3 examples — operator chooses one. v3 listed FIRST as recommended. #}
+        {% set help_text = 'Add to torrc ContactInfo line (pick one):  v3 (recommended): ciissversion:3 url:yourdomain.com proof:uri-familyid-ed25519  ·  v2 (legacy): ciissversion:2 url:yourdomain.com proof:uri-rsa' -%}
     {% endif -%}
     
 <div class="{{ box_class }}" style="margin-top: 15px; padding: 15px; border-left-width: 4px; border-left-style: solid; border-radius: 4px;">
@@ -372,6 +479,9 @@
         {% for relay_info in relays %}
         <li style="margin-bottom: 6px; padding: 8px; background-color: #fff; border-radius: 3px; font-size: 13px; border: 1px solid {{ border_color }}40;">
             <strong><a href="{{ page_ctx.path_prefix }}relay/{{ relay_info.fingerprint }}/">{{ relay_info.nickname|escape }}</a></strong>
+            {%- if relay_info.aroi_version %}
+                <span style="font-size: 10px; padding: 1px 5px; border-radius: 3px; background-color: {{ '#007bff' if relay_info.aroi_version == '3' else '#6c757d' }}; color: white; vertical-align: middle;">v{{ relay_info.aroi_version }}</span>
+            {% endif -%}
             <span style="color: #666;">•</span>
             {% if relay_info.error -%}
                 <span class="al-status-danger">{{ relay_info.error|escape }}</span>
@@ -382,6 +492,26 @@
                 <span style="color: #666;">• Proof: {{ relay_info.proof_type }}</span>
             {% endif %}
             <span style="color: #666;">• FP: <code style="font-size: 11px;">{{ relay_info.fingerprint }}</code></span>
+            {%- if relay_info.hint %}
+            {# B1.3: Pasteable fix example from upstream's `hint` field
+               (or our V3_CATEGORY_LABELS lookup for parse-time errors).
+               Surfaced verbatim so operators get spec-grade actionable
+               text rather than paraphrased prose. #}
+            <div style="margin-top: 4px; font-size: 12px;">
+                <span style="color: {{ text_color }};">💡 Fix:</span>
+                <code style="background: #f8f9fa; padding: 2px 5px; border-radius: 3px; font-size: 11px; display: inline-block; word-break: break-all;">{{ relay_info.hint|escape }}</code>
+            </div>
+            {% endif -%}
+            {%- if relay_info.pasteable_example and relay_info.pasteable_example != relay_info.hint %}
+            {# B-final: pasteable one-line example from V3_CATEGORY_LABELS.
+               Rendered separately from `hint` because the upstream `hint`
+               may be multi-sentence prose; this is always a single
+               copy-paste-able line. #}
+            <div style="margin-top: 2px; font-size: 11px;">
+                <span style="color: {{ text_color }};">📋 Paste:</span>
+                <code style="background: #fff; padding: 2px 5px; border-radius: 3px; font-size: 11px; display: inline-block; word-break: break-all; border: 1px dashed {{ border_color }}80;">{{ relay_info.pasteable_example|escape }}</code>
+            </div>
+            {% endif -%}
         </li>
         {% endfor %}
     </ul>
@@ -396,9 +526,11 @@
 
 {# =============================================================================
    AROI SECTION HEADER MACRO (DRY - reused by all section macros)
+   Supports both v2-era cascade categories and B1.1 peer issue categories.
    ============================================================================= #}
 {% macro aroi_section_header(title, count, style_type) -%}
-{# style_type: 'validated' | 'misconfigured' | 'unauthorized' | 'not_configured' #}
+{# style_type: 'validated' | 'misconfigured' | 'unauthorized' | 'not_configured'
+              | 'security_incident' | 'pending_onionoo' | 'v3_migration' #}
 {% if style_type == 'validated' -%}
     {% set border_style = '3px solid #28a745' -%}
     {% set icon = '✓' -%}
@@ -411,6 +543,23 @@
     {% set border_style = '3px dashed #dc3545' -%}
     {% set icon = '🚫' -%}
     {% set link_class = 'al-status-danger al-link-plain' -%}
+{% elif style_type == 'security_incident' -%}
+    {# B1.1: highest visual priority — secret_family_key was leaked. #}
+    {% set border_style = '4px solid #c82333' -%}
+    {% set icon = '🚨' -%}
+    {% set link_class = 'al-status-danger al-link-plain' -%}
+{% elif style_type == 'pending_onionoo' -%}
+    {# B1.1: Onionoo lag — operator changed torrc but family_ids
+       haven't propagated yet. Transient (< 24h). #}
+    {% set border_style = '3px dotted #17a2b8' -%}
+    {% set icon = '⏳' -%}
+    {% set link_class = 'al-status-info al-link-plain' -%}
+{% elif style_type == 'v3_migration' -%}
+    {# B1.1: operator has both v2 + v3 declarations. Informational only;
+       neither alarming nor an issue. #}
+    {% set border_style = '3px dotted #007bff' -%}
+    {% set icon = '🔁' -%}
+    {% set link_class = 'al-status-info al-link-plain' -%}
 {% else -%}
     {% set border_style = '3px solid #6c757d' -%}
     {% set icon = '○' -%}

--- a/allium/templates/misc-contacts.html
+++ b/allium/templates/misc-contacts.html
@@ -135,18 +135,43 @@
                     {% set d = v['display'] -%}
                     <td class="contact-cell">
                         {% if v['aroi_domain'] and v['aroi_domain'] != 'none' -%}
+                            {# B1.6: peer issue markers FIRST (security + pending). Render
+                               alongside the cascade icon — they're orthogonal signals. #}
+                            {% if v.get('aroi_security_count', 0) > 0 -%}
+                            <span title="🚨 SECURITY: leaked .secret_family_key" class="al-status-danger">🚨</span> {% endif -%}
+                            {% if v.get('aroi_pending_count', 0) > 0 -%}
+                            <span title="⏳ v3 relays waiting for Onionoo to refresh family_ids" class="al-status-info">⏳</span> {% endif -%}
                             {% if v.get('aroi_validation_status') == 'validated' -%}
                             <span title="All relays validated" class="al-status-success">✓</span> {% elif v.get('aroi_validation_status') == 'unauthorized' -%}
                             <span title="Unauthorized: fingerprints not in proof file" class="al-status-danger">🚫</span> {% elif v.get('aroi_validation_status') == 'misconfigured' -%}
                             <span title="Misconfigured: validation errors" class="al-status-warning">⚠</span> {% elif v.get('aroi_validation_status') == 'incomplete' -%}
                             <span title="Incomplete: missing AROI fields" class="al-status-muted">⚬</span> {% endif -%}
+                            {# v3 tier markers removed per UX feedback —
+                               the operator-listing was visually noisy
+                               with trophy/etc. icons. v3 tier still
+                               surfaces on the operator detail page
+                               (contact.html) and in the AROI Validation
+                               Champions leaderboard column. #}
+                            {# Item 3 (variant-aware list views): when the
+                               operator publishes >1 distinct ContactInfo
+                               string under the same AROI domain (mid-
+                               migration v2 + v3 mix is the canonical
+                               case), the listing tooltip says so
+                               explicitly instead of pretending one
+                               representative string speaks for all
+                               relays. The operator-detail page remains
+                               the authoritative variant view. #}
+                            {%- set _cv = v.get('contact_variant_count', 1) or 1 -%}
+                            {%- set _ctitle = ((_cv ~ ' distinct ContactInfo strings under this AROI domain — see operator page for breakdown') if _cv > 1 else ('Contact: ' ~ v['contact']|e)) -%}
                             {% if base_url and v['aroi_domain'] in validated_aroi_domains -%}
-                            <a href="{{ base_url }}/{{ v['aroi_domain']|lower|escape }}/" title="Contact: {{ v['contact']|escape }}" style="text-decoration: underline;">{{ d.display_name|escape }}</a>
+                            <a href="{{ base_url }}/{{ v['aroi_domain']|lower|escape }}/" title="{{ _ctitle }}" style="text-decoration: underline;">{{ d.display_name|escape }}</a>
                             {% else -%}
-                            <a href="{{ page_ctx.path_prefix }}contact/{{ k|escape }}/" title="Contact: {{ v['contact']|escape }}" style="text-decoration: underline;">{{ d.display_name|escape }}</a>
+                            <a href="{{ page_ctx.path_prefix }}contact/{{ k|escape }}/" title="{{ _ctitle }}" style="text-decoration: underline;">{{ d.display_name|escape }}</a>
                             {% endif -%}
                         {% elif v['contact'] and v['contact'] != '' -%}
-                            <a href="{{ page_ctx.path_prefix }}contact/{{ k|escape }}/" title="Contact: {{ v['contact']|escape }}" style="text-decoration: underline;">{{ d.display_name|escape }}</a>
+                            {%- set _cv2 = v.get('contact_variant_count', 1) or 1 -%}
+                            {%- set _ctitle2 = ((_cv2 ~ ' distinct ContactInfo strings — see operator page') if _cv2 > 1 else ('Contact: ' ~ v['contact']|e)) -%}
+                            <a href="{{ page_ctx.path_prefix }}contact/{{ k|escape }}/" title="{{ _ctitle2 }}" style="text-decoration: underline;">{{ d.display_name|escape }}</a>
                         {% else -%}
                             <a href="{{ page_ctx.path_prefix }}contact/{{ k|escape }}/" title="No contact info" style="text-decoration: underline;">none</a>
                         {% endif -%}

--- a/allium/templates/misc-families.html
+++ b/allium/templates/misc-families.html
@@ -150,6 +150,16 @@
                         {% set d = v['display'] -%}
                         <td>
                                                     {% if v['aroi_domain'] and v['aroi_domain'] != 'none' -%}
+                            {# B5.2: v3 tier marker inline before the AROI domain link.
+                               Only renders when the family has at least one
+                               ciissversion:3 relay (sparse — same convention as
+                               misc-contacts.html B1.6 markers). #}
+                            {% set _ftier = v.get('aroi_v3_tier', 'none') -%}
+                            {% if _ftier == 'complete' -%}
+                            <span title="v3 Complete: all relays on ciissversion:3" class="al-status-success">🏆</span> {% elif _ftier == 'mostly' -%}
+                            <span title="v3 Mostly Migrated: {{ '%.0f'|format(v.get('aroi_v3_pct', 0)) }}% of relays on v3" class="al-status-success">🚀</span> {% elif _ftier == 'migrating' -%}
+                            <span title="v3 Migrating: {{ '%.0f'|format(v.get('aroi_v3_pct', 0)) }}% of relays on v3" class="al-status-info">🔁</span> {% elif _ftier == 'explorer' -%}
+                            <span title="v3 Explorer: started migrating to ciissversion:3" class="al-status-info">🔍</span> {% endif -%}
                             <a href="{{ page_ctx.path_prefix }}family/{{ k|escape }}/" title="Family {{ k|escape }}" style="text-decoration: underline;">{{ v['aroi_domain']|escape }} ({{ v['relays']|length }} relays) {{ k[:4]|escape }}</a>
                         {% else -%}
                             <a href="{{ page_ctx.path_prefix }}family/{{ k|escape }}/" title="Family {{ k|escape }}" style="text-decoration: underline;">{{ v['relays']|length }} Relays {{ k[:8]|escape }}</a>

--- a/allium/templates/network-health-dashboard.html
+++ b/allium/templates/network-health-dashboard.html
@@ -379,15 +379,23 @@ Network Health Dashboard
                 </div>
                 <!-- B2.1: v2 (RSA-fingerprint) proof types -->
                 <div class="metric-grid" style="grid-template-columns: repeat(2, 1fr);">
-                    <div class="metric-item" title="DNS-RSA (v2): {{ "{:,}".format(relays.json.network_health.dns_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_rsa_total) }} relays validated. CIISS v2 — DNS TXT record at &lt;domain&gt; (per spec; the record value contains the fingerprint, NOT the host).{% if relays.json.network_health.dns_error_top5 %}
-&#10;&#10;Top DNS failure reasons:{% for error, count in relays.json.network_health.dns_error_top5 %}
-&#10;• {{ error }} — {{ "{:,}".format(count) }} relays{% endfor %}{% endif %}">
+                    {# F2a: dns_error_top5 / uri_error_top5 are
+                       categorised by 'dns' / 'uri' substring of the
+                       proof type, NOT by ciissversion — meaning they
+                       lump v2 (DNS-RSA / URI-RSA) and v3 (DNS-FamilyID /
+                       URI-FamilyID) failures together. Showing those
+                       lists in the v2 tile would surface v3 failures
+                       on a v2-labelled card, which is misleading.
+                       Drop the "Top failure reasons" block from the
+                       v2 tiles until v2-scoped failure rollups exist;
+                       the per-proof-type Top error categories on the
+                       API Diagnostics page already provides v2/v3
+                       split via _build_error_rollup. #}
+                    <div class="metric-item" title="DNS-RSA (v2): {{ "{:,}".format(relays.json.network_health.dns_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_rsa_total) }} relays validated. CIISS v2 — DNS TXT record at &lt;domain&gt; (per spec; the record value contains the fingerprint, NOT the host).">
                         <span class="metric-value">{{ "{:,}".format(relays.json.network_health.dns_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_rsa_total) }} ({{ "%.1f%%"|format(relays.json.network_health.dns_rsa_success_rate) }})</span>
                         <span class="metric-label">DNS-RSA <span style="font-size: 9px; padding: 0 4px; background-color: #6c757d; color: white; border-radius: 2px;">v2</span></span>
                     </div>
-                    <div class="metric-item" title="URI-RSA (v2): {{ "{:,}".format(relays.json.network_health.uri_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.uri_rsa_total) }} relays validated. CIISS v2 — file at /.well-known/tor-relay/rsa-fingerprint.txt.{% if relays.json.network_health.uri_error_top5 %}
-&#10;&#10;Top URI failure reasons:{% for error, count in relays.json.network_health.uri_error_top5 %}
-&#10;• {{ error }} — {{ "{:,}".format(count) }} relays{% endfor %}{% endif %}">
+                    <div class="metric-item" title="URI-RSA (v2): {{ "{:,}".format(relays.json.network_health.uri_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.uri_rsa_total) }} relays validated. CIISS v2 — file at /.well-known/tor-relay/rsa-fingerprint.txt.">
                         <span class="metric-value">{{ "{:,}".format(relays.json.network_health.uri_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.uri_rsa_total) }} ({{ "%.1f%%"|format(relays.json.network_health.uri_rsa_success_rate) }})</span>
                         <span class="metric-label">URI-RSA <span style="font-size: 9px; padding: 0 4px; background-color: #6c757d; color: white; border-radius: 2px;">v2</span></span>
                     </div>
@@ -429,8 +437,23 @@ Network Health Dashboard
                 {%- set _v2_count = _decl.get('2', 0) -%}
                 {%- set _v3_count = _decl.get('3', 0) -%}
                 {%- set _none_count = _decl.get('none', 0) -%}
-                {%- set _v2_pct = relays.json.network_health.v2_success_rate -%}
-                {%- set _v3_pct = relays.json.network_health.v3_success_rate -%}
+                {# F2b: accurate validity calculation. Previously the
+                   tiles paired the declared count (_v{2,3}_count) with
+                   v{2,3}_success_rate which is the proof-attempt
+                   success rate (validated relays / total relays where
+                   the validator ran a proof attempt) — that ignored
+                   declared relays the validator hasn't yet processed
+                   and overstated validity. New ratio:
+                       validated('N') / declared('N')
+                   matches what the reader expects from a "X declared,
+                   Y% valid" tile: of the relays declaring ciissversion:N,
+                   Y% have a successful upstream validation. Uses
+                   ciissversion_validated (set by aroi_validation.py
+                   line 1141) and ciissversion_declared on the same
+                   network_health dict. #}
+                {%- set _val = relays.json.network_health.ciissversion_validated or {} -%}
+                {%- set _v2_pct = (_val.get('2', 0) / _v2_count * 100.0) if _v2_count > 0 else 0.0 -%}
+                {%- set _v3_pct = (_val.get('3', 0) / _v3_count * 100.0) if _v3_count > 0 else 0.0 -%}
                 <div class="metric-grid" style="grid-template-columns: repeat(3, 1fr);">
                     <div class="metric-item" title="Relays declaring ciissversion:2 in their ContactInfo. v2 uses RSA-fingerprint proofs (dns-rsa, uri-rsa) and is the legacy spec.">
                         <span class="metric-value">{{ "{:,}".format(_v2_count) }} ({{ "%.0f%%"|format(_v2_pct) }} valid)</span>

--- a/allium/templates/network-health-dashboard.html
+++ b/allium/templates/network-health-dashboard.html
@@ -440,7 +440,7 @@ Network Health Dashboard
                         <span class="metric-value">{{ "{:,}".format(_v3_count) }} ({{ "%.0f%%"|format(_v3_pct) }} valid)</span>
                         <span class="metric-label">ciissversion v3</span>
                     </div>
-                    <div class="metric-item" title="Relays not declaring any ciissversion in their ContactInfo (no AROI configured).">
+                    <div class="metric-item" title="ContactInfo records with no declared ciissversion (ciissversion missing — may still include legacy or unspecified AROI entries).">
                         <span class="metric-value">{{ "{:,}".format(_none_count) }}</span>
                         <span class="metric-label">No ciissversion</span>
                     </div>

--- a/allium/templates/network-health-dashboard.html
+++ b/allium/templates/network-health-dashboard.html
@@ -377,21 +377,83 @@ Network Health Dashboard
                         <div class="al-text-small-muted metric-subtext">{{ "%.1f%%"|format(relays.json.network_health.relays_without_aroi_percentage) }} of all relays</div>
                     </div>
                 </div>
-                <!-- DNS-RSA and URI-RSA Validation Rates -->
+                <!-- B2.1: v2 (RSA-fingerprint) proof types -->
                 <div class="metric-grid" style="grid-template-columns: repeat(2, 1fr);">
-                    <div class="metric-item" title="DNS-RSA validation: {{ "{:,}".format(relays.json.network_health.dns_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_rsa_total) }} relays validated. DNS-RSA uses DNS TXT records for domain verification.{% if relays.json.network_health.dns_error_top5 %}
+                    <div class="metric-item" title="DNS-RSA (v2): {{ "{:,}".format(relays.json.network_health.dns_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_rsa_total) }} relays validated. CIISS v2 — DNS TXT record at <fingerprint>.<domain>.{% if relays.json.network_health.dns_error_top5 %}
 &#10;&#10;Top DNS failure reasons:{% for error, count in relays.json.network_health.dns_error_top5 %}
 &#10;• {{ error }} — {{ "{:,}".format(count) }} relays{% endfor %}{% endif %}">
                         <span class="metric-value">{{ "{:,}".format(relays.json.network_health.dns_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_rsa_total) }} ({{ "%.1f%%"|format(relays.json.network_health.dns_rsa_success_rate) }})</span>
-                        <span class="metric-label">DNS-RSA Validated</span>
+                        <span class="metric-label">DNS-RSA <span style="font-size: 9px; padding: 0 4px; background-color: #6c757d; color: white; border-radius: 2px;">v2</span></span>
                     </div>
-                    <div class="metric-item" title="URI-RSA validation: {{ "{:,}".format(relays.json.network_health.uri_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.uri_rsa_total) }} relays validated. URI-RSA fetches proof from web server.{% if relays.json.network_health.uri_error_top5 %}
+                    <div class="metric-item" title="URI-RSA (v2): {{ "{:,}".format(relays.json.network_health.uri_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.uri_rsa_total) }} relays validated. CIISS v2 — file at /.well-known/tor-relay/rsa-fingerprint.txt.{% if relays.json.network_health.uri_error_top5 %}
 &#10;&#10;Top URI failure reasons:{% for error, count in relays.json.network_health.uri_error_top5 %}
 &#10;• {{ error }} — {{ "{:,}".format(count) }} relays{% endfor %}{% endif %}">
                         <span class="metric-value">{{ "{:,}".format(relays.json.network_health.uri_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.uri_rsa_total) }} ({{ "%.1f%%"|format(relays.json.network_health.uri_rsa_success_rate) }})</span>
-                        <span class="metric-label">URI-RSA Validated</span>
+                        <span class="metric-label">URI-RSA <span style="font-size: 9px; padding: 0 4px; background-color: #6c757d; color: white; border-radius: 2px;">v2</span></span>
                     </div>
                 </div>
+
+                <!-- B2.1: v3 (ed25519 happy-family) proof types. Only rendered
+                     when v3 totals > 0. -->
+                {% if (relays.json.network_health.dns_familyid_ed25519_total + relays.json.network_health.uri_familyid_ed25519_total) > 0 %}
+                {# B2.4 (final): v3 tile tooltips include top failure categories
+                   sourced from upstream's structured v3_failure_categories
+                   (preferred over substring matching). These complement the
+                   legacy dns_error_top5 / uri_error_top5 lists used by v2
+                   tiles, which remain in place per the planned alias-sunset
+                   schedule (next release after B2 ships). #}
+                {% set _v3_cats = relays.json.network_health.v3_failure_categories or {} %}
+                {% set _v3_top = _v3_cats.items()|sort(attribute=1, reverse=true)|list %}
+                <div class="metric-grid" style="grid-template-columns: repeat(2, 1fr);">
+                    <div class="metric-item" title="DNS-FamilyID (v3): {{ "{:,}".format(relays.json.network_health.dns_familyid_ed25519_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_familyid_ed25519_total) }} relays validated. CIISS v3 — DNS TXT at we-run-this-tor-ed25519-family-id.<domain>. Single shared family-ID proof for all relays.{% if _v3_top %}
+&#10;&#10;Top v3 failure categories (network-wide):{% for cat, count in _v3_top[:5] %}{% if count > 0 %}
+&#10;• {{ cat }} — {{ count }} relays{% endif %}{% endfor %}{% endif %}">
+                        <span class="metric-value">{{ "{:,}".format(relays.json.network_health.dns_familyid_ed25519_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_familyid_ed25519_total) }} ({{ "%.1f%%"|format(relays.json.network_health.dns_familyid_ed25519_success_rate) }})</span>
+                        <span class="metric-label">DNS-FamilyID <span style="font-size: 9px; padding: 0 4px; background-color: #007bff; color: white; border-radius: 2px;">v3</span></span>
+                    </div>
+                    <div class="metric-item" title="URI-FamilyID (v3): {{ "{:,}".format(relays.json.network_health.uri_familyid_ed25519_valid) }}/{{ "{:,}".format(relays.json.network_health.uri_familyid_ed25519_total) }} relays validated. CIISS v3 — file at /.well-known/tor-relay/ed25519-family-id.txt. Single shared family-ID proof for all relays.{% if _v3_top %}
+&#10;&#10;Top v3 failure categories (network-wide):{% for cat, count in _v3_top[:5] %}{% if count > 0 %}
+&#10;• {{ cat }} — {{ count }} relays{% endif %}{% endfor %}{% endif %}">
+                        <span class="metric-value">{{ "{:,}".format(relays.json.network_health.uri_familyid_ed25519_valid) }}/{{ "{:,}".format(relays.json.network_health.uri_familyid_ed25519_total) }} ({{ "%.1f%%"|format(relays.json.network_health.uri_familyid_ed25519_success_rate) }})</span>
+                        <span class="metric-label">URI-FamilyID <span style="font-size: 9px; padding: 0 4px; background-color: #007bff; color: white; border-radius: 2px;">v3</span></span>
+                    </div>
+                </div>
+                {% endif %}
+
+                <!-- B2.2 (revised per UX feedback): ciissversion adoption
+                     as 3 separate metric tiles matching the standard
+                     dashboard pattern (bold-black-value on top, grey
+                     label below). -->
+                {% set _decl = relays.json.network_health.ciissversion_declared or {} %}
+                {% if _decl.get('3', 0) > 0 %}
+                {%- set _v2_count = _decl.get('2', 0) -%}
+                {%- set _v3_count = _decl.get('3', 0) -%}
+                {%- set _none_count = _decl.get('none', 0) -%}
+                {%- set _v2_pct = relays.json.network_health.v2_success_rate -%}
+                {%- set _v3_pct = relays.json.network_health.v3_success_rate -%}
+                <div class="metric-grid" style="grid-template-columns: repeat(3, 1fr);">
+                    <div class="metric-item" title="Relays declaring ciissversion:2 in their ContactInfo. v2 uses RSA-fingerprint proofs (dns-rsa, uri-rsa) and is the legacy spec.">
+                        <span class="metric-value">{{ "{:,}".format(_v2_count) }} ({{ "%.0f%%"|format(_v2_pct) }} valid)</span>
+                        <span class="metric-label">ciissversion v2</span>
+                    </div>
+                    <div class="metric-item" title="Relays declaring ciissversion:3 in their ContactInfo. v3 uses ed25519 happy-family proofs (dns-familyid-ed25519, uri-familyid-ed25519) and is the recommended new spec.">
+                        <span class="metric-value">{{ "{:,}".format(_v3_count) }} ({{ "%.0f%%"|format(_v3_pct) }} valid)</span>
+                        <span class="metric-label">ciissversion v3</span>
+                    </div>
+                    <div class="metric-item" title="Relays not declaring any ciissversion in their ContactInfo (no AROI configured).">
+                        <span class="metric-value">{{ "{:,}".format(_none_count) }}</span>
+                        <span class="metric-label">No ciissversion</span>
+                    </div>
+                </div>
+                {% endif %}
+
+                <!-- B2.3: Schema-version footnote -->
+                {% if relays.json.network_health.aroi_schema_version is not none %}
+                <div style="margin-top: 8px; font-size: 10px; color: #6c757d; text-align: right;">
+                    Source: <a href="https://aroivalidator.1aeo.com/" target="_blank" rel="noopener" style="color: #6c757d;">aroivalidator.1aeo.com</a>
+                    (schema v{{ relays.json.network_health.aroi_schema_version }}{% if relays.json.network_health.aroi_schema_version > 2 %} <span style="color: #c82333;">⚠ newer than tested</span>{% endif %})
+                </div>
+                {% endif %}
                 <!-- Contact Row (moved before Family) -->
                 <div class="metric-grid" style="grid-template-columns: repeat(3, 1fr);">
                     <div class="metric-item" title="Total number of unique contact addresses provided by relay operators.">

--- a/allium/templates/network-health-dashboard.html
+++ b/allium/templates/network-health-dashboard.html
@@ -379,7 +379,7 @@ Network Health Dashboard
                 </div>
                 <!-- B2.1: v2 (RSA-fingerprint) proof types -->
                 <div class="metric-grid" style="grid-template-columns: repeat(2, 1fr);">
-                    <div class="metric-item" title="DNS-RSA (v2): {{ "{:,}".format(relays.json.network_health.dns_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_rsa_total) }} relays validated. CIISS v2 — DNS TXT record at <fingerprint>.<domain>.{% if relays.json.network_health.dns_error_top5 %}
+                    <div class="metric-item" title="DNS-RSA (v2): {{ "{:,}".format(relays.json.network_health.dns_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_rsa_total) }} relays validated. CIISS v2 — DNS TXT record at &lt;fingerprint&gt;.&lt;domain&gt;.{% if relays.json.network_health.dns_error_top5 %}
 &#10;&#10;Top DNS failure reasons:{% for error, count in relays.json.network_health.dns_error_top5 %}
 &#10;• {{ error }} — {{ "{:,}".format(count) }} relays{% endfor %}{% endif %}">
                         <span class="metric-value">{{ "{:,}".format(relays.json.network_health.dns_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_rsa_total) }} ({{ "%.1f%%"|format(relays.json.network_health.dns_rsa_success_rate) }})</span>
@@ -405,7 +405,7 @@ Network Health Dashboard
                 {% set _v3_cats = relays.json.network_health.v3_failure_categories or {} %}
                 {% set _v3_top = _v3_cats.items()|sort(attribute=1, reverse=true)|list %}
                 <div class="metric-grid" style="grid-template-columns: repeat(2, 1fr);">
-                    <div class="metric-item" title="DNS-FamilyID (v3): {{ "{:,}".format(relays.json.network_health.dns_familyid_ed25519_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_familyid_ed25519_total) }} relays validated. CIISS v3 — DNS TXT at we-run-this-tor-ed25519-family-id.<domain>. Single shared family-ID proof for all relays.{% if _v3_top %}
+                    <div class="metric-item" title="DNS-FamilyID (v3): {{ "{:,}".format(relays.json.network_health.dns_familyid_ed25519_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_familyid_ed25519_total) }} relays validated. CIISS v3 — DNS TXT at we-run-this-tor-ed25519-family-id.&lt;domain&gt;. Single shared family-ID proof for all relays.{% if _v3_top %}
 &#10;&#10;Top v3 failure categories (network-wide):{% for cat, count in _v3_top[:5] %}{% if count > 0 %}
 &#10;• {{ cat }} — {{ count }} relays{% endif %}{% endfor %}{% endif %}">
                         <span class="metric-value">{{ "{:,}".format(relays.json.network_health.dns_familyid_ed25519_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_familyid_ed25519_total) }} ({{ "%.1f%%"|format(relays.json.network_health.dns_familyid_ed25519_success_rate) }})</span>

--- a/allium/templates/network-health-dashboard.html
+++ b/allium/templates/network-health-dashboard.html
@@ -379,7 +379,7 @@ Network Health Dashboard
                 </div>
                 <!-- B2.1: v2 (RSA-fingerprint) proof types -->
                 <div class="metric-grid" style="grid-template-columns: repeat(2, 1fr);">
-                    <div class="metric-item" title="DNS-RSA (v2): {{ "{:,}".format(relays.json.network_health.dns_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_rsa_total) }} relays validated. CIISS v2 — DNS TXT record at &lt;fingerprint&gt;.&lt;domain&gt;.{% if relays.json.network_health.dns_error_top5 %}
+                    <div class="metric-item" title="DNS-RSA (v2): {{ "{:,}".format(relays.json.network_health.dns_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_rsa_total) }} relays validated. CIISS v2 — DNS TXT record at &lt;domain&gt; (per spec; the record value contains the fingerprint, NOT the host).{% if relays.json.network_health.dns_error_top5 %}
 &#10;&#10;Top DNS failure reasons:{% for error, count in relays.json.network_health.dns_error_top5 %}
 &#10;• {{ error }} — {{ "{:,}".format(count) }} relays{% endfor %}{% endif %}">
                         <span class="metric-value">{{ "{:,}".format(relays.json.network_health.dns_rsa_valid) }}/{{ "{:,}".format(relays.json.network_health.dns_rsa_total) }} ({{ "%.1f%%"|format(relays.json.network_health.dns_rsa_success_rate) }})</span>

--- a/allium/templates/relay-info.html
+++ b/allium/templates/relay-info.html
@@ -51,12 +51,103 @@
 {# AROI section with verification badge and relay count #}
 {% if has_aroi -%}
     <a href="{{ operator_url }}" title="View all relays by this operator">Operator: {{ relay['aroi_domain']|escape }}</a>
+    {%- if relay.get('aroi_version') %}
+        <span style="font-size: 9px; padding: 0 4px; border-radius: 2px; background-color: {{ '#007bff' if relay.get('aroi_version') == '3' else '#6c757d' }}; color: white;" title="ciissversion:{{ relay.get('aroi_version') }}{%- if relay.get('aroi_proof_type') %} / proof:{{ relay.get('aroi_proof_type') }}{% endif %}">v{{ relay.get('aroi_version') }}</span>
+    {% endif -%}
     {% if contact_validation_status and contact_validation_status.validation_summary -%}
         ({{ contact_validation_status.validation_summary.total_relays }} {{ plural(contact_validation_status.validation_summary.total_relays) }})
     {% endif -%}
     {{- aroi_validation_badge(contact_validation_status) -}}
+    {# B3.1: per-relay status flag for THIS relay specifically (distinct
+       from the operator-level cascade badge above). Prefixed with
+       "this relay:" to disambiguate when operator and relay statuses
+       differ (e.g. operator validated overall but THIS relay is pending).
+
+       The cascade-status overlap suppression logic below avoids
+       redundant badges when the per-relay status matches what the
+       operator-level cascade already shows. Cascade ↔ relay-status
+       overlap rules:
+         - operator status 'unauthorized' suppresses _unauth relay flag
+         - operator status 'misconfigured' suppresses _miscfg relay flag
+       Peer issues (security/pending) ALWAYS show because they're
+       relay-level signals not directly captured by the cascade. #}
+    {# B3.1: per-relay status flag for THIS relay specifically. Only
+       rendered when DIFFERENT from what the operator-level cascade /
+       peer badges already convey, to avoid redundant duplicates like
+       "⏳ Pending ⏳ Pending" or "🚫 Unauthorized 🚫 Unauthorized".
+       Suppression rules:
+         - operator cascade matches this relay's status → suppress
+         - operator-level peer badge (security/pending) covers this
+           relay → suppress
+       Renders ONLY when this relay's status genuinely diverges from
+       operator-level (e.g. operator validated overall but THIS relay
+       is uniquely pending). #}
+    {# Per-relay status flag determined by classifying the relay into
+       its TRUE bucket FIRST, then deciding whether to render based on
+       suppression rules. Bucket priority:
+         security_incident > pending_onionoo > validated >
+         unauthorized > misconfigured
+       Pending-and-misconfigured dual-bucketing (for cascade purposes)
+       is resolved here: if a relay is in the pending bucket, its
+       TRUE category is "pending", not "misconfigured", regardless of
+       what other sets it appears in. #}
+    {%- if contact_validation_status -%}
+        {%- set _fp = relay['fingerprint'] -%}
+        {%- set _summary = contact_validation_status.validation_summary or {} -%}
+        {%- set _op_status = contact_validation_status.validation_status -%}
+        {%- set _op_has_security = _summary.get('security_incident_count', 0) > 0 -%}
+        {%- set _op_has_pending = _summary.get('pending_onionoo_count', 0) > 0 -%}
+        {%- set _sec_fps = contact_validation_status.security_incident_fingerprints or [] -%}
+        {%- set _pend_fps = contact_validation_status.pending_onionoo_fingerprints or [] -%}
+        {%- set _unauth_fps = contact_validation_status.unauthorized_fingerprints or [] -%}
+        {%- set _miscfg_fps = contact_validation_status.misconfigured_fingerprints or [] -%}
+        {%- set _val_fps = contact_validation_status.validated_fingerprints or [] -%}
+        {# Resolve the relay's TRUE category respecting bucket priority. #}
+        {%- if _fp in _sec_fps -%}
+            {%- set _true_cat = 'security' -%}
+        {%- elif _fp in _pend_fps -%}
+            {%- set _true_cat = 'pending' -%}
+        {%- elif _fp in _val_fps -%}
+            {%- set _true_cat = 'validated' -%}
+        {%- elif _fp in _unauth_fps -%}
+            {%- set _true_cat = 'unauthorized' -%}
+        {%- elif _fp in _miscfg_fps -%}
+            {%- set _true_cat = 'misconfigured' -%}
+        {%- else -%}
+            {%- set _true_cat = none -%}
+        {%- endif -%}
+        {# Now decide whether to render: only when relay's true category
+           DIFFERS from what operator-level badges already convey. #}
+        {%- if _true_cat == 'security' and not _op_has_security -%}
+            <span class="al-status-danger" style="margin-left: 5px; padding: 1px 5px; background-color: #f8d7da; border-radius: 3px;" title="🚨 SECURITY: this relay's contact appears to have leaked .secret_family_key. Rotate the family key immediately.">🚨 this relay: SECURITY</span>
+        {%- elif _true_cat == 'pending' and not _op_has_pending -%}
+            <span class="al-status-info" style="margin-left: 5px; padding: 1px 5px; background-color: #d1ecf1; border-radius: 3px;" title="⏳ Pending Onionoo refresh — this relay declared ciissversion:3 but family_ids haven't propagated yet.">⏳ this relay: Pending</span>
+        {%- elif _true_cat == 'validated' and _op_status != 'validated' -%}
+            <span class="al-status-success" style="margin-left: 5px; padding: 1px 5px; background-color: #d4edda; border-radius: 3px;" title="✓ This specific relay's AROI proof validated — sibling relays may not have.">✓ this relay: Validated</span>
+        {%- elif _true_cat == 'unauthorized' and _op_status != 'unauthorized' -%}
+            <span class="al-status-danger" style="margin-left: 5px; padding: 1px 5px; background-color: #f8d7da; border-radius: 3px;" title="🚫 Unauthorized — this relay's fingerprint is not in the operator's published proof file.">🚫 this relay: Unauthorized</span>
+        {%- elif _true_cat == 'misconfigured' and _op_status != 'misconfigured' -%}
+            <span class="al-status-warning" style="margin-left: 5px; padding: 1px 5px; background-color: #fff3cd; border-radius: 3px;" title="⚠ Misconfigured — see operator page for details.">⚠ this relay: Misconfigured</span>
+        {%- endif -%}
+    {%- endif -%}
     | 
 {% endif -%}
+{# B3.1 (re-opened): explicit one-line pending-Onionoo note when this
+   relay's contact declared ciissversion:3 but family_ids hasn't
+   propagated yet. Plan called for a "same explicit ⏳ note as on
+   the contact page" — operators landing on a v3 relay page with
+   no validation should immediately understand it's transient. #}
+{%- if has_aroi and contact_validation_status -%}
+    {%- set _fp = relay['fingerprint'] -%}
+    {%- set _pend_fps = contact_validation_status.pending_onionoo_fingerprints or [] -%}
+    {%- if _fp in _pend_fps %}
+<div style="margin: 4px 0 8px 0; padding: 6px 10px; background-color: #d1ecf1; border-left: 3px dotted #17a2b8; font-size: 11px; color: #0c5460;">
+    ⏳ <strong>Pending Onionoo refresh:</strong> this relay declared <code>ciissversion:3</code> but
+    Onionoo hasn't picked up <code>family_ids</code> yet. Typically resolves within 24h after
+    restarting Tor with the happy-family directive. No action needed unless still pending after 24h.
+</div>
+    {%- endif %}
+{%- endif %}
 {% if relay['effective_family']|length > 1 -%}
     <a href="{{ page_ctx.path_prefix }}family/{{ relay['fingerprint']|escape }}/" title="View family members">Family: {{ relay['effective_family']|length }} relays</a>
 {% else -%}

--- a/allium/templates/relay-info.html
+++ b/allium/templates/relay-info.html
@@ -132,22 +132,12 @@
     {%- endif -%}
     | 
 {% endif -%}
-{# B3.1 (re-opened): explicit one-line pending-Onionoo note when this
-   relay's contact declared ciissversion:3 but family_ids hasn't
-   propagated yet. Plan called for a "same explicit ⏳ note as on
-   the contact page" — operators landing on a v3 relay page with
-   no validation should immediately understand it's transient. #}
-{%- if has_aroi and contact_validation_status -%}
-    {%- set _fp = relay['fingerprint'] -%}
-    {%- set _pend_fps = contact_validation_status.pending_onionoo_fingerprints or [] -%}
-    {%- if _fp in _pend_fps %}
-<div style="margin: 4px 0 8px 0; padding: 6px 10px; background-color: #d1ecf1; border-left: 3px dotted #17a2b8; font-size: 11px; color: #0c5460;">
-    ⏳ <strong>Pending Onionoo refresh:</strong> this relay declared <code>ciissversion:3</code> but
-    Onionoo hasn't picked up <code>family_ids</code> yet. Typically resolves within 24h after
-    restarting Tor with the happy-family directive. No action needed unless still pending after 24h.
-</div>
-    {%- endif %}
-{%- endif %}
+{# Pending-Onionoo callout previously lived here, INSIDE the <h4>
+   (open at line 49, close at line 170). Browsers auto-close the
+   <h4> before a block-level <div>, which silently re-parents the
+   div and breaks the planned layout. Moved to right after the
+   </h4> below — same condition, same content, just at a valid
+   point in the document tree. #}
 {% if relay['effective_family']|length > 1 -%}
     <a href="{{ page_ctx.path_prefix }}family/{{ relay['fingerprint']|escape }}/" title="View family members">Family: {{ relay['effective_family']|length }} relays</a>
 {% else -%}
@@ -168,6 +158,26 @@ Country: unknown
 {% endif -%} | 
 <a href="{{ page_ctx.path_prefix }}platform/{{ relay['platform']|escape }}/">{{ relay['platform']|escape }}</a>
 </h4>
+
+{# B3.1 (re-opened): explicit one-line pending-Onionoo note when this
+   relay's contact declared ciissversion:3 but family_ids hasn't
+   propagated yet. Plan called for a "same explicit ⏳ note as on
+   the contact page" — operators landing on a v3 relay page with
+   no validation should immediately understand it's transient.
+   Reviewer-flagged: previously rendered INSIDE the <h4>, which is
+   invalid HTML (block-level <div> in heading) and got auto-reparented
+   by browsers. Now placed after </h4>. #}
+{%- if has_aroi and contact_validation_status -%}
+    {%- set _fp = relay['fingerprint'] -%}
+    {%- set _pend_fps = contact_validation_status.pending_onionoo_fingerprints or [] -%}
+    {%- if _fp in _pend_fps %}
+<div style="margin: 4px 0 8px 0; padding: 6px 10px; background-color: #d1ecf1; border-left: 3px dotted #17a2b8; font-size: 11px; color: #0c5460;">
+    ⏳ <strong>Pending Onionoo refresh:</strong> this relay declared <code>ciissversion:3</code> but
+    Onionoo hasn't picked up <code>family_ids</code> yet. Typically resolves within 24h after
+    restarting Tor with the happy-family directive. No action needed unless still pending after 24h.
+</div>
+    {%- endif %}
+{%- endif %}
 
 {# ============== HEALTH STATUS SUMMARY (Enhanced) ============== #}
 {# Displays 14 metrics in 8 cells using responsive 2-column layout #}

--- a/allium/templates/relay-list.html
+++ b/allium/templates/relay-list.html
@@ -81,6 +81,12 @@
 			    {% else -%}
 			    <a href="{{ page_ctx.path_prefix }}contact/{{ relay['contact_md5'] }}/" title="{{ relay['aroi_domain']|escape }}">{{ relay['aroi_domain']|escape }}</a>
 			    {% endif -%}
+			    {#- B5.2: per-relay version badge in AROI cell of relay-list pages
+			        (country, AS, family, networks, platforms, all-relays).
+			        Sparse: omitted when relay didn't declare a version. -#}
+			    {%- if relay.get('aroi_version') %}
+			    <span style="font-size: 9px; padding: 0 3px; border-radius: 2px; background-color: {{ '#007bff' if relay.get('aroi_version') == '3' else '#6c757d' }}; color: white; vertical-align: middle;" title="ciissversion:{{ relay.get('aroi_version') }}">v{{ relay.get('aroi_version') }}</span>
+			    {%- endif %}
 			</td>
 		    {% else -%}
 			<td>none</td>

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -34,6 +34,25 @@ Every doc should include:
 - Specific numbers: "Uses ~2.4GB memory with `--apis all`"
 - Code references: "See `lib/aroileaders.py`"
 
+### Pasteable-examples convention (operator-facing UI)
+
+When an Allium template surfaces operator-actionable guidance (AROI
+fix hints, torrc snippets, command-line invocations), the copy MUST
+be pasteable verbatim — never prose. Operators should be able to
+copy a `<code>` block and apply it directly without translating
+instructions into commands.
+
+- Do: `tor --keygen-family /path/myfamily`
+- Do: `ContactInfo ... ciissversion:3 url:foo.bar proof:uri-familyid-ed25519`
+- Don't: "Generate a happy-family key on a secure host using the
+  appropriate Tor command, then..."
+
+For AROI v3 error categories, the pasteable string lives in
+`V3_CATEGORY_LABELS[<category>]['example']` in
+`allium/lib/aroi_validation.py`. When upstream `aroivalidator` adds a
+new `error_category`, A.8 logs a one-time warning so we know to add a
+new entry.
+
 ### Don't
 
 - "We successfully implemented..."

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -85,7 +85,23 @@ Core data processing class. Responsibilities:
 Multiprocessing workers for page generation. Uses fork-based process pool with copy-on-write memory sharing.
 
 ### `lib/aroileaders.py`
-AROI leaderboard calculations. Computes rankings across 18 categories for authenticated operators.
+AROI leaderboard calculations. Computes rankings across 18 categories
+for authenticated operators. Supports both CIISS spec v2 (RSA-fingerprint
+proofs) and v3 (ed25519 happy-family proofs); the AROI Validation
+Champions table surfaces v2/v3 split columns plus tiered v3 migration
+badges (Explorer / Migrating / Mostly / Complete) at 1% / 25% / 75% /
+100% v3 adoption thresholds.
+
+### `lib/aroi_validation.py`
+Single source of truth for CIISS spec parsing, validation-result
+processing, and v3 tier classification. Exports the constants
+(`SUPPORTED_CIISSVERSIONS`, `V2_PROOF_TYPES`, `V3_PROOF_TYPES`,
+`PROOF_TYPE_STAT_KEYS`, `V3_TIER_*`), the regex pair shared with
+`lib/relays.py`, and the `V3_CATEGORY_LABELS` dict that maps every
+upstream `error_category` to a pasteable-example operator hint.
+`get_contact_validation_status` does the per-contact cascade and emits
+the peer-issue buckets (`security_incident_relays`,
+`pending_onionoo_relays`) consumed by templates.
 
 ### `lib/uptime_utils.py`
 Uptime data processing. Normalizes Onionoo values (0-999 → 0-100%), calculates averages, detects outliers.

--- a/docs/development/security.md
+++ b/docs/development/security.md
@@ -86,6 +86,33 @@ display_name = onionoo_data['nickname']  # UNSAFE
 - [ ] No sensitive data in commits
 - [ ] Bandit scan passes
 
+## AROI v3 Security Surfacing
+
+When the upstream AROI validator
+(`https://aroivalidator.1aeo.com/latest.json`) reports a
+`secret_key_leaked` `error_category` for a relay, allium escalates that
+relay to a **first-class security incident** category that surfaces:
+
+- A `🚨 SECURITY` badge next to the operator's AROI status (renders
+  alongside, NOT replacing, the cascade status).
+- A dedicated `SECURITY INCIDENT — ROTATE FAMILY KEY` section above
+  all other issue sections on the contact page, with an explicit
+  `tor --keygen-family <newfile>` rotation hint sourced verbatim from
+  the validator's `hint` field.
+- A `🚨 SECURITY` per-relay flag on the affected relay-info page.
+- A `🚨` marker on the misc-contacts listing for the operator.
+
+This is allium's only "always above the fold" UI signal — a relay
+publishing `.secret_family_key` content (instead of
+`.public_family_id`) is a credential exposure that must be rotated
+immediately. The validator detects this server-side; allium's job is to
+make sure the affected operator sees it the next time they (or anyone)
+loads their contact page.
+
+See `allium/lib/aroi_validation.py::get_contact_validation_status` for
+the bucketing logic and `allium/templates/macros.html::aroi_validation_badge`
++ `aroi_relay_detail_box` for the rendering.
+
 ## How to Verify
 
 ```bash

--- a/docs/features/planned/aroi-validation-integration-plan.md
+++ b/docs/features/planned/aroi-validation-integration-plan.md
@@ -245,10 +245,28 @@ Network Health Dashboard
 ## Implementation Timeline
 
 - **Phase 1:** ✅ Complete (Nov 23, 2025) - Network Health Dashboard
-- **Phase 2:** High priority (Operator badges)
+- **Phase 2:** ✅ Complete (May 5, 2026) - Operator pages (Part B1 of dual-spec rollout)
 - **Phase 3:** Medium priority (Validation status page)
 - **Phase 4:** ✅ Complete (Nov 29, 2025) - AROI Leaderboards Enhancement
-- **Phase 5:** Low priority (Relay pages)
+- **Phase 5:** ✅ Complete (May 5, 2026) - Relay pages (Part B3 of dual-spec rollout)
+- **Phase 6:** ✅ Complete (May 5, 2026) - Dual-spec support (CIISS v2 + v3)
+  - Part A — data backend (constants, schema handshake, error_category
+    cascade, hint passthrough, peer buckets, error rollup, V3_CATEGORY_LABELS,
+    build-time observability)
+  - Part B1 — operator pages (v2/v3 pills, peer-issue sections, pasteable
+    examples, per-operator rollup table, misc-contacts tier markers)
+  - Part B2 — network health dashboard (v2/v3 panels, ciissversion
+    adoption tile, schema footnote)
+  - Part B3 — individual relay pages (per-relay version badge + status flags)
+  - Part B4 — leaderboards (v2/v3 split columns + tiered migration badges
+    Explorer/Migrating/Mostly/Complete at 1%/25%/75%/100%)
+  - Part B5 — search index v1.6 (vn/v3p/v3_thresholds) + v2→v3
+    upgrade nudge for v2-only validated operators
+  - Part B6 — API diagnostics page (schema, version distribution, error
+    categories)
+  - Part B7 — Prometheus per-version labels + new
+    aeo1_aroi_relays_count_by_version metric
+  - Part B8 — documentation
 
 ---
 
@@ -260,6 +278,7 @@ Network Health Dashboard
 
 ---
 
-**Last Updated:** 2025-11-29  
-**Current Phase:** Phases 1 & 4 Complete, Phase 2 Ready to Start
+**Last Updated:** 2026-05-05
+**Current Phase:** Phases 1, 2, 4, 5, and 6 (dual-spec v2 + v3) all complete.
+Phase 3 (dedicated validation status page) remains as future work.
 

--- a/docs/features/planned/aroi-validation-v3-verification-report.md
+++ b/docs/features/planned/aroi-validation-v3-verification-report.md
@@ -1,0 +1,123 @@
+# AROI v3 — End-to-end verification report
+
+**Date**: 2026-05-06
+**Branch**: `cursor/aroi-v3-support` @ `894e357699`
+**Master baseline**: `master` @ origin
+**Method**: clean rebuild of master + branch with `--apis all`, then
+diff every output file and cross-validate against live Onionoo +
+aroivalidator data.
+
+## Build summary
+
+| | Master | Branch |
+|---|---|---|
+| Total relays | 10,867 | 10,867 |
+| Total contacts | 3,160 | 3,161 |
+| Families | 6,305 | 6,305 |
+| Build time | ~3.5 min | ~3.5 min |
+| AROI status line | (no v2/v3 split) | ✓ AROI: schema v2, 2810/3226 v2 valid, 322/332 v3 valid |
+
+## Diff categorization (master → branch)
+
+```
+Common files:        27,422
+  Identical:            312
+  Timestamp only:    11,145
+  Content diffs:     15,850
+Only in baseline:       144 (10 distinct contacts)
+Only in after:          127 (9 distinct contacts)
+```
+
+### Only-in-X analysis (271 files, 19 contacts)
+
+**ALL 19 distinct contacts are v3-driven re-bucketing.** Master grouped v3 operators by `md5(individual_contact:<full_string>)` because its regex rejected `ciissversion:3`; branch correctly groups them by `md5(aroi_domain:<domain>)`. Total v3 relays re-bucketed: **332** (exactly matches upstream count).
+
+| Master hash | → Branch hash | Operator | v3 relays |
+|---|---|---|---|
+| `aeacb4e8` | `ca802db3` | dfri.se | 148 |
+| `16af3d36` | `54432e80` | applied-privacy.net | 120 |
+| `32661c82` | `64e974a7` | (33-relay v3 op) | 33 |
+| `0f37bfe7` | `b35fedab` | (9-relay v3 op) | 9 |
+| `2233f27b` | `592c6ac7` | 1aeo.com (the user's example) | 8 |
+| `5d176435` | `2eb044c3` | (5-relay v3 op) | 5 |
+| `a7ab61d5` | `cd2d6797` | themadhacker.net | 4 |
+| `357d3908` | `13419a25` | (3-relay v3 op) | 3 |
+| `4cdc5765` | `ef142a76` | (1-relay v3 op) | 1 |
+| `0a6f89c5` | `48798099` | (1-relay v3 op) | 1 |
+
+This is the **exact intended fix**: master silently mis-bucketed every v3 operator; branch correctly groups them into proper AROI-domain contact pages.
+
+### Content diff breakdown (15,850 files)
+
+| Bucket | Count | Cause | Intentional? |
+|---|---|---|---|
+| relay pages | 3,582 | B3 v2/v3 badge + per-relay status flags on AROI relays | ✅ Yes |
+| contact pages | 7,830 | B1 pills/peer-issue sections/rollup table on AROI contacts (and family pages including them) | ✅ Yes |
+| family pages | 4,153 | Family pages render contact-relay-list.html which has new sections | ✅ Yes |
+| AS pages | 162 | Sample inspection: pure volatile-time drift ("X ago" strings, "Last fetch" GMT timestamps) | ✅ Drift only |
+| country pages | 42 | Same as AS pages, plus relay-list v2/v3 badges where applicable | ✅ Drift + B5.2 |
+| flag pages | 11 | Volatile time drift | ✅ Drift only |
+| first_seen pages | 18 | Volatile time drift | ✅ Drift only |
+| platform pages | 7 | Volatile time drift | ✅ Drift only |
+| misc pages | 40 | B2 dashboard, B4 leaderboard, B5 search index, B6 diagnostics, B1.6 misc-contacts | ✅ Yes |
+| root pages | 5 | search-index.json (B5.1 schema 1.6), index page, all relays, top500 | ✅ Yes |
+
+**Conclusion**: every diff is either an intentional v3 surface change or live data drift between the two builds (~10min apart). No accidental regressions.
+
+## Onionoo + aroivalidator content accuracy validation
+
+Spot-checked 4 key relay-info pages against live source data:
+
+### Test 1: `eisbaer` (applied-privacy.net, valid v3)
+- Onionoo says: `family_ids = ['Ajo1uQ+kzXdIToo6wib4iZLnf7oqSHLsqjqxSrdcQfE']`
+- aroivalidator says: `valid=True, proof_type=dns-familyid-ed25519, ciissversion=3`
+- ✅ rendered shows `applied-privacy.net` (matches upstream domain)
+- ✅ rendered shows blue `v3` badge
+- ✅ rendered shows `✓ Validated`
+- ✅ no `⏳ Pending` (correct — relay is valid)
+- ✅ no per-relay duplicate badge (op cascade=validated, suppression works)
+
+### Test 2: `kodakblack` (1aeo.com, missing_family_ids)
+- Onionoo says: `family_ids = NOT_PRESENT` (operator hasn't refreshed yet)
+- aroivalidator says: `valid=False, error_category=missing_family_ids`
+- ✅ rendered shows blue `v3` badge
+- ✅ rendered shows operator-level `⏳ Pending` peer badge
+- ✅ rendered shows explicit "⏳ Pending Onionoo refresh" note explaining transient
+- ✅ no per-relay `⏳ Pending` duplicate (suppressed correctly after audit fix)
+
+### Test 3: `TheMadHacker5Plaza` (themadhacker.net, uri_file_missing)
+- aroivalidator says: `valid=False, error_category=uri_file_missing`
+- ✅ rendered shows blue `v3` badge
+- ✅ rendered shows operator-level `🚫 Unauthorized` cascade (other relays hit content_mismatch)
+- ✅ rendered shows per-relay `⚠ this relay: Misconfigured` with disambiguating prefix (this relay's `uri_file_missing` is misconfigured-not-unauthorized)
+- ✅ no false `✓ Validated`
+
+### Test 4: Network Health Dashboard counts
+| Metric | Live source | Rendered | Match |
+|---|---|---|---|
+| ciissversion v2 declared | 3383 | 3383 | ✅ |
+| ciissversion v3 declared | 332 | 332 | ✅ |
+| v2 success rate | 87.0% (2808 of 3226 attempts) | 87.0% | ✅ |
+| v3 success rate | 97.0% (322 of 332 attempts) | 97.0% | ✅ |
+| DNS-FamilyID | 268/268 (100%) | 268/268 (100%) | ✅ |
+| URI-FamilyID | 54/64 (84.4%) | 54/64 (84.4%) | ✅ |
+
+## Issue surfaced + fixed during this audit
+
+The before/after comparison + cross-validation surfaced **one real UX bug** that prior continuation passes hadn't caught:
+
+**Bug**: relay-info pages stacked operator-level badges AND relay-specific badges, producing confusing duplicates like `✓ Validated ⏳ Pending ⏳ this relay: Pending`.
+
+**Root cause**: pending-bucket relays are also in misconfigured-bucket (dual-bucketing for cascade purposes). When pending was suppressed, the elif chain fell through to misconfigured.
+
+**Fix** (commit `894e357699`): resolve relay's TRUE category FIRST with strict priority order, then decide whether to render based on operator-level overlap. Adds `this relay:` prefix for disambiguation. Renders ONLY when relay status differs from what operator-level badges already convey.
+
+## Sign-off
+
+- **891 tests** pass in default `pytest tests/` (offline)
+- **+1 system-marker test** for live API verification (codified A.10 smoke check)
+- **0 unintentional diffs** in master → branch comparison
+- **All sampled rendered content** matches live Onionoo + aroivalidator data exactly
+- **Bug from audit** identified and fixed
+
+The branch is verified ready for review.

--- a/docs/prometheus/alerts_aroi.yml
+++ b/docs/prometheus/alerts_aroi.yml
@@ -58,6 +58,42 @@ groups:
       #   annotations:
       #     summary: "AROI checked coverage is low ({{ $value | humanizePercentage }})"
 
+      # ----------------------------------------------------------------
+      # B7.2: per-version alerts (CIISS v2 + v3 dual-spec)
+      # Sourced from aeo1_aroi_relays_count_by_version (B7.2 metric) +
+      # the aeo1_aroi_v3_*_derived recording rules (optional).
+      # ----------------------------------------------------------------
+
+      # v3 success rate dropped sharply — possible upstream regression
+      # (validator broke a rule, schema bumped, or operators
+      # mass-mismigrated). Threshold deliberately permissive to avoid
+      # noise during the migration funnel; tighten once v3 stabilises.
+      - alert: AroiV3SuccessRateLow
+        expr: aeo1_aroi_v3_success_ratio_derived < 0.80
+        for: 6h
+        labels:
+          severity: warning
+        annotations:
+          summary: "AROI v3 success rate low ({{ $value | humanizePercentage }})"
+          description: "Possible upstream regression or mass operator misconfig. Investigate aroivalidator schema + recent v3 declarations."
+
+      # SECURITY: any relay leaking .secret_family_key. Always page.
+      # If aeo1_aroi_relays_count_by_version emits a non-zero count with
+      # ciissversion="3" + state="configured_checked_invalid", and the
+      # operator's relay-info metric has secret_key_leaked error
+      # category, this is a credential incident.
+      # NOTE: this requires a future per-error-category metric; for now,
+      # operators should subscribe to allium build logs which warn on
+      # the secret_key_leaked category via _warn_unknown_error_categories
+      # observability path. Documenting here as planned future work.
+      # - alert: AroiSecretKeyLeaked
+      #   expr: aeo1_aroi_secret_key_leaked_count > 0
+      #   for: 0m
+      #   labels:
+      #     severity: critical
+      #   annotations:
+      #     summary: "{{ $value }} relays appear to have leaked .secret_family_key"
+
   - name: aeo1_freshness
     interval: 1m
     rules:

--- a/docs/prometheus/alerts_aroi.yml
+++ b/docs/prometheus/alerts_aroi.yml
@@ -61,9 +61,17 @@ groups:
       # ----------------------------------------------------------------
       # B7.2: per-version alerts (CIISS v2 + v3 dual-spec)
       # Sourced from aeo1_aroi_relays_count_by_version (B7.2 metric) +
-      # the aeo1_aroi_v3_*_derived recording rules (optional).
+      # the aeo1_aroi_v3_*_derived recording rules.
       # ----------------------------------------------------------------
 
+      # IMPORTANT: AroiV3SuccessRateLow depends on the recording rule
+      # `aeo1_aroi_v3_success_ratio_derived` defined in
+      # docs/prometheus/recording_rules.yml. If you have NOT installed
+      # recording_rules.yml alongside this file, the alert query will
+      # never match anything (silent no-op) — same precedent as
+      # AroiCheckedCoverageLow above. Either install recording_rules.yml
+      # before relying on this alert, or comment it out until you do.
+      #
       # v3 success rate dropped sharply — possible upstream regression
       # (validator broke a rule, schema bumped, or operators
       # mass-mismigrated). Threshold deliberately permissive to avoid

--- a/docs/prometheus/recording_rules.yml
+++ b/docs/prometheus/recording_rules.yml
@@ -38,3 +38,47 @@ groups:
           aeo1_aroi_relays_count{state="configured_checked_valid"}
           /
           clamp_min(aeo1_aroi_configured_relays_count_derived, 1)
+
+      # ----------------------------------------------------------------
+      # B7.2: per-version recording rules (CIISS v2 + v3 dual-spec)
+      # Sourced from aeo1_aroi_relays_count_by_version{state, ciissversion}.
+      # Cardinality bound: 4 states × 4 ciissversion = 16 series per scrape.
+      # ----------------------------------------------------------------
+
+      # v2 declared (configured) relay count
+      - record: aeo1_aroi_v2_configured_relays_count_derived
+        expr: >
+          sum(aeo1_aroi_relays_count_by_version{ciissversion="2"})
+          - aeo1_aroi_relays_count_by_version{ciissversion="2",state="not_configured"}
+
+      # v3 declared (configured) relay count
+      - record: aeo1_aroi_v3_configured_relays_count_derived
+        expr: >
+          sum(aeo1_aroi_relays_count_by_version{ciissversion="3"})
+          - aeo1_aroi_relays_count_by_version{ciissversion="3",state="not_configured"}
+
+      # v3 success ratio (over v3 configured)
+      - record: aeo1_aroi_v3_success_ratio_derived
+        expr: >
+          aeo1_aroi_relays_count_by_version{ciissversion="3",state="configured_checked_valid"}
+          /
+          clamp_min(aeo1_aroi_v3_configured_relays_count_derived, 1)
+
+      # v2 success ratio (over v2 configured)
+      - record: aeo1_aroi_v2_success_ratio_derived
+        expr: >
+          aeo1_aroi_relays_count_by_version{ciissversion="2",state="configured_checked_valid"}
+          /
+          clamp_min(aeo1_aroi_v2_configured_relays_count_derived, 1)
+
+      # v3 migration adoption ratio: v3 declared / total declared.
+      # Network-wide migration progress KPI for dashboards.
+      - record: aeo1_aroi_v3_adoption_ratio_derived
+        expr: >
+          aeo1_aroi_v3_configured_relays_count_derived
+          /
+          clamp_min(
+            aeo1_aroi_v2_configured_relays_count_derived
+            + aeo1_aroi_v3_configured_relays_count_derived,
+            1
+          )

--- a/docs/prometheus/recording_rules.yml
+++ b/docs/prometheus/recording_rules.yml
@@ -65,18 +65,29 @@ groups:
 
       # v3 success ratio (over v3 configured). sum() on the numerator
       # for the same label-matching reason as above.
+      #
+      # The previous version used clamp_min(..., 1) to avoid divide-
+      # by-zero, but that caused installations with zero v3-configured
+      # relays to emit a misleading 0% series. Switched to `unless` to
+      # DROP the series entirely when configured count is zero —
+      # cleaner for dashboards (no fake 0% line) and for AroiV3SuccessRateLow
+      # alerting (no spurious "v3 success rate is 0%" page when the
+      # operator simply hasn't migrated to v3 yet).
       - record: aeo1_aroi_v3_success_ratio_derived
         expr: >
           sum(aeo1_aroi_relays_count_by_version{ciissversion="3",state="configured_checked_valid"})
           /
-          clamp_min(aeo1_aroi_v3_configured_relays_count_derived, 1)
+          aeo1_aroi_v3_configured_relays_count_derived
+          unless aeo1_aroi_v3_configured_relays_count_derived == 0
 
-      # v2 success ratio (over v2 configured)
+      # v2 success ratio (over v2 configured) — same drop-on-zero
+      # behaviour as v3 for symmetry.
       - record: aeo1_aroi_v2_success_ratio_derived
         expr: >
           sum(aeo1_aroi_relays_count_by_version{ciissversion="2",state="configured_checked_valid"})
           /
-          clamp_min(aeo1_aroi_v2_configured_relays_count_derived, 1)
+          aeo1_aroi_v2_configured_relays_count_derived
+          unless aeo1_aroi_v2_configured_relays_count_derived == 0
 
       # v3 migration adoption ratio: v3 declared / total declared.
       # Network-wide migration progress KPI for dashboards.

--- a/docs/prometheus/recording_rules.yml
+++ b/docs/prometheus/recording_rules.yml
@@ -45,29 +45,36 @@ groups:
       # Cardinality bound: 4 states × 4 ciissversion = 16 series per scrape.
       # ----------------------------------------------------------------
 
-      # v2 declared (configured) relay count
+      # v2 declared (configured) relay count.
+      # NOTE: every operand is wrapped in sum(...) so both sides of the
+      # subtraction have an EMPTY label set. Mixing a sum() result with
+      # a labeled vector (e.g. aeo1_aroi_relays_count_by_version{...})
+      # would yield no-match vector arithmetic and emit nothing.
       - record: aeo1_aroi_v2_configured_relays_count_derived
         expr: >
           sum(aeo1_aroi_relays_count_by_version{ciissversion="2"})
-          - aeo1_aroi_relays_count_by_version{ciissversion="2",state="not_configured"}
+          -
+          sum(aeo1_aroi_relays_count_by_version{ciissversion="2",state="not_configured"})
 
       # v3 declared (configured) relay count
       - record: aeo1_aroi_v3_configured_relays_count_derived
         expr: >
           sum(aeo1_aroi_relays_count_by_version{ciissversion="3"})
-          - aeo1_aroi_relays_count_by_version{ciissversion="3",state="not_configured"}
+          -
+          sum(aeo1_aroi_relays_count_by_version{ciissversion="3",state="not_configured"})
 
-      # v3 success ratio (over v3 configured)
+      # v3 success ratio (over v3 configured). sum() on the numerator
+      # for the same label-matching reason as above.
       - record: aeo1_aroi_v3_success_ratio_derived
         expr: >
-          aeo1_aroi_relays_count_by_version{ciissversion="3",state="configured_checked_valid"}
+          sum(aeo1_aroi_relays_count_by_version{ciissversion="3",state="configured_checked_valid"})
           /
           clamp_min(aeo1_aroi_v3_configured_relays_count_derived, 1)
 
       # v2 success ratio (over v2 configured)
       - record: aeo1_aroi_v2_success_ratio_derived
         expr: >
-          aeo1_aroi_relays_count_by_version{ciissversion="2",state="configured_checked_valid"}
+          sum(aeo1_aroi_relays_count_by_version{ciissversion="2",state="configured_checked_valid"})
           /
           clamp_min(aeo1_aroi_v2_configured_relays_count_derived, 1)
 

--- a/docs/prometheus/recording_rules.yml
+++ b/docs/prometheus/recording_rules.yml
@@ -91,12 +91,21 @@ groups:
 
       # v3 migration adoption ratio: v3 declared / total declared.
       # Network-wide migration progress KPI for dashboards.
+      #
+      # Same drop-on-zero guard as the success-ratio rules above:
+      # `unless ... == 0` omits the series entirely when the network has
+      # zero AROI-configured relays (rather than emitting a misleading
+      # 0/1 = 0% line that would imply v3 adoption is collapsing when
+      # actually nothing is configured).
       - record: aeo1_aroi_v3_adoption_ratio_derived
         expr: >
           aeo1_aroi_v3_configured_relays_count_derived
           /
-          clamp_min(
+          (
             aeo1_aroi_v2_configured_relays_count_derived
-            + aeo1_aroi_v3_configured_relays_count_derived,
-            1
+            + aeo1_aroi_v3_configured_relays_count_derived
           )
+          unless (
+            aeo1_aroi_v2_configured_relays_count_derived
+            + aeo1_aroi_v3_configured_relays_count_derived
+          ) == 0

--- a/docs/reference/api-integration.md
+++ b/docs/reference/api-integration.md
@@ -52,8 +52,24 @@
 | **Memory** | Minimal |
 | **Required** | No |
 | **Failure** | AROI validation features disabled |
+| **Schema versions tested** | 1, 2 (see `AROIVALIDATOR_TESTED_SCHEMAS`) |
 
-**Purpose**: Provides cryptographic proof of relay operator identity for AROI leaderboards.
+**Purpose**: Provides cryptographic proof of relay operator identity for
+AROI leaderboards. Allium consumes the validator's output for both
+**CIISS ContactInfo specification version 2** (RSA-fingerprint proofs:
+`dns-rsa`, `uri-rsa`) and **version 3** (ed25519 happy-family proofs:
+`dns-familyid-ed25519`, `uri-familyid-ed25519`). Both versions are
+supported concurrently during the migration window — operators are
+nudged toward v3 but not forced.
+
+**Schema-version handshake**: Allium reads
+`metadata.aroivalidator_schema_version` and logs a one-time warning
+when an unrecognized schema is received but does **not** reject the
+data — this is forward-compatible by design. The schema version is
+surfaced as `aroi_schema_version` in `network_health` metrics and shown
+as a footnote on the dashboard. When the validator adds a new
+`error_category` value, allium logs a one-time warning so we know to
+update `V3_CATEGORY_LABELS` in `aroi_validation.py`.
 
 ### CollecTor Consensus (Optional)
 

--- a/docs/reference/current-capabilities.md
+++ b/docs/reference/current-capabilities.md
@@ -12,7 +12,7 @@
 | Onionoo Details API | Core relay data | ~400MB |
 | Onionoo Uptime API | Historical uptime | ~2GB |
 | Onionoo Bandwidth API | Historical bandwidth | ~500MB |
-| AROI Validator API | Authenticated operators | Minimal |
+| AROI Validator API | Authenticated operators (CIISS v2 + v3 dual-spec) | Minimal |
 | CollecTor Consensus | Flag thresholds (optional) | Minimal |
 
 ### Processing

--- a/tests/integration/test_contact_template.py
+++ b/tests/integration/test_contact_template.py
@@ -1015,5 +1015,260 @@ class TestContactMultiprocessingRegression(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(vanity_dir, "by-ipv6.html")))
 
 
+class TestB3V3RelayInfoRendering(unittest.TestCase):
+    """B3.2 (re-opened): integration tests for v3 awareness in
+    relay-info / contact macros. Focused on the new B1 + B3 rendering
+    contract — does NOT duplicate the data-layer tests in
+    test_aroi_validation.py.
+
+    Verifies that the macros emit:
+    - aroi_v2v3_pills strip when v2_relay_count + v3_relay_count > 0
+    - 🚨 SECURITY badge when security_incident_count > 0
+    - ⏳ Pending badge when pending_onionoo_count > 0
+    - 🏆 v3 complete pill when 100% v3 + not mixed
+    - 🔁 migration percentage when is_mixed_migration
+    - relay-info v2/v3 version label per relay
+    """
+
+    def setUp(self):
+        import os
+        from jinja2 import Environment, FileSystemLoader
+        template_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+            'allium', 'templates'
+        )
+        self.jinja_env = Environment(
+            loader=FileSystemLoader(template_dir), autoescape=True,
+        )
+
+    def _render_pills(self, validation_summary):
+        """Render the aroi_v2v3_pills macro with a fake validation status."""
+        template_str = (
+            "{% from 'macros.html' import aroi_v2v3_pills %}"
+            "{{ aroi_v2v3_pills(contact_validation_status) }}"
+        )
+        template = self.jinja_env.from_string(template_str)
+        return template.render(contact_validation_status={
+            'validation_summary': validation_summary,
+        })
+
+    def test_pills_hidden_when_no_aroi_relays(self):
+        """No pill strip when operator has 0 v2 + 0 v3 relays."""
+        rendered = self._render_pills({
+            'v2_relay_count': 0, 'v3_relay_count': 0,
+            'v3_relay_percentage': 0.0, 'is_mixed_migration': False,
+            'v3_tier': 'none', 'is_v3_adopter': False,
+        })
+        self.assertNotIn('v2:', rendered)
+        self.assertNotIn('v3:', rendered)
+
+    def test_v2_only_pill(self):
+        """Operator with only v2 relays: gray v2 pill, no v3 pill."""
+        rendered = self._render_pills({
+            'v2_relay_count': 5, 'v3_relay_count': 0,
+            'v3_relay_percentage': 0.0, 'is_mixed_migration': False,
+            'v3_tier': 'none', 'is_v3_adopter': False,
+        })
+        self.assertIn('v2: 5', rendered)
+        self.assertNotIn('v3:', rendered)
+
+    def test_v3_complete_marker(self):
+        """100% v3 operator: pill + 🏆 v3 complete badge."""
+        rendered = self._render_pills({
+            'v2_relay_count': 0, 'v3_relay_count': 10,
+            'v3_relay_percentage': 100.0, 'is_mixed_migration': False,
+            'v3_tier': 'complete', 'is_v3_adopter': True,
+        })
+        self.assertIn('v3: 10', rendered)
+        self.assertIn('🏆 v3 complete', rendered)
+        self.assertNotIn('🔁', rendered)
+
+    def test_mixed_migration_marker(self):
+        """Mixed v2/v3 operator: shows 🔁 migration percentage."""
+        rendered = self._render_pills({
+            'v2_relay_count': 7, 'v3_relay_count': 3,
+            'v3_relay_percentage': 30.0, 'is_mixed_migration': True,
+            'v3_tier': 'migrating', 'is_v3_adopter': True,
+        })
+        self.assertIn('v2: 7', rendered)
+        self.assertIn('v3: 3', rendered)
+        self.assertIn('🔁 30% v3', rendered)
+
+    def test_security_badge_renders_alongside_validated(self):
+        """B1.1: 🚨 SECURITY badge appears AT THE TOP of badge group
+        when security_incident_count > 0, not replacing cascade."""
+        template_str = (
+            "{% from 'macros.html' import aroi_validation_badge %}"
+            "{{ aroi_validation_badge(contact_validation_status) }}"
+        )
+        template = self.jinja_env.from_string(template_str)
+        rendered = template.render(contact_validation_status={
+            'validation_status': 'validated',
+            'validation_summary': {
+                'validated_count': 5,
+                'unauthorized_count': 0,
+                'misconfigured_count': 1,
+                'incomplete_count': 0,
+                'not_configured_count': 0,
+                'security_incident_count': 1,
+                'pending_onionoo_count': 0,
+            },
+        })
+        # Both badges visible (not exclusive).
+        self.assertIn('🚨 SECURITY', rendered)
+        self.assertIn('Validated', rendered)
+
+    def test_pending_onionoo_badge_NOT_rendered_in_header(self):
+        """UX-fix: ⏳ Pending peer badge intentionally REMOVED from
+        aroi_validation_badge header to avoid the confusing
+        "✓ Validated ⏳ Pending" dual presentation. Pending relays
+        are dual-bucketed into 'misconfigured' so the cascade badge
+        already conveys "something needs attention", and the section
+        anchor (#misconfigured-relays) drills into the per-relay
+        error_category for actionable detail.
+        """
+        template_str = (
+            "{% from 'macros.html' import aroi_validation_badge %}"
+            "{{ aroi_validation_badge(contact_validation_status) }}"
+        )
+        template = self.jinja_env.from_string(template_str)
+        rendered = template.render(contact_validation_status={
+            'validation_status': 'validated',
+            'validation_summary': {
+                'validated_count': 5,
+                'unauthorized_count': 0,
+                'misconfigured_count': 1,
+                'incomplete_count': 0,
+                'not_configured_count': 0,
+                'security_incident_count': 0,
+                'pending_onionoo_count': 6,
+            },
+        })
+        # Cascade badge IS rendered.
+        self.assertIn('Validated', rendered)
+        # ⏳ Pending peer badge is NO LONGER rendered in the header.
+        self.assertNotIn('⏳ Pending', rendered)
+
+    def test_aroi_validation_icon_v3_label(self):
+        """B1.5: aroi_validation_icon appends 'v3' badge for v3 relays."""
+        template_str = (
+            "{% from 'macros.html' import aroi_validation_icon %}"
+            "{{ aroi_validation_icon('AAAA', 'v3.example.com', "
+            "validated_fps, [], [], [], [], '3') }}"
+        )
+        template = self.jinja_env.from_string(template_str)
+        rendered = template.render(validated_fps={'AAAA'})
+        self.assertIn('v3</span>', rendered)
+        # v3 label uses blue background (matches B1.6 styling).
+        self.assertIn('background-color: #007bff', rendered)
+
+    def test_aroi_validation_icon_pending_takes_precedence(self):
+        """B1.5: ⏳ icon takes visual precedence over the cascade icon."""
+        template_str = (
+            "{% from 'macros.html' import aroi_validation_icon %}"
+            "{{ aroi_validation_icon('AAAA', 'v3.example.com', "
+            "validated_fps, [], [], [], pending_fps, '3') }}"
+        )
+        template = self.jinja_env.from_string(template_str)
+        rendered = template.render(
+            validated_fps={'AAAA'},
+            pending_fps={'AAAA'},
+        )
+        # Pending icon present; validated checkmark absent in same span group.
+        self.assertIn('⏳', rendered)
+        # Validated checkmark not emitted because pending branch ran first.
+        self.assertNotIn('AROI Validated:', rendered)
+
+    def test_relay_detail_box_renders_fix_and_paste_when_distinct(self):
+        """B-final pasteable contract: aroi_relay_detail_box renders both
+        💡 Fix: (upstream hint) AND 📋 Paste: (V3_CATEGORY_LABELS example)
+        when they differ, ensuring operators always see a literally-pasteable
+        line even when upstream hint is multi-sentence prose."""
+        template_str = (
+            "{% from 'macros.html' import aroi_relay_detail_box %}"
+            "{{ aroi_relay_detail_box(relays, 'misconfigured', page_ctx, ts) }}"
+        )
+        template = self.jinja_env.from_string(template_str)
+        rendered = template.render(
+            relays=[{
+                'fingerprint': 'A' * 40,
+                'nickname': 'TestRelay',
+                'aroi_domain': 'foo.bar',
+                'aroi_version': '3',
+                'proof_type': 'uri-familyid-ed25519',
+                'error': 'URI-FamilyID: family_id not found at foo.bar',
+                'hint': 'Multi-sentence upstream prose. Confirm content. Never paste secrets.',
+                'pasteable_example': '# /.well-known/tor-relay/ed25519-family-id.txt must list family_id',
+                'error_category': 'uri_content_mismatch',
+            }],
+            page_ctx={'path_prefix': ''},
+            ts='2026-05-06 03:00 UTC',
+        )
+        # Both 💡 Fix: and 📋 Paste: render
+        self.assertIn('💡 Fix:', rendered)
+        self.assertIn('📋 Paste:', rendered)
+        # Upstream hint visible in 💡 Fix: block
+        self.assertIn('Multi-sentence upstream prose', rendered)
+        # V3_CATEGORY_LABELS example visible in 📋 Paste: block
+        self.assertIn('.well-known/tor-relay', rendered)
+        # v3 version label appended next to nickname
+        self.assertIn('v3</span>', rendered)
+
+    def test_relay_detail_box_dedups_paste_when_identical_to_hint(self):
+        """B-final pasteable contract: when hint == pasteable_example
+        (e.g. parse-time errors that share the V3_CATEGORY_LABELS source),
+        skip the 📋 Paste: block to avoid duplication."""
+        template_str = (
+            "{% from 'macros.html' import aroi_relay_detail_box %}"
+            "{{ aroi_relay_detail_box(relays, 'not_configured', page_ctx, ts) }}"
+        )
+        template = self.jinja_env.from_string(template_str)
+        same_text = '# pick consistent pair: ciissversion:3 + proof:uri-familyid-ed25519'
+        rendered = template.render(
+            relays=[{
+                'fingerprint': 'B' * 40,
+                'nickname': 'MismatchRelay',
+                'aroi_domain': None,
+                'missing': 'ciissversion:2 declared but proof:uri-familyid-ed25519',
+                'hint': same_text,
+                'pasteable_example': same_text,
+                'error_category': 'version_proof_mismatch',
+            }],
+            page_ctx={'path_prefix': ''},
+            ts='2026-05-06 03:00 UTC',
+        )
+        # 💡 Fix: renders (hint is set)
+        self.assertIn('💡 Fix:', rendered)
+        # 📋 Paste: NOT rendered because hint == pasteable_example (dedup guard)
+        self.assertNotIn('📋 Paste:', rendered)
+
+    def test_relay_detail_box_security_incident_box_type(self):
+        """B1.1: 'security_incident' box type renders red border + 🚨 +
+        rotation guidance."""
+        template_str = (
+            "{% from 'macros.html' import aroi_relay_detail_box %}"
+            "{{ aroi_relay_detail_box(relays, 'security_incident', page_ctx, ts) }}"
+        )
+        template = self.jinja_env.from_string(template_str)
+        rendered = template.render(
+            relays=[{
+                'fingerprint': 'C' * 40,
+                'nickname': 'LeakedRelay',
+                'aroi_domain': 'leak.bar',
+                'aroi_version': '3',
+                'error': 'SECURITY: published .secret_family_key',
+                'hint': 'Rotate immediately',
+                'pasteable_example': 'tor --keygen-family <newfile>',
+                'error_category': 'secret_key_leaked',
+            }],
+            page_ctx={'path_prefix': ''},
+            ts=None,
+        )
+        self.assertIn('SECURITY INCIDENT', rendered)
+        self.assertIn('🚨', rendered)
+        # Pasteable rotation command surfaced
+        self.assertIn('tor --keygen-family', rendered)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/system/test_aroi_v3_live_smoke.py
+++ b/tests/system/test_aroi_v3_live_smoke.py
@@ -18,8 +18,8 @@ Or with pytest, opt-in via the marker:
     pytest -m system tests/system/test_aroi_v3_live_smoke.py
 """
 import hashlib
+import os
 import sys
-from unittest.mock import patch
 
 import pytest
 
@@ -37,7 +37,13 @@ def test_aroi_v3_a10_smoke_against_live_apis():
     pytest.importorskip("requests")
     import requests
 
-    target_hash = "592c6ac73b6520aabeaed46dacbbb914"
+    # Allow operators running this against a different test contact
+    # without code changes (e.g. when 1aeo.com's hash rotates or for
+    # local debugging of a specific operator).
+    target_hash = os.getenv(
+        "ALLIUM_A10_SMOKE_HASH",
+        "592c6ac73b6520aabeaed46dacbbb914",
+    )
     ua = {"User-Agent": "Allium-V3-Smoke-Test/1.0"}
 
     aroi_data = requests.get(
@@ -47,15 +53,20 @@ def test_aroi_v3_a10_smoke_against_live_apis():
     onionoo_data = requests.get(
         "https://onionoo.torproject.org/details"
         "?fields=fingerprint,nickname,contact,country,first_seen",
-        timeout=60,
+        headers=ua, timeout=60,
     ).json()
 
     from allium.lib.relays import Relays
     from allium.lib.aroi_validation import get_contact_validation_status
 
-    with patch.object(Relays, "__init__", lambda x, **kwargs: None):
-        relays_obj = Relays()
-        parser = relays_obj._simple_aroi_parsing
+    # _simple_aroi_parsing is a pure parsing method that doesn't touch
+    # `self` (the regexes it uses are module-level constants). Bind it
+    # directly off the class instead of constructing a half-initialised
+    # Relays instance via patch.object("__init__", ...) — simpler and
+    # avoids relying on patch internals. We pass `None` for the unused
+    # self argument since the method's signature still requires it.
+    def parser(contact_str):
+        return Relays._simple_aroi_parsing(None, contact_str)
 
     matching = []
     for relay in onionoo_data["relays"]:
@@ -110,8 +121,8 @@ def test_aroi_v3_a10_smoke_against_live_apis():
 if __name__ == "__main__":
     # Allow direct invocation outside pytest. Need to add the repo
     # root to sys.path so the `allium.lib.*` imports resolve.
-    import os, sys as _sys
-    _sys.path.insert(
+    # Module-level `os` and `sys` imports are reused here.
+    sys.path.insert(
         0,
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
     )

--- a/tests/system/test_aroi_v3_live_smoke.py
+++ b/tests/system/test_aroi_v3_live_smoke.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Live smoke test for AROI v3 acceptance criterion A.10.
+
+Per PLAN.md (Part A.10):
+  > Smoke check: in a debugger, fetch the validation_summary for
+  > contact hash 592c6ac73b6520aabeaed46dacbbb914 and confirm
+  > is_v3_adopter, pending_onionoo_count, security_incident_count
+  > are populated correctly.
+
+This codifies that smoke check as a runnable test against live
+upstream data (aroivalidator.1aeo.com + onionoo.torproject.org).
+
+Excluded from the default pytest run (network-dependent); runnable via:
+    python3 tests/system/test_aroi_v3_live_smoke.py
+
+Or with pytest, opt-in via the marker:
+    pytest -m system tests/system/test_aroi_v3_live_smoke.py
+"""
+import hashlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# Match the pattern used by tests/system/test_real_api.py: slow + system
+# markers so the test is deselected from default `pytest -m "not slow"`
+# runs but still discoverable via `pytest -m system tests/system/`.
+# Without `slow`, this test would make 2 HTTP requests on every pytest
+# invocation — bad for CI flakiness and offline development.
+pytestmark = [pytest.mark.slow, pytest.mark.system]
+
+
+def test_aroi_v3_a10_smoke_against_live_apis():
+    """A.10: validate is_v3_adopter / pending_onionoo_count /
+    security_incident_count on the user-cited contact hash."""
+    pytest.importorskip("requests")
+    import requests
+
+    target_hash = "592c6ac73b6520aabeaed46dacbbb914"
+    ua = {"User-Agent": "Allium-V3-Smoke-Test/1.0"}
+
+    aroi_data = requests.get(
+        "https://aroivalidator.1aeo.com/latest.json",
+        headers=ua, timeout=30,
+    ).json()
+    onionoo_data = requests.get(
+        "https://onionoo.torproject.org/details"
+        "?fields=fingerprint,nickname,contact,country,first_seen",
+        timeout=60,
+    ).json()
+
+    from allium.lib.relays import Relays
+    from allium.lib.aroi_validation import get_contact_validation_status
+
+    with patch.object(Relays, "__init__", lambda x, **kwargs: None):
+        relays_obj = Relays()
+        parser = relays_obj._simple_aroi_parsing
+
+    matching = []
+    for relay in onionoo_data["relays"]:
+        contact = relay.get("contact", "") or ""
+        domain, version, proof = parser(contact)
+        if domain != "none":
+            ghash = hashlib.md5(f"aroi_domain:{domain}".encode()).hexdigest()
+            if ghash == target_hash:
+                relay.update({
+                    "aroi_domain": domain,
+                    "aroi_version": version,
+                    "aroi_proof_type": proof,
+                    "aroi_configured": True,
+                })
+                matching.append(relay)
+        elif hashlib.md5(contact.encode()).hexdigest() == target_hash:
+            relay.update({
+                "aroi_domain": "none",
+                "aroi_version": version,
+                "aroi_proof_type": proof,
+                "aroi_configured": False,
+            })
+            matching.append(relay)
+
+    assert matching, f"no relays matched contact hash {target_hash}"
+
+    result = get_contact_validation_status(matching, aroi_data)
+    summary = result["validation_summary"]
+
+    # Plan A.10 explicitly asks for these three fields:
+    assert "is_v3_adopter" in summary
+    assert isinstance(summary["is_v3_adopter"], bool)
+
+    assert "pending_onionoo_count" in summary
+    assert isinstance(summary["pending_onionoo_count"], int)
+    assert summary["pending_onionoo_count"] >= 0
+
+    assert "security_incident_count" in summary
+    assert isinstance(summary["security_incident_count"], int)
+    assert summary["security_incident_count"] >= 0
+
+    # A.5 v3 migration metadata present:
+    assert summary["v3_tier"] in {
+        "none", "explorer", "migrating", "mostly", "complete",
+    }
+    assert isinstance(summary["is_mixed_migration"], bool)
+    assert summary["v2_relay_count"] >= 0
+    assert summary["v3_relay_count"] >= 0
+    assert 0.0 <= summary["v3_relay_percentage"] <= 100.0
+
+
+if __name__ == "__main__":
+    # Allow direct invocation outside pytest. Need to add the repo
+    # root to sys.path so the `allium.lib.*` imports resolve.
+    import os, sys as _sys
+    _sys.path.insert(
+        0,
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    )
+    test_aroi_v3_a10_smoke_against_live_apis()
+    print("OK: A.10 smoke check passed.")

--- a/tests/system/test_timeout_integration.py
+++ b/tests/system/test_timeout_integration.py
@@ -18,10 +18,18 @@ import sys
 import threading
 import time
 from datetime import datetime
+from pathlib import Path
 
 # Configuration
 SLOW_SERVER_PORT = 19100
 HANG_DURATION = 300  # 5 minutes - longer than any timeout
+
+# Repo-relative path to the allium package directory used as cwd for
+# the subprocess invocation. Resolves from this test file's location
+# (tests/system/test_timeout_integration.py) up to the repo root and
+# into ./allium, so the test works regardless of where the repo is
+# checked out (no hard-coded /workspace).
+ALLIUM_CWD = str(Path(__file__).resolve().parents[2] / "allium")
 
 
 class HangingAPIHandler(http.server.BaseHTTPRequestHandler):
@@ -102,7 +110,7 @@ def run_allium_with_hanging_details_api():
     try:
         result = subprocess.run(
             cmd,
-            cwd="/workspace/allium",
+            cwd=ALLIUM_CWD,
             capture_output=True,
             text=True,
             timeout=180,  # 3 minute timeout for the entire test
@@ -191,7 +199,7 @@ def run_allium_with_hanging_uptime_api():
     try:
         result = subprocess.run(
             cmd,
-            cwd="/workspace/allium",
+            cwd=ALLIUM_CWD,
             capture_output=True,
             text=True,
             timeout=180,

--- a/tests/unit/aroi/test_aroi_domain_extraction.py
+++ b/tests/unit/aroi/test_aroi_domain_extraction.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 """
-Test AROI domain extraction to ensure it follows the AROI spec requirements.
-Tests validation that contact strings must have ciissversion:2, proof:(dns-rsa|uri-rsa), and url:<domain>.
+Test AROI domain extraction follows the CIISS spec for both v2 and v3.
+
+Recognised contact formats:
+  - CIISS v2: ciissversion:2 + proof:(dns-rsa|uri-rsa) + url:<domain>
+  - CIISS v3: ciissversion:3 + proof:(dns-familyid-ed25519|uri-familyid-ed25519) + url:<domain>
 """
 
 import unittest
@@ -11,83 +14,202 @@ from allium.lib.relays import Relays
 
 
 class TestAROIDomainExtraction(unittest.TestCase):
-    """Test AROI domain extraction matches AROIValidator specification."""
-    
+    """Test AROI domain extraction for both v2 and v3 specs.
+
+    `_simple_aroi_parsing` returns a 3-tuple:
+      (domain_or_'none', version_or_None, proof_type_or_None)
+    """
+
     def setUp(self):
         """Set up test instance with minimal mocking."""
-        # Create a minimal Relays instance just to test _simple_aroi_parsing
         with patch.object(Relays, '__init__', lambda x, **kwargs: None):
             self.relays = Relays()
-    
-    def test_valid_aroi_contact_with_all_required_fields(self):
-        """Test that valid AROI contacts with all required fields are extracted correctly."""
-        # Valid contact with ciissversion:2, proof:dns-rsa, and url:
+
+    # -------------------------------------------------------------------------
+    # CIISS v2 (existing semantics — preserved)
+    # -------------------------------------------------------------------------
+
+    def test_v2_dns_rsa_full(self):
         contact = "email:test@example.com ciissversion:2 proof:dns-rsa url:example.com"
-        result = self.relays._simple_aroi_parsing(contact)
-        self.assertEqual(result, "example.com")
-    
-    def test_valid_aroi_contact_with_uri_rsa_proof(self):
-        """Test that proof:uri-rsa is also accepted as valid."""
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "example.com")
+        self.assertEqual(version, "2")
+        self.assertEqual(proof, "dns-rsa")
+
+    def test_v2_uri_rsa_full(self):
         contact = "email:test@example.com ciissversion:2 proof:uri-rsa url:example.com"
-        result = self.relays._simple_aroi_parsing(contact)
-        self.assertEqual(result, "example.com")
-    
-    def test_invalid_aroi_contact_missing_proof(self):
-        """Test that contacts missing proof field are rejected."""
-        # Missing proof field
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "example.com")
+        self.assertEqual(version, "2")
+        self.assertEqual(proof, "uri-rsa")
+
+    def test_v2_missing_proof(self):
         contact = "email:test@example.com ciissversion:2 url:example.com"
-        result = self.relays._simple_aroi_parsing(contact)
-        self.assertEqual(result, "none")
-    
-    def test_invalid_aroi_contact_missing_ciissversion(self):
-        """Test that contacts missing ciissversion are rejected."""
-        # Missing ciissversion field
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "none")
+        self.assertEqual(version, "2")
+        self.assertIsNone(proof)
+
+    def test_v2_missing_ciissversion(self):
         contact = "email:test@example.com proof:dns-rsa url:example.com"
-        result = self.relays._simple_aroi_parsing(contact)
-        self.assertEqual(result, "none")
-    
-    def test_invalid_aroi_contact_missing_url(self):
-        """Test that contacts missing url field are rejected."""
-        # Missing url field
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "none")
+        self.assertIsNone(version)
+        self.assertEqual(proof, "dns-rsa")
+
+    def test_v2_missing_url(self):
         contact = "email:test@example.com ciissversion:2 proof:dns-rsa"
-        result = self.relays._simple_aroi_parsing(contact)
-        self.assertEqual(result, "none")
-    
-    def test_aroi_contact_with_donationurl_not_confused_with_url(self):
-        """Test that donationurl: is not confused with url: field."""
-        # This should be rejected because it has donationurl: but not url:
-        contact = "email:test@example.com ciissversion:2 proof:dns-rsa donationurl:https://donate.example.com"
-        result = self.relays._simple_aroi_parsing(contact)
-        self.assertEqual(result, "none")
-    
-    def test_aroi_contact_case_insensitive_matching(self):
-        """Test that AROI field matching is case-insensitive."""
-        # Case variations should still be accepted
-        contact = "email:test@example.com CIISSVersion:2 Proof:DNS-RSA URL:example.com"
-        result = self.relays._simple_aroi_parsing(contact)
-        self.assertEqual(result, "example.com")
-    
-    def test_aroi_domain_extraction_with_protocol(self):
-        """Test that domains with protocols are extracted correctly."""
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "none")
+        self.assertEqual(version, "2")
+        self.assertEqual(proof, "dns-rsa")
+
+    def test_donationurl_is_not_url(self):
+        contact = ("email:test@example.com ciissversion:2 proof:dns-rsa "
+                   "donationurl:https://donate.example.com")
+        domain, _, _ = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "none")
+
+    def test_case_insensitive_keys(self):
+        contact = ("email:test@example.com CIISSVersion:2 Proof:DNS-RSA "
+                   "URL:example.com")
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "example.com")
+        self.assertEqual(version, "2")
+        # proof_type stored lowercase regardless of input casing
+        self.assertEqual(proof, "dns-rsa")
+
+    def test_url_with_protocol_strips_scheme(self):
         contact = "ciissversion:2 proof:dns-rsa url:https://example.com/path"
-        result = self.relays._simple_aroi_parsing(contact)
-        self.assertEqual(result, "example.com")
-    
-    def test_aroi_domain_extraction_removes_www_prefix(self):
-        """Test that www. prefix is removed from domains."""
+        domain, _, _ = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "example.com")
+
+    def test_url_strips_www_prefix(self):
         contact = "ciissversion:2 proof:dns-rsa url:www.example.com"
-        result = self.relays._simple_aroi_parsing(contact)
-        self.assertEqual(result, "example.com")
-    
-    def test_empty_contact_returns_none(self):
-        """Test that empty contact returns 'none'."""
-        result = self.relays._simple_aroi_parsing("")
-        self.assertEqual(result, "none")
-    
-    def test_none_contact_returns_none(self):
-        """Test that None contact returns 'none'."""
-        result = self.relays._simple_aroi_parsing(None)
-        self.assertEqual(result, "none")
+        domain, _, _ = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "example.com")
+
+    def test_empty_contact(self):
+        self.assertEqual(
+            self.relays._simple_aroi_parsing(""),
+            ("none", None, None),
+        )
+
+    def test_none_contact(self):
+        self.assertEqual(
+            self.relays._simple_aroi_parsing(None),
+            ("none", None, None),
+        )
+
+    # -------------------------------------------------------------------------
+    # CIISS v3 (new)
+    # -------------------------------------------------------------------------
+
+    def test_v3_dns_familyid_full(self):
+        contact = "ciissversion:3 url:example.com proof:dns-familyid-ed25519"
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "example.com")
+        self.assertEqual(version, "3")
+        self.assertEqual(proof, "dns-familyid-ed25519")
+
+    def test_v3_uri_familyid_full(self):
+        contact = "ciissversion:3 url:example.com proof:uri-familyid-ed25519"
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "example.com")
+        self.assertEqual(version, "3")
+        self.assertEqual(proof, "uri-familyid-ed25519")
+
+    def test_v3_url_less_is_not_aroi_domain(self):
+        """v3 informational-only ContactInfo (no url:) is spec-legal but
+        does not have a verifiable domain — domain MUST be 'none'.
+
+        is_v3_no_proof_compliant flag in _check_aroi_fields lets the
+        contact-page surface distinguish this from "incomplete".
+        """
+        contact = ("ciissversion:3 email:tor@example.com "
+                   "donationurl:https://donate.example.com")
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "none")
+        self.assertEqual(version, "3")
+        self.assertIsNone(proof)
+
+    def test_v3_url_with_protocol(self):
+        contact = ("ciissversion:3 url:https://example.com "
+                   "proof:dns-familyid-ed25519")
+        domain, _, _ = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "example.com")
+
+    # -------------------------------------------------------------------------
+    # Defensive parsing edge cases (A.0.1)
+    # -------------------------------------------------------------------------
+
+    def test_legacy_ciissversion_1_rejected(self):
+        """ciissversion:1 (legacy) is silently ignored, not crashed on."""
+        contact = "ciissversion:1 url:example.com proof:dns-rsa"
+        domain, version, _ = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "none")
+        # version is None because the supported-version regex didn't match
+        self.assertIsNone(version)
+
+    def test_unknown_future_ciissversion_rejected(self):
+        contact = "ciissversion:99 url:example.com proof:dns-rsa"
+        domain, version, _ = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "none")
+        self.assertIsNone(version)
+
+    def test_v2_with_v3_proof_type_rejected(self):
+        """Operator copy-paste error: ciissversion:2 + v3 proof type.
+
+        Should be rejected as "incomplete AROI" rather than silently
+        accepted (which would falsely claim domain ownership).
+        """
+        contact = ("ciissversion:2 url:example.com "
+                   "proof:uri-familyid-ed25519")
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "none")
+        # version + proof are still reported (for diagnostic UI), but
+        # mismatch means no aroi_domain was extracted.
+        self.assertEqual(version, "2")
+        self.assertEqual(proof, "uri-familyid-ed25519")
+
+    def test_v3_with_v2_proof_type_rejected(self):
+        contact = "ciissversion:3 url:example.com proof:dns-rsa"
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "none")
+        self.assertEqual(version, "3")
+        self.assertEqual(proof, "dns-rsa")
+
+    def test_unknown_proof_type_rejected(self):
+        """Future or typoed proof type silently rejected (logged once)."""
+        contact = ("ciissversion:3 url:example.com "
+                   "proof:dns-familyid-x25519")  # made-up future type
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "none")
+        self.assertEqual(version, "3")
+        # proof is None because the SUPPORTED-proof regex didn't match
+        self.assertIsNone(proof)
+
+    def test_multiple_proof_declarations_first_wins(self):
+        """Per CIISS spec: keys MUST appear once; if they don't, the
+        first occurrence wins. re.search returns the first match by
+        construction; this test pins the contract.
+        """
+        contact = ("ciissversion:3 url:example.com "
+                   "proof:uri-familyid-ed25519 proof:dns-familyid-ed25519")
+        domain, version, proof = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "example.com")
+        self.assertEqual(version, "3")
+        self.assertEqual(proof, "uri-familyid-ed25519")
+
+    def test_whitespace_in_value_rejected(self):
+        """CIISS spec: keys/values MUST NOT contain whitespace.
+
+        'ciissversion: 2' is malformed and silently ignored.
+        """
+        contact = "ciissversion: 2 url:example.com proof:dns-rsa"
+        domain, version, _ = self.relays._simple_aroi_parsing(contact)
+        self.assertEqual(domain, "none")
+        self.assertIsNone(version)
 
 
 if __name__ == '__main__':

--- a/tests/unit/aroi/test_aroi_validation.py
+++ b/tests/unit/aroi/test_aroi_validation.py
@@ -551,5 +551,735 @@ class TestAROIValidation(unittest.TestCase):
         self.assertIsInstance(result['misconfigured_fingerprints'], set)
 
 
+class TestAROIValidationV3(unittest.TestCase):
+    """v3 (CIISS spec version 3) integration tests covering Part A.
+
+    Verifies:
+      - all 4 proof types read into metrics (A.3)
+      - ciissversion adoption + v3_failure_categories passthrough (A.3)
+      - error_category-driven cascade (A.4)
+      - upstream hint passthrough (A.4)
+      - peer issue categories: security_incident, pending_onionoo (A.5)
+      - operator-level v2/v3 counts + tier classification (A.5)
+      - is_mixed_migration / is_v3_adopter flags (A.5)
+      - schema-version handshake (A.1)
+      - error rollup buckets (A.6)
+      - V3_CATEGORY_LABELS coverage of all upstream categories (A.7)
+    """
+
+    def test_all_four_proof_types_populated(self):
+        """A.3: dns_familyid_ed25519 + uri_familyid_ed25519 must be read."""
+        relays = [
+            {'fingerprint': 'V2A', 'aroi_domain': 'v2.org', 'aroi_version': '2',
+             'aroi_proof_type': 'dns-rsa', 'contact': 'ciissversion:2 proof:dns-rsa url:v2.org'},
+            {'fingerprint': 'V3A', 'aroi_domain': 'v3.org', 'aroi_version': '3',
+             'aroi_proof_type': 'uri-familyid-ed25519',
+             'contact': 'ciissversion:3 proof:uri-familyid-ed25519 url:v3.org'},
+        ]
+        validation_data = {
+            'metadata': {'timestamp': '2026-05-05T00:00:00Z',
+                         'aroivalidator_schema_version': 2},
+            'statistics': {
+                'proof_types': {
+                    'dns_rsa':              {'total': 100, 'valid': 80, 'success_rate': 80.0},
+                    'uri_rsa':              {'total': 200, 'valid': 180, 'success_rate': 90.0},
+                    'dns_familyid_ed25519': {'total': 50, 'valid': 50, 'success_rate': 100.0},
+                    'uri_familyid_ed25519': {'total': 30, 'valid': 28, 'success_rate': 93.3},
+                },
+                'ciissversion_declared':  {'2': 300, '3': 80, 'none': 100},
+                'ciissversion_validated': {'2': 300, '3': 80, 'filtered_out': 0},
+                'v3_failure_categories':  {'missing_family_ids': 2,
+                                            'uri_content_mismatch': 1},
+            },
+            'results': [
+                {'fingerprint': 'V2A', 'valid': True, 'proof_type': 'dns-rsa',
+                 'ciissversion': '2'},
+                {'fingerprint': 'V3A', 'valid': True,
+                 'proof_type': 'uri-familyid-ed25519', 'ciissversion': '3'},
+            ]
+        }
+        m = calculate_aroi_validation_metrics(relays, validation_data)
+
+        # Per-proof-type keys (12 total: 4 types * 3 stats each).
+        self.assertEqual(m['dns_rsa_total'], 100)
+        self.assertEqual(m['uri_rsa_total'], 200)
+        self.assertEqual(m['dns_familyid_ed25519_total'], 50)
+        self.assertEqual(m['dns_familyid_ed25519_valid'], 50)
+        self.assertEqual(m['dns_familyid_ed25519_success_rate'], 100.0)
+        self.assertEqual(m['uri_familyid_ed25519_total'], 30)
+        self.assertEqual(m['uri_familyid_ed25519_valid'], 28)
+
+        # v2 / v3 aggregates.
+        self.assertEqual(m['v2_total'], 300)   # 100 + 200
+        self.assertEqual(m['v2_valid'], 260)   # 80 + 180
+        self.assertEqual(m['v3_total'], 80)    # 50 + 30
+        self.assertEqual(m['v3_valid'], 78)    # 50 + 28
+        self.assertAlmostEqual(m['v2_success_rate'], 260/300*100, places=1)
+        self.assertAlmostEqual(m['v3_success_rate'], 78/80*100, places=1)
+
+        # Upstream stats passthrough.
+        self.assertEqual(m['ciissversion_declared'],
+                         {'2': 300, '3': 80, 'none': 100})
+        self.assertEqual(m['v3_failure_categories'],
+                         {'missing_family_ids': 2, 'uri_content_mismatch': 1})
+
+    def test_security_incident_peer_bucket(self):
+        """A.5: secret_key_leaked relays go into security_incident_relays."""
+        relays = [{
+            'fingerprint': 'BAD', 'aroi_domain': 'leak.org',
+            'aroi_version': '3', 'aroi_proof_type': 'uri-familyid-ed25519',
+            'nickname': 'leakedrelay',
+            'contact': 'ciissversion:3 proof:uri-familyid-ed25519 url:leak.org',
+        }]
+        validation_data = {
+            'metadata': {'aroivalidator_schema_version': 2},
+            'statistics': {'proof_types': {}},
+            'results': [{
+                'fingerprint': 'BAD', 'valid': False, 'ciissversion': '3',
+                'proof_type': 'uri-familyid-ed25519',
+                'error': ('SECURITY: URI-FamilyID: published content '
+                          'appears to contain .secret_family_key. '
+                          'Rotate immediately.'),
+                'error_category': 'secret_key_leaked',
+                'hint': 'tor --keygen-family <newfile>',
+            }],
+        }
+        s = get_contact_validation_status(relays, validation_data)
+
+        # Peer bucket populated.
+        self.assertEqual(s['validation_summary']['security_incident_count'], 1)
+        self.assertEqual(len(s['security_incident_relays']), 1)
+        self.assertIn('BAD', s['security_incident_fingerprints'])
+
+        # Hint passes through verbatim from upstream.
+        self.assertEqual(s['security_incident_relays'][0]['hint'],
+                         'tor --keygen-family <newfile>')
+
+        # Top-level cascade still reports "misconfigured" (cascade DOES
+        # NOT change for peer alerts; templates render the security
+        # banner alongside whatever cascade picks).
+        self.assertEqual(s['validation_status'], 'misconfigured')
+
+    def test_pending_onionoo_peer_bucket(self):
+        """A.5: missing_family_ids -> pending_onionoo_relays bucket."""
+        relays = [{
+            'fingerprint': 'NEW', 'aroi_domain': 'fresh.org',
+            'aroi_version': '3', 'aroi_proof_type': 'uri-familyid-ed25519',
+            'contact': 'ciissversion:3 proof:uri-familyid-ed25519 url:fresh.org',
+        }]
+        validation_data = {
+            'metadata': {'aroivalidator_schema_version': 2},
+            'statistics': {'proof_types': {}},
+            'results': [{
+                'fingerprint': 'NEW', 'valid': False, 'ciissversion': '3',
+                'error_category': 'missing_family_ids',
+                'hint': "Run 'tor --keygen-family ...'",
+            }],
+        }
+        s = get_contact_validation_status(relays, validation_data)
+        self.assertEqual(s['validation_summary']['pending_onionoo_count'], 1)
+        self.assertEqual(len(s['pending_onionoo_relays']), 1)
+        self.assertIn('NEW', s['pending_onionoo_fingerprints'])
+
+    def test_dns_content_mismatch_unauthorized_via_error_category(self):
+        """A.4: error_category='dns_content_mismatch' -> unauthorized cascade.
+
+        Today's substring heuristic would not catch this (the v3 error
+        message says 'TXT record content does not match...' which
+        doesn't include 'fingerprint not found'). With error_category
+        plumbed through, classification is correct.
+        """
+        relays = [{
+            'fingerprint': 'X', 'aroi_domain': 'x.org', 'aroi_version': '3',
+            'contact': 'ciissversion:3 proof:dns-familyid-ed25519 url:x.org',
+        }]
+        validation_data = {
+            'metadata': {},
+            'statistics': {'proof_types': {}},
+            'results': [{
+                'fingerprint': 'X', 'valid': False, 'ciissversion': '3',
+                'error': 'DNS-FamilyID: TXT record content does not match relay family_ids',
+                'error_category': 'dns_content_mismatch',
+            }],
+        }
+        s = get_contact_validation_status(relays, validation_data)
+        self.assertEqual(s['validation_status'], 'unauthorized')
+        self.assertEqual(s['validation_summary']['unauthorized_count'], 1)
+
+    def test_v3_tier_classification_explorer(self):
+        """A.5: 1 v3 relay out of 50 -> 'explorer' tier."""
+        from allium.lib.aroi_validation import classify_v3_tier
+        self.assertEqual(classify_v3_tier(0, 50), 'none')
+        self.assertEqual(classify_v3_tier(1, 50), 'explorer')   # 2%
+        self.assertEqual(classify_v3_tier(12, 50), 'explorer')  # 24%
+        self.assertEqual(classify_v3_tier(13, 50), 'migrating') # 26%
+        self.assertEqual(classify_v3_tier(37, 50), 'migrating') # 74%
+        self.assertEqual(classify_v3_tier(38, 50), 'mostly')    # 76%
+        self.assertEqual(classify_v3_tier(49, 50), 'mostly')    # 98%
+        self.assertEqual(classify_v3_tier(50, 50), 'complete')  # 100%
+        self.assertEqual(classify_v3_tier(0, 0), 'none')
+        self.assertEqual(classify_v3_tier(5, 0), 'none')
+
+    def test_mixed_migration_operator_metadata(self):
+        """A.5: operator with both v2 and v3 -> is_mixed_migration=True."""
+        relays = [
+            {'fingerprint': 'V2', 'aroi_domain': 'mix.org',
+             'aroi_version': '2', 'aroi_proof_type': 'uri-rsa',
+             'contact': 'ciissversion:2 proof:uri-rsa url:mix.org'},
+            {'fingerprint': 'V3A', 'aroi_domain': 'mix.org',
+             'aroi_version': '3', 'aroi_proof_type': 'uri-familyid-ed25519',
+             'contact': 'ciissversion:3 proof:uri-familyid-ed25519 url:mix.org'},
+            {'fingerprint': 'V3B', 'aroi_domain': 'mix.org',
+             'aroi_version': '3', 'aroi_proof_type': 'uri-familyid-ed25519',
+             'contact': 'ciissversion:3 proof:uri-familyid-ed25519 url:mix.org'},
+        ]
+        s = get_contact_validation_status(relays, {'results': []})
+        self.assertEqual(s['validation_summary']['v2_relay_count'], 1)
+        self.assertEqual(s['validation_summary']['v3_relay_count'], 2)
+        self.assertAlmostEqual(s['validation_summary']['v3_relay_percentage'],
+                                66.66666, places=2)
+        self.assertTrue(s['validation_summary']['is_mixed_migration'])
+        self.assertTrue(s['validation_summary']['is_v3_adopter'])
+        # 2 of 3 = 66% -> 'migrating' tier (>=25%, <75%)
+        self.assertEqual(s['validation_summary']['v3_tier'], 'migrating')
+
+    def test_aroi_warnings_log_records_unknown_proof_type(self):
+        """B6 (final): _record_warning surfaces unknown_proof_type for the
+        api-diagnostics page. Each kind+value pair recorded once with
+        timestamp + count of occurrences."""
+        from allium.lib.aroi_validation import (
+            _check_aroi_fields, get_aroi_warnings_log, reset_aroi_warnings_log,
+        )
+        reset_aroi_warnings_log()
+
+        # First occurrence: a relay declaring an unknown proof type
+        _check_aroi_fields(
+            'ciissversion:3 url:foo.bar proof:dns-future-cipher-2030'
+        )
+        # Same unknown proof type again should NOT add a duplicate entry
+        _check_aroi_fields(
+            'ciissversion:3 url:bar.baz proof:dns-future-cipher-2030'
+        )
+        # Different unknown proof type should add a new entry
+        _check_aroi_fields(
+            'ciissversion:3 url:foo.bar proof:another-unknown-thing'
+        )
+
+        warnings = get_aroi_warnings_log()
+        kinds_values = {(w['kind'], w['value']) for w in warnings}
+        # Both unknown proof types tracked; one warning each (first-occurrence dedup)
+        self.assertIn(('unsupported_proof_type', 'dns-future-cipher-2030'), kinds_values)
+        self.assertIn(('unsupported_proof_type', 'another-unknown-thing'), kinds_values)
+
+        # Each entry must have a timestamp_iso (Z-suffixed)
+        for w in warnings:
+            self.assertIn('timestamp_iso', w)
+            self.assertTrue(w['timestamp_iso'].endswith('Z'))
+            self.assertGreaterEqual(w['count'], 1)
+
+    def test_aroi_warnings_log_records_schema_mismatch(self):
+        """B6 (final): schema-version mismatch logged in the warning feed."""
+        from allium.lib.aroi_validation import (
+            check_schema_version, get_aroi_warnings_log,
+            reset_aroi_warnings_log,
+        )
+        reset_aroi_warnings_log()
+        check_schema_version(
+            {'metadata': {'aroivalidator_schema_version': 99}},
+            lambda m: None,
+        )
+        warnings = get_aroi_warnings_log()
+        kinds_values = {(w['kind'], w['value']) for w in warnings}
+        self.assertIn(('schema_mismatch', '99'), kinds_values)
+
+    def test_aroi_warnings_log_timestamp_format(self):
+        """B6 (final): timestamp_iso uses Python 3.12-safe APIs.
+
+        Pins the contract that timestamps are ISO format with Z suffix
+        and represent UTC. Catches accidental introduction of deprecated
+        datetime.utcnow() (deprecated in Python 3.12+, scheduled removal
+        in a future release)."""
+        import re
+        from allium.lib.aroi_validation import (
+            _check_aroi_fields, get_aroi_warnings_log, reset_aroi_warnings_log,
+        )
+        reset_aroi_warnings_log()
+        _check_aroi_fields(
+            'ciissversion:3 url:foo.bar proof:future-cipher-x'
+        )
+        warnings = get_aroi_warnings_log()
+        self.assertTrue(warnings)
+        ts = warnings[0]['timestamp_iso']
+        # ISO 8601 second-precision UTC: YYYY-MM-DDTHH:MM:SSZ
+        self.assertRegex(
+            ts,
+            r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$',
+            f'timestamp_iso has invalid format: {ts!r}'
+        )
+
+    def test_aroi_warnings_propagates_through_api_diagnostics(self):
+        """B6 (final): collect_api_diagnostics surfaces warnings as
+        aroi_extras['warnings'] so the template can render them.
+
+        End-to-end test exercising the
+        aroi_validation._record_warning → get_aroi_warnings_log
+        → api_diagnostics.collect_api_diagnostics path."""
+        from allium.lib.aroi_validation import (
+            _check_aroi_fields, reset_aroi_warnings_log,
+        )
+
+        # Trigger an unsupported_proof_type warning during this test.
+        reset_aroi_warnings_log()
+        _check_aroi_fields(
+            'ciissversion:3 url:foo.bar proof:future-cipher-2030'
+        )
+
+        # Stub a relay_set + args minimally so collect_api_diagnostics
+        # can produce its dict for the AROI entry.
+        from allium.lib.api_diagnostics import collect_api_diagnostics
+
+        class _StubArgs:
+            enabled_apis = 'all'
+            aroi_url = 'https://aroivalidator.1aeo.com/latest.json'
+
+        class _StubRelaySet:
+            aroi_validation_data = {
+                'metadata': {'aroivalidator_schema_version': 2},
+                'statistics': {'proof_types': {}, 'v3_failure_categories': {}},
+                'results': [],
+            }
+            # Other APIs read .json or other attributes; stub them as empty
+            # dicts so collect_api_diagnostics doesn't crash on the non-AROI
+            # entries.
+            json = {'relays': []}
+            exit_dns_health_data = None
+            collector_consensus_data = None
+            collector_descriptors_data = None
+            uptime_data = None
+            bandwidth_data = None
+
+        diag = collect_api_diagnostics(_StubRelaySet(), _StubArgs())
+        aroi_entry = next(a for a in diag['apis'] if a['name'] == 'aroi_validation')
+        warnings = aroi_entry.get('aroi_extras', {}).get('warnings') or []
+        kinds_values = {(w['kind'], w['value']) for w in warnings}
+        self.assertIn(('unsupported_proof_type', 'future-cipher-2030'), kinds_values)
+
+    def test_per_version_success_rate_pills(self):
+        """B1.1 (final): per-version validated counts + success rates
+        populated for the v3_migration_summary section's success-rate pills.
+        Plan called for 'v2 relay count and v3 relay count side-by-side
+        with success-rate pills'."""
+        relays = [
+            # v2 relays: 2 declared, both valid
+            {'fingerprint': 'V2A', 'aroi_domain': 'mix.org',
+             'aroi_version': '2', 'aroi_proof_type': 'uri-rsa',
+             'contact': 'ciissversion:2 proof:uri-rsa url:mix.org'},
+            {'fingerprint': 'V2B', 'aroi_domain': 'mix.org',
+             'aroi_version': '2', 'aroi_proof_type': 'uri-rsa',
+             'contact': 'ciissversion:2 proof:uri-rsa url:mix.org'},
+            # v3 relays: 4 declared, only 1 valid (3 pending)
+            {'fingerprint': 'V3A', 'aroi_domain': 'mix.org',
+             'aroi_version': '3', 'aroi_proof_type': 'uri-familyid-ed25519',
+             'contact': 'ciissversion:3 proof:uri-familyid-ed25519 url:mix.org'},
+            {'fingerprint': 'V3B', 'aroi_domain': 'mix.org',
+             'aroi_version': '3', 'aroi_proof_type': 'uri-familyid-ed25519',
+             'contact': 'ciissversion:3 proof:uri-familyid-ed25519 url:mix.org'},
+            {'fingerprint': 'V3C', 'aroi_domain': 'mix.org',
+             'aroi_version': '3', 'aroi_proof_type': 'uri-familyid-ed25519',
+             'contact': 'ciissversion:3 proof:uri-familyid-ed25519 url:mix.org'},
+            {'fingerprint': 'V3D', 'aroi_domain': 'mix.org',
+             'aroi_version': '3', 'aroi_proof_type': 'uri-familyid-ed25519',
+             'contact': 'ciissversion:3 proof:uri-familyid-ed25519 url:mix.org'},
+        ]
+        validation_data = {
+            'metadata': {'aroivalidator_schema_version': 2},
+            'statistics': {'proof_types': {}},
+            'results': [
+                {'fingerprint': 'V2A', 'valid': True, 'ciissversion': '2',
+                 'proof_type': 'uri-rsa'},
+                {'fingerprint': 'V2B', 'valid': True, 'ciissversion': '2',
+                 'proof_type': 'uri-rsa'},
+                {'fingerprint': 'V3A', 'valid': True, 'ciissversion': '3',
+                 'proof_type': 'uri-familyid-ed25519'},
+                {'fingerprint': 'V3B', 'valid': False, 'ciissversion': '3',
+                 'error_category': 'missing_family_ids',
+                 'error': 'no family_ids in Onionoo'},
+                {'fingerprint': 'V3C', 'valid': False, 'ciissversion': '3',
+                 'error_category': 'missing_family_ids',
+                 'error': 'no family_ids in Onionoo'},
+                {'fingerprint': 'V3D', 'valid': False, 'ciissversion': '3',
+                 'error_category': 'missing_family_ids',
+                 'error': 'no family_ids in Onionoo'},
+            ],
+        }
+        s = get_contact_validation_status(relays, validation_data)
+        summary = s['validation_summary']
+        # v2 declarations + validations
+        self.assertEqual(summary['v2_relay_count'], 2)
+        self.assertEqual(summary['v2_validated_count'], 2)
+        self.assertEqual(summary['v2_success_rate'], 100.0)
+        # v3 declarations + validations
+        self.assertEqual(summary['v3_relay_count'], 4)
+        self.assertEqual(summary['v3_validated_count'], 1)
+        self.assertEqual(summary['v3_success_rate'], 25.0)
+
+    def test_pure_v3_operator_complete_tier(self):
+        """A.5: 100% v3 operator -> v3_tier='complete'."""
+        relays = [
+            {'fingerprint': 'A', 'aroi_domain': 'pure.org',
+             'aroi_version': '3', 'aroi_proof_type': 'dns-familyid-ed25519',
+             'contact': 'ciissversion:3 proof:dns-familyid-ed25519 url:pure.org'},
+            {'fingerprint': 'B', 'aroi_domain': 'pure.org',
+             'aroi_version': '3', 'aroi_proof_type': 'dns-familyid-ed25519',
+             'contact': 'ciissversion:3 proof:dns-familyid-ed25519 url:pure.org'},
+        ]
+        s = get_contact_validation_status(relays, {'results': []})
+        self.assertEqual(s['validation_summary']['v3_tier'], 'complete')
+        self.assertFalse(s['validation_summary']['is_mixed_migration'])
+        self.assertTrue(s['validation_summary']['is_v3_adopter'])
+
+    def test_v2_only_operator_no_tier(self):
+        """A.5: v2-only operator -> v3_tier='none', is_v3_adopter=False."""
+        relays = [
+            {'fingerprint': 'A', 'aroi_domain': 'old.org',
+             'aroi_version': '2', 'aroi_proof_type': 'uri-rsa',
+             'contact': 'ciissversion:2 proof:uri-rsa url:old.org'},
+        ]
+        s = get_contact_validation_status(relays, {'results': []})
+        self.assertEqual(s['validation_summary']['v3_tier'], 'none')
+        self.assertFalse(s['validation_summary']['is_v3_adopter'])
+
+    def test_schema_version_handshake_unknown(self):
+        """A.1: schema version outside tested set logs a warning, doesn't crash."""
+        from allium.lib.aroi_validation import (
+            check_schema_version, _warned_schema_versions
+        )
+        _warned_schema_versions.clear()  # Test isolation
+        warnings = []
+
+        def capture(msg):
+            warnings.append(msg)
+
+        # Schema 99 is far in the future of tested schemas.
+        result = check_schema_version(
+            {'metadata': {'aroivalidator_schema_version': 99}}, capture
+        )
+        self.assertEqual(result, 99)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn('schema version 99', warnings[0])
+        self.assertIn('newer than tested', warnings[0])
+
+        # Second call with same version: no duplicate warning.
+        result2 = check_schema_version(
+            {'metadata': {'aroivalidator_schema_version': 99}}, capture
+        )
+        self.assertEqual(result2, 99)
+        self.assertEqual(len(warnings), 1, "duplicate warning emitted")
+
+    def test_schema_version_handshake_known(self):
+        """A.1: schema version in tested set -> no warning."""
+        from allium.lib.aroi_validation import check_schema_version
+        warnings = []
+        result = check_schema_version(
+            {'metadata': {'aroivalidator_schema_version': 2}},
+            lambda m: warnings.append(m)
+        )
+        self.assertEqual(result, 2)
+        self.assertEqual(warnings, [])
+
+    def test_schema_version_handshake_missing(self):
+        """A.1: no schema version -> returns None, no warning."""
+        from allium.lib.aroi_validation import check_schema_version
+        warnings = []
+        result = check_schema_version(
+            {'metadata': {}}, lambda m: warnings.append(m)
+        )
+        self.assertIsNone(result)
+        self.assertEqual(warnings, [])
+
+    def test_error_rollup_shared_v2_v3_split(self):
+        """A.6: _build_error_rollup splits errors into shared / v2-only / v3-only."""
+        from allium.lib.aroi_validation import _build_error_rollup
+        results = [
+            # Shared category: both v2 and v3 hit transport errors
+            {'fingerprint': 'A', 'valid': False, 'ciissversion': '2',
+             'error_category': 'transport_error'},
+            {'fingerprint': 'B', 'valid': False, 'ciissversion': '3',
+             'error_category': 'transport_error'},
+            # v3-only: missing_family_ids
+            {'fingerprint': 'C', 'valid': False, 'ciissversion': '3',
+             'error_category': 'missing_family_ids'},
+            {'fingerprint': 'D', 'valid': False, 'ciissversion': '3',
+             'error_category': 'missing_family_ids'},
+            # v2-only: imagine a future v2-specific category
+            {'fingerprint': 'E', 'valid': False, 'ciissversion': '2',
+             'error_category': 'some_v2_only_thing'},
+            # Valid relay should not appear in any rollup
+            {'fingerprint': 'F', 'valid': True, 'ciissversion': '3'},
+        ]
+        shared, v2_only, v3_only = _build_error_rollup(results)
+        # Shared: transport_error counted across both versions = 2
+        self.assertEqual(len(shared), 1)
+        self.assertEqual(shared[0][0], 'transport_error')
+        self.assertEqual(shared[0][2], 2)
+        # v3-only: missing_family_ids count 2
+        v3_categories = {row[0]: row[2] for row in v3_only}
+        self.assertEqual(v3_categories.get('missing_family_ids'), 2)
+        # v2-only: some_v2_only_thing
+        v2_categories = {row[0]: row[2] for row in v2_only}
+        self.assertEqual(v2_categories.get('some_v2_only_thing'), 1)
+
+    def test_v3_category_labels_cover_upstream_categories(self):
+        """A.7: every upstream error_category we expect must have a label."""
+        from allium.lib.aroi_validation import V3_CATEGORY_LABELS
+        # The 13 categories from upstream's CATEGORY_INFO.
+        upstream_cats = {
+            'missing_family_ids', 'dns_txt_missing', 'dns_content_mismatch',
+            'uri_file_missing', 'uri_content_mismatch',
+            'wrong_proof_type_rsa', 'missing_proof_field', 'invalid_url',
+            'unsafe_target', 'redirect_disallowed', 'secret_key_leaked',
+            'ciissversion_unsupported', 'transport_error',
+        }
+        for cat in upstream_cats:
+            self.assertIn(cat, V3_CATEGORY_LABELS, f"missing label for {cat}")
+            entry = V3_CATEGORY_LABELS[cat]
+            self.assertTrue(entry.get('title'), f"{cat} missing title")
+            self.assertTrue(entry.get('example'),
+                            f"{cat} missing pasteable example")
+
+    def test_version_proof_mismatch_routes_to_incomplete(self):
+        """A.5: ciissversion:2 + proof:uri-familyid-ed25519 -> incomplete bucket
+        with version_proof_mismatch sub-category and pasteable hint."""
+        # _simple_aroi_parsing returns aroi_domain="none" for mismatches, so
+        # the relay reaches get_contact_validation_status with aroi_domain="none"
+        # but contact has all 3 fields detected by _check_aroi_fields.
+        relays = [{
+            'fingerprint': 'MIX', 'aroi_domain': 'none',
+            'aroi_version': '2', 'aroi_proof_type': 'uri-familyid-ed25519',
+            'contact': 'ciissversion:2 url:foo.bar proof:uri-familyid-ed25519',
+        }]
+        s = get_contact_validation_status(relays, {'results': []})
+        # Should be in incomplete bucket with version_proof_mismatch flag.
+        self.assertEqual(s['validation_summary']['incomplete_count'], 1)
+        self.assertEqual(
+            s['validation_summary']['incomplete_version_proof_mismatch_count'], 1
+        )
+        relay_info = s['incomplete_relays'][0]
+        self.assertEqual(relay_info['error_category'], 'version_proof_mismatch')
+        # Pasteable example hint surfaced.
+        self.assertIn('ciissversion:3', relay_info['hint'])
+        self.assertIn('proof:uri-familyid-ed25519', relay_info['hint'])
+
+
+class TestAROIPasteableExamples(unittest.TestCase):
+    """Pasteable-example contract enforcement (UX feedback round 2).
+
+    Categories that fire for both CIISS v2 and CIISS v3 must render
+    version-appropriate file paths in their pasteable curl/DNS examples.
+
+    The user-reported bug: a v2 relay hitting 'URI-RSA fingerprint not found'
+    was rendering the ed25519-family-id.txt path (the v3 file). After the
+    fix, V3_CATEGORY_LABELS may declare an alternate 'example_v2' entry,
+    and _resolve_example_for_proof picks it when proof_type is RSA-flavored.
+    """
+
+    def test_resolve_example_for_proof_picks_v2_for_uri_rsa(self):
+        from allium.lib.aroi_validation import (
+            V3_CATEGORY_LABELS, _resolve_example_for_proof,
+        )
+        label = V3_CATEGORY_LABELS['uri_content_mismatch']
+        v2_example = _resolve_example_for_proof(label, 'uri-rsa')
+        v3_example = _resolve_example_for_proof(label, 'uri-familyid-ed25519')
+        # v2 must reference rsa-fingerprint.txt (the v2 spec file).
+        self.assertIn('rsa-fingerprint.txt', v2_example)
+        self.assertNotIn('ed25519-family-id.txt', v2_example)
+        # v3 must reference ed25519-family-id.txt (the v3 spec file).
+        self.assertIn('ed25519-family-id.txt', v3_example)
+
+    def test_resolve_example_for_proof_picks_v2_for_dns_rsa(self):
+        from allium.lib.aroi_validation import (
+            V3_CATEGORY_LABELS, _resolve_example_for_proof,
+        )
+        label = V3_CATEGORY_LABELS['dns_txt_missing']
+        v2_example = _resolve_example_for_proof(label, 'dns-rsa')
+        # v2 DNS uses 'we-run-this-tor-relay <fingerprint>' pattern.
+        self.assertIn('we-run-this-tor-relay', v2_example)
+        self.assertIn('<fingerprint>', v2_example)
+
+    def test_resolve_example_for_proof_falls_back_to_v3_when_no_v2_field(self):
+        """v3-only categories (no example_v2 key) still return the v3 example
+        even if proof_type is somehow RSA — fail-open, never None."""
+        from allium.lib.aroi_validation import (
+            V3_CATEGORY_LABELS, _resolve_example_for_proof,
+        )
+        # 'wrong_proof_type_rsa' is v3-only (it describes "v3 contact declares
+        # v2 proof type"). No example_v2 declared.
+        label = V3_CATEGORY_LABELS['wrong_proof_type_rsa']
+        self.assertIsNone(label.get('example_v2'))
+        result = _resolve_example_for_proof(label, 'uri-rsa')
+        # Should still return *something* (the default v3 example) — never None.
+        self.assertIsNotNone(result)
+        self.assertEqual(result, label['example'])
+
+    def test_uri_rsa_misconfigured_relay_renders_full_v2_url(self):
+        """User-reported bug: a v2 (URI-RSA) misconfigured relay with category
+        'uri_content_mismatch' must render the FULL v2 URL in its pasteable
+        example, not just '~/.well-known' nor the ed25519 file path.
+
+        The path must include https:// + domain + /.well-known/tor-relay/ +
+        rsa-fingerprint.txt + the actual relay's fingerprint."""
+        relay = {
+            'fingerprint': '0' * 40,
+            'aroi_domain': 'example.org',
+            'aroi_version': '2',
+            'aroi_proof_type': 'uri-rsa',
+            'contact': 'ciissversion:2 proof:uri-rsa url:example.org',
+        }
+        validation_data = {
+            'results': [{
+                'fingerprint': '0' * 40,
+                'valid': False,
+                'proof_type': 'uri-rsa',
+                'ciissversion': '2',
+                'error_category': 'uri_content_mismatch',
+                'error': 'URI-RSA: Fingerprint not found at example.org',
+            }],
+        }
+        s = get_contact_validation_status([relay], validation_data)
+        # uri_content_mismatch routes to 'unauthorized' (per A.4 cascade),
+        # not misconfigured. The pasteable-example contract is the same
+        # regardless of which bucket the relay lands in.
+        unauthorized = s['unauthorized_relays']
+        self.assertEqual(len(unauthorized), 1)
+        info = unauthorized[0]
+        ex = info.get('pasteable_example') or ''
+        # Must reference v2 (RSA) path, not v3 (ed25519) path.
+        self.assertIn('rsa-fingerprint.txt', ex)
+        self.assertNotIn('ed25519-family-id.txt', ex)
+        # Must include the operator's actual domain.
+        self.assertIn('example.org', ex)
+        # Must include the actual relay fingerprint (substituted in by
+        # _render_pasteable_example).
+        self.assertIn('0' * 40, ex)
+        # Must be a fully-qualified URL, not '~/.well-known'.
+        self.assertIn('https://', ex)
+        self.assertIn('/.well-known/tor-relay/', ex)
+
+
+class TestAROIValidationMapCacheRegression(unittest.TestCase):
+    """Regression test for commit 119687b33e -> d68fcec7ec.
+
+    Phase 2 caching used .pop('_validation_map', {}) to extract the
+    validation_map from the metrics dict, then assigned it to
+    relay_set.validation_map. The .pop is destructive: on the first call
+    it extracted the map correctly, but on subsequent CACHE-HIT calls
+    it found no '_validation_map' key (already popped) and overwrote
+    relay_set.validation_map with {} (the .pop default).
+
+    Net effect was: every contact page rendered AFTER the first
+    _calculate_network_health_metrics call had relay_set.validation_map
+    = {} -> every fingerprint lookup missed -> every relay rendered as
+    'misconfigured' / 0% valid even when upstream said 100% valid.
+
+    Visible to operators as: 'all operators show misconfigured AROI'.
+
+    The fix: cache the validation_map separately on
+    relay_set._aroi_metrics_cache and restore it from the cache on
+    every call (not just first compute). This test enforces that
+    contract.
+    """
+
+    def _build_mock_relay_set(self):
+        """Construct a minimal relay_set with one v2-AROI relay that
+        upstream marks as valid, and the validation_data needed."""
+        validation_data = {
+            'results': [{
+                'fingerprint': '1' * 40,
+                'valid': True,
+                'proof_type': 'uri-rsa',
+                'ciissversion': '2',
+            }],
+            'metadata': {'aroivalidator_schema_version': 1},
+        }
+        relays = [{
+            'fingerprint': '1' * 40,
+            'nickname': 'TestRelay',
+            'contact': 'ciissversion:2 proof:uri-rsa url:test.example',
+            'aroi_domain': 'test.example',
+            'aroi_version': '2',
+            'aroi_proof_type': 'uri-rsa',
+            'aroi_configured': True,
+        }]
+
+        class MockRelaySet:
+            progress = False
+            progress_logger = None
+
+            def __init__(self):
+                self.aroi_validation_data = validation_data
+                self.json = {'relays': relays}
+
+        return MockRelaySet(), validation_data, relays
+
+    def test_validation_map_survives_multiple_cache_hits(self):
+        """The cache-hit path must NOT wipe relay_set.validation_map."""
+        from allium.lib.network_health import _integrate_aroi_validation
+        rs, _, _ = self._build_mock_relay_set()
+
+        # First call (cache miss): map populated.
+        hm1 = {}
+        _integrate_aroi_validation(hm1, rs, 1)
+        size_after_1st = len(getattr(rs, 'validation_map', {}))
+        self.assertGreater(
+            size_after_1st, 0,
+            "validation_map empty after first call - cache miss path broken"
+        )
+
+        # Second call (cache hit): map MUST still be populated.
+        hm2 = {}
+        _integrate_aroi_validation(hm2, rs, 1)
+        size_after_2nd = len(getattr(rs, 'validation_map', {}))
+        self.assertEqual(
+            size_after_2nd, size_after_1st,
+            "validation_map was wiped on cache hit "
+            "(regression of commit 119687b33e)"
+        )
+
+        # Third call (still cache hit) - reinforces the contract.
+        hm3 = {}
+        _integrate_aroi_validation(hm3, rs, 1)
+        size_after_3rd = len(getattr(rs, 'validation_map', {}))
+        self.assertEqual(size_after_3rd, size_after_1st)
+
+    def test_contact_validation_correct_after_cache_hits(self):
+        """End-to-end: a valid v2 relay must still be reported as
+        validated after the cache has been hit multiple times.
+
+        This is the BEHAVIOURAL contract that the cache regression
+        violated: contact pages rendered after the first call were
+        seeing every relay as misconfigured.
+        """
+        from allium.lib.network_health import _integrate_aroi_validation
+        from allium.lib.aroi_validation import get_contact_validation_status
+        rs, validation_data, relays = self._build_mock_relay_set()
+
+        # Drive 4 calls (matches typical _calculate_network_health_metrics
+        # call count: uptime + bandwidth + exit_dns + fallback).
+        for _ in range(4):
+            _integrate_aroi_validation({}, rs, 1)
+
+        # After all those cache hits, validation_map must still let the
+        # one valid relay round-trip as 'validated'.
+        result = get_contact_validation_status(
+            relays, validation_data, rs.validation_map
+        )
+        s = result['validation_summary']
+        self.assertEqual(s['validated_count'], 1)
+        self.assertEqual(s['v2_validated_count'], 1)
+        self.assertEqual(s['v2_relay_count'], 1)
+        self.assertEqual(s['v2_success_rate'], 100.0)
+        self.assertEqual(result['validation_status'], 'validated')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/aroi/test_aroi_validation.py
+++ b/tests/unit/aroi/test_aroi_validation.py
@@ -951,10 +951,14 @@ class TestAROIValidationV3(unittest.TestCase):
 
     def test_schema_version_handshake_unknown(self):
         """A.1: schema version outside tested set logs a warning, doesn't crash."""
+        # Use the existing public reset helper instead of poking at
+        # the private _warned_schema_versions set directly.
+        # reset_aroi_warnings_log() already clears every per-warning
+        # dedupe set including _warned_schema_versions.
         from allium.lib.aroi_validation import (
-            check_schema_version, _warned_schema_versions
+            check_schema_version, reset_aroi_warnings_log,
         )
-        _warned_schema_versions.clear()  # Test isolation
+        reset_aroi_warnings_log()  # Test isolation
         warnings = []
 
         def capture(msg):

--- a/tests/unit/aroi/test_leaders_scoring.py
+++ b/tests/unit/aroi/test_leaders_scoring.py
@@ -4,7 +4,49 @@ Tests for reliability_masters and legacy_titans categories
 """
 import pytest
 
-from allium.lib.aroileaders import _calculate_reliability_score
+from allium.lib.aroileaders import _calculate_reliability_score, _classify_v3_tier_local
+
+
+class TestV3TierLeaderboardPropagation:
+    """B4.test (re-opened): verify aroileaders.py uses the same tier
+    classifier as contact-page pills + misc-contacts icons.
+
+    Unit-level coverage of the tier-boundary contract that the
+    Validation Champions table cells (B4.2) consume. classify_v3_tier
+    itself is exhaustively tested in test_aroi_validation.py; here we
+    just confirm the leaderboard side imports the same function and
+    its output flows correctly across boundary thresholds.
+    """
+
+    def test_imports_shared_classifier(self):
+        """The leaderboard module imports the canonical classifier from
+        aroi_validation, NOT a local re-implementation."""
+        from allium.lib.aroi_validation import classify_v3_tier
+        # _classify_v3_tier_local is the imported alias used in aroileaders.
+        assert _classify_v3_tier_local is classify_v3_tier
+
+    @pytest.mark.parametrize("v3,total,expected_tier", [
+        (0, 50, 'none'),
+        (1, 50, 'explorer'),     # 2% — 1 relay, < 25%
+        (12, 50, 'explorer'),    # 24%
+        (13, 50, 'migrating'),   # 26%
+        (37, 50, 'migrating'),   # 74%
+        (38, 50, 'mostly'),      # 76%
+        (49, 50, 'mostly'),      # 98%
+        (50, 50, 'complete'),    # 100%
+        # Single-relay operator edge case — 1/1 = 100% complete.
+        (1, 1, 'complete'),
+        # Empty operator (defensive — should not crash).
+        (0, 0, 'none'),
+    ])
+    def test_tier_boundary_propagation(self, v3, total, expected_tier):
+        """Every tier boundary classifier output matches the constants
+        in aroi_validation.py. If thresholds are tuned, this test must
+        be updated alongside the constants."""
+        assert _classify_v3_tier_local(v3, total) == expected_tier
+
+
+
 
 
 class TestReliabilityScoring:

--- a/tests/unit/aroi/test_leaders_scoring.py
+++ b/tests/unit/aroi/test_leaders_scoring.py
@@ -25,7 +25,7 @@ class TestV3TierLeaderboardPropagation:
         # _classify_v3_tier_local is the imported alias used in aroileaders.
         assert _classify_v3_tier_local is classify_v3_tier
 
-    @pytest.mark.parametrize("v3,total,expected_tier", [
+    @pytest.mark.parametrize(("v3", "total", "expected_tier"), [
         (0, 50, 'none'),
         (1, 50, 'explorer'),     # 2% — 1 relay, < 25%
         (12, 50, 'explorer'),    # 24%

--- a/tests/unit/prometheus_fixtures.py
+++ b/tests/unit/prometheus_fixtures.py
@@ -25,17 +25,25 @@ def make_relay(
     # B7.1: derive aroi_version + aroi_proof_type from contact string when
     # not explicitly provided. Mirrors what _simple_aroi_parsing does in
     # production so test fixtures don't have to know about the new fields.
-    if aroi_version is None and contact:
+    #
+    # Each field is derived INDEPENDENTLY (was previously only derived
+    # when aroi_version was None — that meant a fixture passing an
+    # explicit aroi_version but NO aroi_proof_type would silently leave
+    # the proof type at None). Now version and proof_type are filled
+    # in separately based on whichever is missing.
+    if contact:
         import re as _re
-        v_match = _re.search(r'\bciissversion:(\d+)\b', contact, _re.IGNORECASE)
-        if v_match:
-            aroi_version = v_match.group(1) if v_match.group(1) in ('2', '3') else None
-        p_match = _re.search(
-            r'\bproof:(dns-rsa|uri-rsa|dns-familyid-ed25519|uri-familyid-ed25519)\b',
-            contact, _re.IGNORECASE,
-        )
-        if p_match and aroi_proof_type is None:
-            aroi_proof_type = p_match.group(1).lower()
+        if aroi_version is None:
+            v_match = _re.search(r'\bciissversion:(\d+)\b', contact, _re.IGNORECASE)
+            if v_match:
+                aroi_version = v_match.group(1) if v_match.group(1) in ('2', '3') else None
+        if aroi_proof_type is None:
+            p_match = _re.search(
+                r'\bproof:(dns-rsa|uri-rsa|dns-familyid-ed25519|uri-familyid-ed25519)\b',
+                contact, _re.IGNORECASE,
+            )
+            if p_match:
+                aroi_proof_type = p_match.group(1).lower()
 
     return {
         "fingerprint": fingerprint,

--- a/tests/unit/prometheus_fixtures.py
+++ b/tests/unit/prometheus_fixtures.py
@@ -12,6 +12,8 @@ def make_relay(
     dns_timing=1000,
     dns_consecutive=0,
     aroi_domain="none",
+    aroi_version=None,
+    aroi_proof_type=None,
 ):
     if dns_status == "success":
         health_status = "success"
@@ -20,12 +22,29 @@ def make_relay(
     else:
         health_status = "fail"
 
+    # B7.1: derive aroi_version + aroi_proof_type from contact string when
+    # not explicitly provided. Mirrors what _simple_aroi_parsing does in
+    # production so test fixtures don't have to know about the new fields.
+    if aroi_version is None and contact:
+        import re as _re
+        v_match = _re.search(r'\bciissversion:(\d+)\b', contact, _re.IGNORECASE)
+        if v_match:
+            aroi_version = v_match.group(1) if v_match.group(1) in ('2', '3') else None
+        p_match = _re.search(
+            r'\bproof:(dns-rsa|uri-rsa|dns-familyid-ed25519|uri-familyid-ed25519)\b',
+            contact, _re.IGNORECASE,
+        )
+        if p_match and aroi_proof_type is None:
+            aroi_proof_type = p_match.group(1).lower()
+
     return {
         "fingerprint": fingerprint,
         "nickname": nickname,
         "flags": flags or ["Exit", "Fast", "Guard", "Running", "Stable", "Valid"],
         "contact": contact,
         "aroi_domain": aroi_domain,
+        "aroi_version": aroi_version,
+        "aroi_proof_type": aroi_proof_type,
         "exit_dns_health_status": health_status,
         "exit_dns_health_detail": dns_status,
         "exit_dns_health_timing_ms": dns_timing,

--- a/tests/unit/templates/test_search_index_v3.py
+++ b/tests/unit/templates/test_search_index_v3.py
@@ -103,15 +103,15 @@ class TestSearchIndexV3Fields(unittest.TestCase):
             'sorted': {'family': {}},
             'relays_published': '2026-05-05 00:00:00',
         }
-        with tempfile.NamedTemporaryFile(suffix='.json', mode='w', delete=False) as f:
-            output_path = f.name
-        try:
+        # TemporaryDirectory is auto-cleaned on context exit — no
+        # explicit os.unlink needed (cleaner than NamedTemporaryFile +
+        # finally + os.unlink).
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, 'index.json')
             generate_search_index(relays_data, output_path)
             with open(output_path) as f:
                 index = json.load(f)
             self.assertEqual(index['meta']['version'], '1.6')
-        finally:
-            os.unlink(output_path)
 
     def test_lookups_v3_thresholds_present(self):
         """B5.1: lookups block exposes v3_thresholds map."""
@@ -120,9 +120,8 @@ class TestSearchIndexV3Fields(unittest.TestCase):
             'sorted': {'family': {}},
             'relays_published': '2026-05-05 00:00:00',
         }
-        with tempfile.NamedTemporaryFile(suffix='.json', mode='w', delete=False) as f:
-            output_path = f.name
-        try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, 'index.json')
             generate_search_index(relays_data, output_path)
             with open(output_path) as f:
                 index = json.load(f)
@@ -136,8 +135,6 @@ class TestSearchIndexV3Fields(unittest.TestCase):
                 'mostly': 75,
                 'complete': 100,
             })
-        finally:
-            os.unlink(output_path)
 
 
 if __name__ == '__main__':

--- a/tests/unit/templates/test_search_index_v3.py
+++ b/tests/unit/templates/test_search_index_v3.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 """
-Tests for B5.1 \u2014 search index v3 schema (version 1.6).
+Tests for B5.1 — search index v3 schema (version 1.6).
 
 Verifies the search-index.json generator (allium/lib/search_index.py)
 emits the v3-related compact fields (`vn` per relay, `v3p` per family,
 `v3_thresholds` lookup) and bumps `meta.version` to '1.6'.
+
+Pytest-style functions; uses the built-in tmp_path fixture for
+generate_search_index file I/O so individual tests do not need to
+manage TemporaryDirectory contexts manually.
 """
 
 import json
-import os
-import tempfile
-import unittest
 
 from allium.lib.search_index import (
     generate_search_index,
@@ -19,123 +20,119 @@ from allium.lib.search_index import (
 )
 
 
-class TestSearchIndexV3Fields(unittest.TestCase):
-
-    def test_relay_entry_emits_vn_for_v3_relay(self):
-        """B5.1: per-relay 'vn' field set to '3' for ciissversion:3 relays."""
-        relay = {
-            'fingerprint': 'A' * 40,
-            'nickname': 'v3relay',
-            'aroi_domain': 'v3.example.com',
-            'aroi_version': '3',
-            'aroi_proof_type': 'uri-familyid-ed25519',
-            'or_addresses': ['1.2.3.4:9001'],
-            'as': 'AS12345',
-            'country': 'DE',
-        }
-        entry = compact_relay_entry(relay, family_id=None)
-        self.assertEqual(entry.get('vn'), '3')
-
-    def test_relay_entry_emits_vn_for_v2_relay(self):
-        """B5.1: 'vn' set to '2' for ciissversion:2 relays."""
-        relay = {
-            'fingerprint': 'B' * 40,
-            'nickname': 'v2relay',
-            'aroi_domain': 'v2.example.com',
-            'aroi_version': '2',
-            'aroi_proof_type': 'uri-rsa',
-            'or_addresses': [],
-        }
-        entry = compact_relay_entry(relay, family_id=None)
-        self.assertEqual(entry.get('vn'), '2')
-
-    def test_relay_entry_omits_vn_when_no_aroi_version(self):
-        """B5.1: sparse \u2014 'vn' absent for relays without aroi_version."""
-        relay = {
-            'fingerprint': 'C' * 40,
-            'nickname': 'no_aroi',
-            'or_addresses': [],
-        }
-        entry = compact_relay_entry(relay, family_id=None)
-        self.assertNotIn('vn', entry)
-
-    def test_family_entry_emits_v3p_for_pure_v3_family(self):
-        """B5.1: per-family 'v3p' set to 100 for 100% v3 families."""
-        members = [
-            {'fingerprint': 'A' * 40, 'nickname': 'a', 'aroi_version': '3'},
-            {'fingerprint': 'B' * 40, 'nickname': 'b', 'aroi_version': '3'},
-        ]
-        entry = compact_family_entry('fam_id', {}, members)
-        self.assertEqual(entry.get('v3p'), 100)
-
-    def test_family_entry_emits_v3p_for_mixed_family(self):
-        """B5.1: 'v3p' = round(v3 / total * 100) for mixed families."""
-        members = [
-            {'fingerprint': 'A' * 40, 'nickname': 'a', 'aroi_version': '2'},
-            {'fingerprint': 'B' * 40, 'nickname': 'b', 'aroi_version': '3'},
-            {'fingerprint': 'C' * 40, 'nickname': 'c', 'aroi_version': '3'},
-            {'fingerprint': 'D' * 40, 'nickname': 'd', 'aroi_version': '3'},
-        ]
-        entry = compact_family_entry('fam_id', {}, members)
-        # 3/4 = 75%
-        self.assertEqual(entry.get('v3p'), 75)
-
-    def test_family_entry_omits_v3p_when_no_v3(self):
-        """B5.1: sparse \u2014 'v3p' absent when no v3 relays in family."""
-        members = [
-            {'fingerprint': 'A' * 40, 'nickname': 'a', 'aroi_version': '2'},
-            {'fingerprint': 'B' * 40, 'nickname': 'b', 'aroi_version': '2'},
-        ]
-        entry = compact_family_entry('fam_id', {}, members)
-        self.assertNotIn('v3p', entry)
-
-    def test_meta_version_bumped_to_1_6(self):
-        """B5.1: meta.version bumped to '1.6' on schema change."""
-        relays_data = {
-            'relays': [
-                {
-                    'fingerprint': 'A' * 40,
-                    'nickname': 'a',
-                    'aroi_version': '3',
-                    'or_addresses': [],
-                }
-            ],
-            'sorted': {'family': {}},
-            'relays_published': '2026-05-05 00:00:00',
-        }
-        # TemporaryDirectory is auto-cleaned on context exit — no
-        # explicit os.unlink needed (cleaner than NamedTemporaryFile +
-        # finally + os.unlink).
-        with tempfile.TemporaryDirectory() as tmpdir:
-            output_path = os.path.join(tmpdir, 'index.json')
-            generate_search_index(relays_data, output_path)
-            with open(output_path) as f:
-                index = json.load(f)
-            self.assertEqual(index['meta']['version'], '1.6')
-
-    def test_lookups_v3_thresholds_present(self):
-        """B5.1: lookups block exposes v3_thresholds map."""
-        relays_data = {
-            'relays': [],
-            'sorted': {'family': {}},
-            'relays_published': '2026-05-05 00:00:00',
-        }
-        with tempfile.TemporaryDirectory() as tmpdir:
-            output_path = os.path.join(tmpdir, 'index.json')
-            generate_search_index(relays_data, output_path)
-            with open(output_path) as f:
-                index = json.load(f)
-            thresholds = index['lookups'].get('v3_thresholds')
-            self.assertIsNotNone(thresholds)
-            # Mirror constants in aroi_validation.py for cross-surface
-            # consistency.
-            self.assertEqual(thresholds, {
-                'explorer': 1,
-                'migrating': 25,
-                'mostly': 75,
-                'complete': 100,
-            })
+def test_relay_entry_emits_vn_for_v3_relay():
+    """B5.1: per-relay 'vn' field set to '3' for ciissversion:3 relays."""
+    relay = {
+        'fingerprint': 'A' * 40,
+        'nickname': 'v3relay',
+        'aroi_domain': 'v3.example.com',
+        'aroi_version': '3',
+        'aroi_proof_type': 'uri-familyid-ed25519',
+        'or_addresses': ['1.2.3.4:9001'],
+        'as': 'AS12345',
+        'country': 'DE',
+    }
+    entry = compact_relay_entry(relay, family_id=None)
+    assert entry.get('vn') == '3'
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_relay_entry_emits_vn_for_v2_relay():
+    """B5.1: 'vn' set to '2' for ciissversion:2 relays."""
+    relay = {
+        'fingerprint': 'B' * 40,
+        'nickname': 'v2relay',
+        'aroi_domain': 'v2.example.com',
+        'aroi_version': '2',
+        'aroi_proof_type': 'uri-rsa',
+        'or_addresses': [],
+    }
+    entry = compact_relay_entry(relay, family_id=None)
+    assert entry.get('vn') == '2'
+
+
+def test_relay_entry_omits_vn_when_no_aroi_version():
+    """B5.1: sparse — 'vn' absent for relays without aroi_version."""
+    relay = {
+        'fingerprint': 'C' * 40,
+        'nickname': 'no_aroi',
+        'or_addresses': [],
+    }
+    entry = compact_relay_entry(relay, family_id=None)
+    assert 'vn' not in entry
+
+
+def test_family_entry_emits_v3p_for_pure_v3_family():
+    """B5.1: per-family 'v3p' set to 100 for 100% v3 families."""
+    members = [
+        {'fingerprint': 'A' * 40, 'nickname': 'a', 'aroi_version': '3'},
+        {'fingerprint': 'B' * 40, 'nickname': 'b', 'aroi_version': '3'},
+    ]
+    entry = compact_family_entry('fam_id', {}, members)
+    assert entry.get('v3p') == 100
+
+
+def test_family_entry_emits_v3p_for_mixed_family():
+    """B5.1: 'v3p' = round(v3 / total * 100) for mixed families."""
+    members = [
+        {'fingerprint': 'A' * 40, 'nickname': 'a', 'aroi_version': '2'},
+        {'fingerprint': 'B' * 40, 'nickname': 'b', 'aroi_version': '3'},
+        {'fingerprint': 'C' * 40, 'nickname': 'c', 'aroi_version': '3'},
+        {'fingerprint': 'D' * 40, 'nickname': 'd', 'aroi_version': '3'},
+    ]
+    entry = compact_family_entry('fam_id', {}, members)
+    # 3/4 = 75%
+    assert entry.get('v3p') == 75
+
+
+def test_family_entry_omits_v3p_when_no_v3():
+    """B5.1: sparse — 'v3p' absent when no v3 relays in family."""
+    members = [
+        {'fingerprint': 'A' * 40, 'nickname': 'a', 'aroi_version': '2'},
+        {'fingerprint': 'B' * 40, 'nickname': 'b', 'aroi_version': '2'},
+    ]
+    entry = compact_family_entry('fam_id', {}, members)
+    assert 'v3p' not in entry
+
+
+def test_meta_version_bumped_to_1_6(tmp_path):
+    """B5.1: meta.version bumped to '1.6' on schema change."""
+    relays_data = {
+        'relays': [
+            {
+                'fingerprint': 'A' * 40,
+                'nickname': 'a',
+                'aroi_version': '3',
+                'or_addresses': [],
+            }
+        ],
+        'sorted': {'family': {}},
+        'relays_published': '2026-05-05 00:00:00',
+    }
+    output_path = tmp_path / 'index.json'
+    generate_search_index(relays_data, str(output_path))
+    with open(output_path) as f:
+        index = json.load(f)
+    assert index['meta']['version'] == '1.6'
+
+
+def test_lookups_v3_thresholds_present(tmp_path):
+    """B5.1: lookups block exposes v3_thresholds map."""
+    relays_data = {
+        'relays': [],
+        'sorted': {'family': {}},
+        'relays_published': '2026-05-05 00:00:00',
+    }
+    output_path = tmp_path / 'index.json'
+    generate_search_index(relays_data, str(output_path))
+    with open(output_path) as f:
+        index = json.load(f)
+    thresholds = index['lookups'].get('v3_thresholds')
+    assert thresholds is not None
+    # Mirror constants in aroi_validation.py for cross-surface
+    # consistency.
+    assert thresholds == {
+        'explorer': 1,
+        'migrating': 25,
+        'mostly': 75,
+        'complete': 100,
+    }

--- a/tests/unit/templates/test_search_index_v3.py
+++ b/tests/unit/templates/test_search_index_v3.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Tests for B5.1 \u2014 search index v3 schema (version 1.6).
+
+Verifies the search-index.json generator (allium/lib/search_index.py)
+emits the v3-related compact fields (`vn` per relay, `v3p` per family,
+`v3_thresholds` lookup) and bumps `meta.version` to '1.6'.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+from allium.lib.search_index import (
+    generate_search_index,
+    compact_relay_entry,
+    compact_family_entry,
+)
+
+
+class TestSearchIndexV3Fields(unittest.TestCase):
+
+    def test_relay_entry_emits_vn_for_v3_relay(self):
+        """B5.1: per-relay 'vn' field set to '3' for ciissversion:3 relays."""
+        relay = {
+            'fingerprint': 'A' * 40,
+            'nickname': 'v3relay',
+            'aroi_domain': 'v3.example.com',
+            'aroi_version': '3',
+            'aroi_proof_type': 'uri-familyid-ed25519',
+            'or_addresses': ['1.2.3.4:9001'],
+            'as': 'AS12345',
+            'country': 'DE',
+        }
+        entry = compact_relay_entry(relay, family_id=None)
+        self.assertEqual(entry.get('vn'), '3')
+
+    def test_relay_entry_emits_vn_for_v2_relay(self):
+        """B5.1: 'vn' set to '2' for ciissversion:2 relays."""
+        relay = {
+            'fingerprint': 'B' * 40,
+            'nickname': 'v2relay',
+            'aroi_domain': 'v2.example.com',
+            'aroi_version': '2',
+            'aroi_proof_type': 'uri-rsa',
+            'or_addresses': [],
+        }
+        entry = compact_relay_entry(relay, family_id=None)
+        self.assertEqual(entry.get('vn'), '2')
+
+    def test_relay_entry_omits_vn_when_no_aroi_version(self):
+        """B5.1: sparse \u2014 'vn' absent for relays without aroi_version."""
+        relay = {
+            'fingerprint': 'C' * 40,
+            'nickname': 'no_aroi',
+            'or_addresses': [],
+        }
+        entry = compact_relay_entry(relay, family_id=None)
+        self.assertNotIn('vn', entry)
+
+    def test_family_entry_emits_v3p_for_pure_v3_family(self):
+        """B5.1: per-family 'v3p' set to 100 for 100% v3 families."""
+        members = [
+            {'fingerprint': 'A' * 40, 'nickname': 'a', 'aroi_version': '3'},
+            {'fingerprint': 'B' * 40, 'nickname': 'b', 'aroi_version': '3'},
+        ]
+        entry = compact_family_entry('fam_id', {}, members)
+        self.assertEqual(entry.get('v3p'), 100)
+
+    def test_family_entry_emits_v3p_for_mixed_family(self):
+        """B5.1: 'v3p' = round(v3 / total * 100) for mixed families."""
+        members = [
+            {'fingerprint': 'A' * 40, 'nickname': 'a', 'aroi_version': '2'},
+            {'fingerprint': 'B' * 40, 'nickname': 'b', 'aroi_version': '3'},
+            {'fingerprint': 'C' * 40, 'nickname': 'c', 'aroi_version': '3'},
+            {'fingerprint': 'D' * 40, 'nickname': 'd', 'aroi_version': '3'},
+        ]
+        entry = compact_family_entry('fam_id', {}, members)
+        # 3/4 = 75%
+        self.assertEqual(entry.get('v3p'), 75)
+
+    def test_family_entry_omits_v3p_when_no_v3(self):
+        """B5.1: sparse \u2014 'v3p' absent when no v3 relays in family."""
+        members = [
+            {'fingerprint': 'A' * 40, 'nickname': 'a', 'aroi_version': '2'},
+            {'fingerprint': 'B' * 40, 'nickname': 'b', 'aroi_version': '2'},
+        ]
+        entry = compact_family_entry('fam_id', {}, members)
+        self.assertNotIn('v3p', entry)
+
+    def test_meta_version_bumped_to_1_6(self):
+        """B5.1: meta.version bumped to '1.6' on schema change."""
+        relays_data = {
+            'relays': [
+                {
+                    'fingerprint': 'A' * 40,
+                    'nickname': 'a',
+                    'aroi_version': '3',
+                    'or_addresses': [],
+                }
+            ],
+            'sorted': {'family': {}},
+            'relays_published': '2026-05-05 00:00:00',
+        }
+        with tempfile.NamedTemporaryFile(suffix='.json', mode='w', delete=False) as f:
+            output_path = f.name
+        try:
+            generate_search_index(relays_data, output_path)
+            with open(output_path) as f:
+                index = json.load(f)
+            self.assertEqual(index['meta']['version'], '1.6')
+        finally:
+            os.unlink(output_path)
+
+    def test_lookups_v3_thresholds_present(self):
+        """B5.1: lookups block exposes v3_thresholds map."""
+        relays_data = {
+            'relays': [],
+            'sorted': {'family': {}},
+            'relays_published': '2026-05-05 00:00:00',
+        }
+        with tempfile.NamedTemporaryFile(suffix='.json', mode='w', delete=False) as f:
+            output_path = f.name
+        try:
+            generate_search_index(relays_data, output_path)
+            with open(output_path) as f:
+                index = json.load(f)
+            thresholds = index['lookups'].get('v3_thresholds')
+            self.assertIsNotNone(thresholds)
+            # Mirror constants in aroi_validation.py for cross-surface
+            # consistency.
+            self.assertEqual(thresholds, {
+                'explorer': 1,
+                'migrating': 25,
+                'mostly': 75,
+                'complete': 100,
+            })
+        finally:
+            os.unlink(output_path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_api_diagnostics.py
+++ b/tests/unit/test_api_diagnostics.py
@@ -1254,28 +1254,36 @@ class TestCheckAROIFieldsFirstWins:
         from allium.lib.aroi_validation import _check_aroi_fields
         return _check_aroi_fields(contact)
 
-    def test_unsupported_first_version_blocks_supported_later(self):
-        """ciissversion:99 first, ciissversion:2 second — first wins:
-        no supported version recognised."""
+    def test_unsupported_first_version_preserved_blocks_supported_later(self):
+        """ciissversion:99 first, ciissversion:2 second — first-wins
+        semantics: the v99 token wins. Per the latest hardening, the
+        raw '99' is PRESERVED in result['version'] so downstream code
+        can route the relay to the unsupported/mismatch bucket
+        instead of bucketing it as 'no ciissversion declared'.
+        """
         from allium.lib.aroi_validation import reset_aroi_warnings_log
         reset_aroi_warnings_log()
         result = self._check(
             'ciissversion:99 ciissversion:2 url:foo.com proof:uri-rsa'
         )
-        assert result['version'] is None
-        # has_ciissversion is True only if a SUPPORTED version was found.
-        assert result['has_ciissversion'] is False
+        # Raw token preserved (NOT silently overridden by the v2 that
+        # appears later in the contact string).
+        assert result['version'] == '99'
+        # has_ciissversion just reflects 'a version was declared'.
+        assert result['has_ciissversion'] is True
 
-    def test_unsupported_first_proof_type_blocks_supported_later(self):
+    def test_unsupported_first_proof_type_preserved_blocks_supported_later(self):
         """proof:rsa-extended-pq first, proof:uri-rsa second — first
-        wins: no supported proof_type recognised."""
+        wins: raw 'rsa-extended-pq' preserved so downstream sees the
+        explicit-but-unsupported declaration."""
         from allium.lib.aroi_validation import reset_aroi_warnings_log
         reset_aroi_warnings_log()
         result = self._check(
             'ciissversion:2 proof:rsa-extended-pq proof:uri-rsa url:foo.com'
         )
-        assert result['proof_type'] is None
-        assert result['has_proof'] is False
+        assert result['proof_type'] == 'rsa-extended-pq'
+        # has_proof flag tracks 'a proof was declared'.
+        assert result['has_proof'] is True
 
     def test_supported_first_version_still_works(self):
         from allium.lib.aroi_validation import reset_aroi_warnings_log
@@ -1292,3 +1300,86 @@ class TestCheckAROIFieldsFirstWins:
         result = self._check('ciissversion:2 proof:uri-rsa url:foo.com')
         assert result['proof_type'] == 'uri-rsa'
         assert result['has_proof'] is True
+
+
+# ============================================================================
+# Reviewer follow-up #5: F1 preserve raw unsupported tokens
+# ============================================================================
+
+
+class TestUnsupportedTokenPreservation:
+    """F1: when the FIRST declared ciissversion / proof_type is
+    unsupported, _check_aroi_fields preserves the raw token in
+    aroi_fields['version'] / aroi_fields['proof_type'] (was None
+    previously). This routes the relay through a different bucket
+    in _categorize_by_missing_fields than 'missing field' — the
+    operator-actionable distinction between 'didn't declare a version'
+    vs 'declared an unsupported version' is preserved."""
+
+    def _check(self, contact):
+        from allium.lib.aroi_validation import _check_aroi_fields, reset_aroi_warnings_log
+        reset_aroi_warnings_log()
+        return _check_aroi_fields(contact)
+
+    def test_unsupported_version_preserved_in_aroi_fields(self):
+        result = self._check(
+            'ciissversion:99 url:foo.com proof:uri-rsa'
+        )
+        assert result['version'] == '99'
+        assert result['has_ciissversion'] is True
+
+    def test_unsupported_proof_type_preserved_in_aroi_fields(self):
+        result = self._check(
+            'ciissversion:2 proof:rsa-extended-pq url:foo.com'
+        )
+        assert result['proof_type'] == 'rsa-extended-pq'
+        assert result['has_proof'] is True
+
+    def test_unsupported_version_does_not_route_to_no_aroi_info(self):
+        """With all 3 fields declared but ciissversion is unsupported,
+        the relay should NOT land in the 'no_aroi_info' bucket (which
+        is reserved for relays with NO AROI fields at all). The
+        unsupported-version case ends up routed via the
+        version_proof_mismatch branch because PROOF_TYPE_VERSION can't
+        match the unsupported value to any known proof type — that's a
+        more accurate signal than 'missing field'."""
+        from allium.lib.aroi_validation import (
+            _check_aroi_fields, _categorize_by_missing_fields,
+            reset_aroi_warnings_log,
+        )
+        reset_aroi_warnings_log()
+        result = _check_aroi_fields(
+            'ciissversion:99 url:foo.com proof:uri-rsa'
+        )
+        category = _categorize_by_missing_fields(result, has_contact=True)
+        # Anything OTHER than the missing-field buckets is acceptable —
+        # the explicit-but-unsupported declaration is no longer hidden.
+        assert category not in ('no_aroi_info', 'missing_two_aroi',
+                                'no_proof', 'no_domain', 'no_ciissversion')
+
+
+class TestDashboardTileValidityAccuracy:
+    """F2b: dashboard ciissversion v2/v3 tiles compute validity as
+    validated / declared (NOT the proof-attempt success rate which
+    the *_success_rate fields carry). The new template logic divides
+    ciissversion_validated[N] by ciissversion_declared[N]; this
+    test enforces the data shape the template depends on so a future
+    change in aroi_validation can't silently break the tile math."""
+
+    def test_ciissversion_validated_and_declared_keys_present(self):
+        """Both dicts must be populated by calculate_aroi_validation_metrics
+        even for the empty / fallback path the template can hit."""
+        from allium.lib.aroi_validation import calculate_aroi_validation_metrics
+        m = calculate_aroi_validation_metrics(
+            [{'fingerprint': 'A' * 40,
+              'contact': 'ciissversion:2 proof:uri-rsa url:foo.com',
+              'aroi_domain': 'foo.com', 'aroi_version': '2',
+              'aroi_proof_type': 'uri-rsa', 'aroi_configured': True}],
+            None,  # validation_data None -> early-return fallback
+        )
+        # Both dicts must exist (even if empty) so the template's
+        # dict.get(...) calls don't crash on undefined access.
+        assert 'ciissversion_declared' in m
+        assert 'ciissversion_validated' in m
+        assert isinstance(m['ciissversion_declared'], dict)
+        assert isinstance(m['ciissversion_validated'], dict)

--- a/tests/unit/test_api_diagnostics.py
+++ b/tests/unit/test_api_diagnostics.py
@@ -651,19 +651,45 @@ class TestComputeContactDisplayDataMergedLoop:
         assert result['total_data_formatted']  # non-empty
 
     def test_single_pass_over_members(self):
-        """Source-level guarantee: only ONE 'for r in members' in
-        compute_contact_display_data after the item B merge.
+        """Source-level guarantee: the variants+total_data merged loop
+        introduced by item B is exactly ONE pass over members. The
+        original two passes used loop target name `r`; after the merge,
+        only one such `for r in members` loop remains.
 
-        Uses inspect.getsource() on the imported function instead of
-        reading a hard-coded repo path, so the test works regardless
-        of where the workspace is mounted (/workspace, /home/user,
-        cloud-agent VM paths, contributor laptop, etc.).
+        Note: a *separate* `for relay in members` loop later in the
+        function handles version compliance + family-support tracking
+        — that's independent of item B's merge and out of scope here.
+        We assert specifically on the loop whose target is the Name
+        `r` so renaming the unrelated `relay` loop does not falsely
+        trip this guarantee.
+
+        Reviewer-flagged upgrade: parse the function body as an AST
+        instead of substring-matching. Substring matching can be
+        spoofed by comments/docstrings ("# for r in members") and
+        breaks on harmless reformatting; AST inspection asserts on
+        actual control-flow structure.
         """
+        import ast
         import inspect
+        import textwrap
         from allium.lib.operator_analysis import compute_contact_display_data
-        src = inspect.getsource(compute_contact_display_data)
-        # Allow at most ONE member-loop in the function body.
-        assert src.count('for r in members') == 1
+        src = textwrap.dedent(inspect.getsource(compute_contact_display_data))
+        tree = ast.parse(src)
+        # The item-B merged loop has target Name('r') and iter
+        # Name('members'). Count those specifically.
+        merged_loops = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.For)
+            and isinstance(node.iter, ast.Name)
+            and node.iter.id == 'members'
+            and isinstance(node.target, ast.Name)
+            and node.target.id == 'r'
+        ]
+        assert len(merged_loops) == 1, (
+            "expected exactly 1 'for r in members' merged loop "
+            "(item B contract) in compute_contact_display_data, found "
+            f"{len(merged_loops)}"
+        )
 
 
 # ============================================================================
@@ -850,22 +876,47 @@ class TestProofTypeVersionSingleSourceOfTruth:
         local proof-type -> version dict definition. The single source
         of truth lives in aroi_validation.PROOF_TYPE_VERSION.
 
-        Uses inspect.getsourcefile() to discover the module's file
-        path at test time instead of hard-coding /workspace/..., so
-        the test works regardless of where the repo is mounted.
+        Reviewer-flagged upgrade: parse the module as an AST instead of
+        substring/regex-matching. Substring checks can be spoofed by
+        comments/docstrings ("# legacy _PROOF_TYPE_VERSION_MAP removed")
+        and break on harmless reformatting. We assert on actual
+        ast.Assign nodes whose target is a Name with id
+        '_PROOF_TYPE_VERSION_MAP' — that's the only structure that
+        could shadow the central helper. We also assert on an actual
+        ImportFrom node bringing get_proof_type_version into scope.
         """
-        import inspect, re
+        import ast
+        import inspect
         from allium.lib import api_diagnostics
+
         module_file = inspect.getsourcefile(api_diagnostics)
         assert module_file, "could not resolve api_diagnostics module file"
         with open(module_file) as f:
             src = f.read()
-        # No literal dict-definition for the local map. Comments
-        # mentioning the old name are fine — they explain the migration.
-        assert not re.search(r'^\s*_PROOF_TYPE_VERSION_MAP\s*=\s*\{', src, re.MULTILINE), \
-            "Local proof-type map must be removed; use aroi_validation.get_proof_type_version"
-        # And the central helper IS imported/used.
-        assert 'get_proof_type_version' in src
+        tree = ast.parse(src)
+
+        local_map_assigns = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == '_PROOF_TYPE_VERSION_MAP'
+                for t in node.targets
+            )
+        ]
+        assert local_map_assigns == [], (
+            "Local _PROOF_TYPE_VERSION_MAP rebinding detected; use "
+            "aroi_validation.get_proof_type_version instead"
+        )
+
+        imports_central = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            and any(alias.name == 'get_proof_type_version' for alias in node.names)
+        ]
+        assert imports_central, (
+            "api_diagnostics must import get_proof_type_version from "
+            "aroi_validation"
+        )
 
 
 class TestCiissversionNumericSort:
@@ -1087,12 +1138,157 @@ class TestRankingsCacheVersionCounter:
 
     def test_relays_generate_aroi_leaderboards_bumps_version(self):
         """Source-level guarantee: _generate_aroi_leaderboards must
-        increment leaderboards_version. Locks the production-side
-        contract that the cache invalidation depends on."""
+        increment relay_set.leaderboards_version. Locks the production
+        contract that the cache invalidation relies on.
+
+        Reviewer-flagged upgrade: AST inspection instead of substring
+        match. We accept any of the common ways to bump an integer
+        attribute (`self.leaderboards_version += 1`,
+        `self.leaderboards_version = ... + 1`, `getattr(...,
+        'leaderboards_version', 0) + 1`) — what matters structurally is
+        an Assign or AugAssign node that writes back to
+        self.leaderboards_version with an arithmetic expression on the
+        right-hand side that itself references leaderboards_version.
+        Behavioural correctness is also covered by
+        test_version_counter_invalidates_cache below; this test
+        guarantees the bump WILL happen on every rebuild even when
+        nobody runs the integration smoke.
+        """
+        import ast
         import inspect
+        import textwrap
         from allium.lib.relays import Relays
-        src = inspect.getsource(Relays._generate_aroi_leaderboards)
-        assert 'leaderboards_version' in src, (
-            "_generate_aroi_leaderboards must bump leaderboards_version "
-            "to invalidate the rankings index cache"
+
+        src = textwrap.dedent(inspect.getsource(Relays._generate_aroi_leaderboards))
+        tree = ast.parse(src)
+
+        def writes_to_leaderboards_version(node):
+            """True if `node` is `self.leaderboards_version` (Attribute on
+            Name 'self' with attr 'leaderboards_version')."""
+            return (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == 'self'
+                and node.attr == 'leaderboards_version'
+            )
+
+        # Look for `self.leaderboards_version = <expr>` (Assign) OR
+        # `self.leaderboards_version += <expr>` (AugAssign).
+        bump_nodes = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AugAssign) and writes_to_leaderboards_version(node.target):
+                bump_nodes.append(node)
+            elif isinstance(node, ast.Assign) and any(
+                writes_to_leaderboards_version(t) for t in node.targets
+            ):
+                bump_nodes.append(node)
+
+        assert bump_nodes, (
+            "_generate_aroi_leaderboards must assign to "
+            "self.leaderboards_version on every rebuild — required for "
+            "the cache invalidation contract enforced by "
+            "_get_contact_rankings_index"
         )
+
+
+# ============================================================================
+# Reviewer follow-up #4: F1 has_aroi for v3_informational + F2 first-wins
+# ============================================================================
+
+
+class TestV3InformationalHasAROI:
+    """F1: a v3_informational relay HAS declared ciissversion:3 — it is
+    NOT a zero-AROI-fields contact. result['has_aroi'] must be True
+    so downstream code that filters on 'operator has any AROI
+    declaration' picks them up. The not_configured_no_aroi_info_count
+    bucket (reserved for relays with NO AROI fields at all) must NOT
+    be incremented for v3_informational relays."""
+
+    def test_v3_informational_sets_has_aroi(self):
+        from allium.lib.aroi_validation import get_contact_validation_status
+        relays = [{
+            'fingerprint': 'A' * 40,
+            'contact': 'ciissversion:3 email:owner[]example.com',
+            'aroi_domain': 'none',
+            'aroi_version': '3',
+            'aroi_proof_type': None,
+            'aroi_configured': False,
+        }]
+        result = get_contact_validation_status(relays, {'results': []})
+        assert result['has_aroi'] is True
+
+    def test_v3_informational_does_not_inflate_no_aroi_info(self):
+        from allium.lib.aroi_validation import get_contact_validation_status
+        relays = [{
+            'fingerprint': 'A' * 40,
+            'contact': 'ciissversion:3 email:owner[]example.com',
+            'aroi_domain': 'none',
+            'aroi_version': '3',
+            'aroi_proof_type': None,
+            'aroi_configured': False,
+        }]
+        s = get_contact_validation_status(relays, {'results': []})['validation_summary']
+        # Bucket reserved for "has contact, no AROI fields at all"
+        # MUST NOT count v3_informational (which DOES have ciissversion).
+        assert s['not_configured_no_aroi_info_count'] == 0
+        # But not_configured_count and incomplete_v3_informational_count DO go up.
+        assert s['not_configured_count'] == 1
+        assert s['incomplete_v3_informational_count'] == 1
+
+
+class TestCheckAROIFieldsFirstWins:
+    """F2: CIISS spec says duplicate keys -> FIRST wins.
+    aroi_validation._check_aroi_fields() previously searched for
+    SUPPORTED versions first via _CIISS_VERSION_RE, which silently
+    skipped a leading unsupported declaration if a supported one
+    followed. Per the spec, an unsupported FIRST token means the
+    relay has no usable version regardless of subsequent tokens.
+
+    Note: `Relays._simple_aroi_parsing` (relays.py) is a separate
+    parsing path used at categorisation time; the reviewer's F2 ask
+    was specifically about the validation-time path here, so we
+    target `_check_aroi_fields` directly.
+    """
+
+    def _check(self, contact):
+        from allium.lib.aroi_validation import _check_aroi_fields
+        return _check_aroi_fields(contact)
+
+    def test_unsupported_first_version_blocks_supported_later(self):
+        """ciissversion:99 first, ciissversion:2 second — first wins:
+        no supported version recognised."""
+        from allium.lib.aroi_validation import reset_aroi_warnings_log
+        reset_aroi_warnings_log()
+        result = self._check(
+            'ciissversion:99 ciissversion:2 url:foo.com proof:uri-rsa'
+        )
+        assert result['version'] is None
+        # has_ciissversion is True only if a SUPPORTED version was found.
+        assert result['has_ciissversion'] is False
+
+    def test_unsupported_first_proof_type_blocks_supported_later(self):
+        """proof:rsa-extended-pq first, proof:uri-rsa second — first
+        wins: no supported proof_type recognised."""
+        from allium.lib.aroi_validation import reset_aroi_warnings_log
+        reset_aroi_warnings_log()
+        result = self._check(
+            'ciissversion:2 proof:rsa-extended-pq proof:uri-rsa url:foo.com'
+        )
+        assert result['proof_type'] is None
+        assert result['has_proof'] is False
+
+    def test_supported_first_version_still_works(self):
+        from allium.lib.aroi_validation import reset_aroi_warnings_log
+        reset_aroi_warnings_log()
+        result = self._check(
+            'ciissversion:3 url:foo.com proof:uri-familyid-ed25519'
+        )
+        assert result['version'] == '3'
+        assert result['has_ciissversion'] is True
+
+    def test_supported_first_proof_type_still_works(self):
+        from allium.lib.aroi_validation import reset_aroi_warnings_log
+        reset_aroi_warnings_log()
+        result = self._check('ciissversion:2 proof:uri-rsa url:foo.com')
+        assert result['proof_type'] == 'uri-rsa'
+        assert result['has_proof'] is True

--- a/tests/unit/test_api_diagnostics.py
+++ b/tests/unit/test_api_diagnostics.py
@@ -410,3 +410,478 @@ class TestCollectApiDiagnostics:
         uptime_api = next(a for a in result["apis"] if a["name"] == "onionoo_uptime")
         assert uptime_api["enabled"] is False
         assert uptime_api["freshness"] == "unavailable"
+
+
+# ============================================================================
+# Item D: pre-formatted diagnostics rows (template-side simplification)
+# ============================================================================
+
+
+class TestProofTypeRowFormatter:
+    """_format_proof_type_rows pre-builds template-ready rows so the
+    api-diagnostics.html template doesn't need to do dictsort + 'familyid
+    in pt' string-substring classification + zero-bucket filtering in
+    Jinja. This locks the contract."""
+
+    def test_v3_proof_types_get_blue_v3_badge(self):
+        from allium.lib.api_diagnostics import _format_proof_type_rows
+        rows = _format_proof_type_rows({
+            'dns_familyid_ed25519': {'valid': 269, 'total': 269},
+            'uri_familyid_ed25519': {'valid': 969, 'total': 978},
+        })
+        assert len(rows) == 2
+        for r in rows:
+            assert r['version'] == '3'
+            assert r['badge_color'] == '#007bff'
+
+    def test_v2_proof_types_get_grey_v2_badge(self):
+        from allium.lib.api_diagnostics import _format_proof_type_rows
+        rows = _format_proof_type_rows({
+            'dns_rsa': {'valid': 211, 'total': 247},
+            'uri_rsa': {'valid': 2571, 'total': 2971},
+        })
+        for r in rows:
+            assert r['version'] == '2'
+            assert r['badge_color'] == '#6c757d'
+
+    def test_no_proof_bucket_excluded(self):
+        from allium.lib.api_diagnostics import _format_proof_type_rows
+        rows = _format_proof_type_rows({
+            'dns_rsa': {'valid': 1, 'total': 1},
+            'no_proof': {'valid': 0, 'total': 6248},
+        })
+        assert len(rows) == 1
+        assert rows[0]['proof_type'] == 'dns_rsa'
+
+    def test_zero_total_buckets_excluded(self):
+        from allium.lib.api_diagnostics import _format_proof_type_rows
+        rows = _format_proof_type_rows({
+            'dns_rsa': {'valid': 0, 'total': 0},
+            'uri_rsa': {'valid': 5, 'total': 10},
+        })
+        assert len(rows) == 1
+        assert rows[0]['proof_type'] == 'uri_rsa'
+
+    def test_alphabetical_sort_order(self):
+        from allium.lib.api_diagnostics import _format_proof_type_rows
+        rows = _format_proof_type_rows({
+            'uri_rsa': {'valid': 1, 'total': 1},
+            'dns_familyid_ed25519': {'valid': 1, 'total': 1},
+            'dns_rsa': {'valid': 1, 'total': 1},
+            'uri_familyid_ed25519': {'valid': 1, 'total': 1},
+        })
+        types = [r['proof_type'] for r in rows]
+        assert types == sorted(types)
+
+    def test_unknown_proof_type_falls_back_to_neutral_color(self):
+        from allium.lib.api_diagnostics import _format_proof_type_rows
+        rows = _format_proof_type_rows({
+            'mystery_proof': {'valid': 1, 'total': 5},
+        })
+        assert rows[0]['version'] == 'unknown'
+        assert rows[0]['badge_color'] == '#adb5bd'
+
+    def test_non_dict_input_returns_empty(self):
+        from allium.lib.api_diagnostics import _format_proof_type_rows
+        assert _format_proof_type_rows(None) == []
+        assert _format_proof_type_rows([]) == []
+
+
+class TestCiissversionRowFormatter:
+    """_format_ciissversion_rows pre-builds the version-declared row list
+    with consistent ordering (numeric versions ascending, 'none' last)
+    and is_none flag the template uses directly."""
+
+    def test_numeric_versions_ascending(self):
+        from allium.lib.api_diagnostics import _format_ciissversion_rows
+        rows = _format_ciissversion_rows({'3': 1247, '1': 1, '2': 3376})
+        keys = [r['key'] for r in rows]
+        assert keys == ['1', '2', '3']
+
+    def test_none_bucket_appears_last(self):
+        from allium.lib.api_diagnostics import _format_ciissversion_rows
+        rows = _format_ciissversion_rows({'2': 100, 'none': 50, '3': 200})
+        assert rows[-1]['key'] == 'none'
+        assert rows[-1]['is_none'] is True
+
+    def test_v3_gets_blue_badge_v2_gets_grey(self):
+        from allium.lib.api_diagnostics import _format_ciissversion_rows
+        rows = _format_ciissversion_rows({'2': 1, '3': 1})
+        v2 = next(r for r in rows if r['key'] == '2')
+        v3 = next(r for r in rows if r['key'] == '3')
+        assert v2['badge_color'] == '#6c757d'
+        assert v3['badge_color'] == '#007bff'
+
+
+# ============================================================================
+# Item A: contact rankings index (precomputed once, reused per contact)
+# ============================================================================
+
+
+class TestContactRankingsIndex:
+    """The legacy generate_contact_rankings(contact, relay_set) walked
+    every leaderboard category × top-25 entries per contact, costing
+    O(N_contacts × N_categories × 25). _build_contact_rankings_index
+    builds the full {contact_hash: [rankings]} map in ONE pass; per-
+    contact lookups are then O(1) dict access. This locks both the
+    output equivalence and the cache behaviour."""
+
+    def _mock_relay_set(self, leaderboards):
+        rs = MagicMock()
+        rs.json = {'aroi_leaderboards': {'leaderboards': leaderboards}}
+        return rs
+
+    def test_index_matches_legacy_output_for_each_contact(self):
+        from allium.lib.operator_analysis import (
+            generate_contact_rankings, _build_contact_rankings_index,
+        )
+        rs = self._mock_relay_set({
+            'bandwidth': [('A', {}), ('B', {}), ('C', {})],
+            'consensus_weight': [{'contact_hash': 'C'}, {'contact_hash': 'A'}],
+            'exit_authority': [{'contact_hash': 'X'}],
+        })
+        index = _build_contact_rankings_index(rs)
+        for contact in ('A', 'B', 'C', 'X', 'NONE'):
+            fresh = generate_contact_rankings(contact, rs)
+            cached = list(index.get(contact, []))
+            assert [r['rank'] for r in fresh] == [r['rank'] for r in cached]
+            assert [r['category'] for r in fresh] == [r['category'] for r in cached]
+
+    def test_rankings_sorted_by_rank_ascending(self):
+        from allium.lib.operator_analysis import generate_contact_rankings
+        rs = self._mock_relay_set({
+            # 'A' is rank-1 in bandwidth but rank-3 in consensus_weight
+            'bandwidth': [('A', {}), ('B', {})],
+            'consensus_weight': [('X', {}), ('Y', {}), ('A', {})],
+        })
+        rankings = generate_contact_rankings('A', rs)
+        assert [r['rank'] for r in rankings] == [1, 3]
+
+    def test_rank_capped_at_25(self):
+        from allium.lib.operator_analysis import generate_contact_rankings
+        # Place 'A' at rank 26 — should NOT appear in the rankings.
+        rs = self._mock_relay_set({
+            'bandwidth': [('OTHER', {})] * 25 + [('A', {})],
+        })
+        assert generate_contact_rankings('A', rs) == []
+
+    def test_returns_copy_not_reference(self):
+        """Mutating the returned list MUST NOT affect the cached index."""
+        from allium.lib.operator_analysis import generate_contact_rankings
+        rs = self._mock_relay_set({
+            'bandwidth': [('A', {})],
+        })
+        first = generate_contact_rankings('A', rs)
+        first.clear()
+        second = generate_contact_rankings('A', rs)
+        assert len(second) == 1, "cache was clobbered by external mutation"
+
+    def test_cache_invalidated_on_leaderboards_replacement(self):
+        from allium.lib.operator_analysis import generate_contact_rankings
+        rs = self._mock_relay_set({
+            'bandwidth': [('OLD', {})],
+        })
+        first = generate_contact_rankings('OLD', rs)
+        assert first  # populates cache
+        # Replace the leaderboards object — cache key (id of leaderboards
+        # dict) should differ, so a fresh build kicks in.
+        rs.json['aroi_leaderboards']['leaderboards'] = {
+            'bandwidth': [('NEW', {})],
+        }
+        assert generate_contact_rankings('NEW', rs)
+        assert generate_contact_rankings('OLD', rs) == []
+
+
+# ============================================================================
+# Item B: merged variants/total_data loop in compute_contact_display_data
+# ============================================================================
+
+
+class TestComputeContactDisplayDataMergedLoop:
+    """compute_contact_display_data must produce identical contact_variants
+    AND td_sums when items are folded into one members loop. The single-
+    pass loop is a hot path during ~3,000 contact-page precomputes per
+    build."""
+
+    def test_variants_grouped_by_distinct_raw_contact_string(self):
+        from allium.lib.operator_analysis import compute_contact_display_data
+        members = [
+            {'contact': 'STR_A', 'aroi_version': '2', 'aroi_proof_type': 'uri-rsa',
+             'aroi_domain': 'mock.com', 'aroi_configured': True,
+             'total_data': {'1_month': 10, '6_months': 20, '1_year': 50, '5_years': 100}},
+            {'contact': 'STR_A', 'aroi_version': '2', 'aroi_proof_type': 'uri-rsa',
+             'aroi_domain': 'mock.com', 'aroi_configured': True,
+             'total_data': {'1_month': 5, '6_months': 10, '1_year': 25, '5_years': 50}},
+            {'contact': 'STR_B', 'aroi_version': '3', 'aroi_proof_type': 'uri-familyid-ed25519',
+             'aroi_domain': 'mock.com', 'aroi_configured': True,
+             'total_data': {'1_month': 1, '6_months': 2, '1_year': 5, '5_years': 10}},
+        ]
+        # Build minimal mock `i` (the contact's sorted data).
+        i = {k: 0 for k in (
+            'bandwidth', 'guard_bandwidth', 'middle_bandwidth', 'exit_bandwidth',
+            'consensus_weight_fraction', 'guard_consensus_weight_fraction',
+            'middle_consensus_weight_fraction', 'exit_consensus_weight_fraction',
+            'count', 'measured_count',
+            'guard_count', 'middle_count', 'exit_count',
+            'unique_as_count', 'unique_country_count',
+        )}
+        i['first_seen'] = '2025-01-01 00:00:00'
+
+        # Mock relay_set with the methods needed by helpers.
+        rs = MagicMock()
+        rs.bandwidth_formatter.format_bandwidth_with_unit.return_value = '0'
+        rs.json = {
+            'network_health': {'network_total_data_by_period': {'1_year': 100}},
+            'smart_context': {},
+        }
+
+        result = compute_contact_display_data(i, 'GB', None, 'mock_v', members, rs)
+        # Two distinct ContactInfo strings under this operator.
+        assert result['contact_variant_count'] == 2
+        # Sorted by count desc — STR_A (2 relays) before STR_B (1 relay).
+        assert result['contact_variants'][0]['raw'] == 'STR_A'
+        assert result['contact_variants'][0]['count'] == 2
+        assert result['contact_variants'][1]['raw'] == 'STR_B'
+        assert result['contact_variants'][1]['count'] == 1
+        # Total-data summed across all relays in same loop.
+        assert result['total_data_formatted']  # non-empty
+
+    def test_single_pass_over_members(self):
+        """Source-level guarantee: only ONE 'for r in members' in
+        compute_contact_display_data after the item B merge.
+
+        Uses inspect.getsource() on the imported function instead of
+        reading a hard-coded repo path, so the test works regardless
+        of where the workspace is mounted (/workspace, /home/user,
+        cloud-agent VM paths, contributor laptop, etc.).
+        """
+        import inspect
+        from allium.lib.operator_analysis import compute_contact_display_data
+        src = inspect.getsource(compute_contact_display_data)
+        # Allow at most ONE member-loop in the function body.
+        assert src.count('for r in members') == 1
+
+
+# ============================================================================
+# Item 3: contact_variant_count tracked during categorization
+# ============================================================================
+
+
+class TestContactVariantCountInCategorization:
+    """Item 3: the relays-categorization pass tracks distinct ContactInfo
+    strings per contact group via a set, exposing the count as
+    sorted.contact[hash].contact_variant_count for variant-aware
+    list-view tooltips."""
+
+    def _make_relay(self, raw_contact):
+        return {
+            'fingerprint': 'F' * 40, 'contact': raw_contact, 'contact_md5': 'h1',
+            'aroi_domain': 'x.com', 'flags': [],
+            'observed_bandwidth': 100, 'consensus_weight': 1,
+            'consensus_weight_fraction': 0.0,
+            'guard_consensus_weight_fraction': 0.0,
+            'middle_consensus_weight_fraction': 0.0,
+            'exit_consensus_weight_fraction': 0.0,
+            'first_seen': '2025-01-01 00:00:00',
+            'country': 'US', 'platform': 'Linux', 'as': '111', 'as_name': '',
+            'effective_family': [],
+        }
+
+    def _make_relay_set(self, relays):
+        rs = MagicMock()
+        rs.json = {
+            'relays': relays,
+            'sorted': {'contact': {}},
+        }
+        return rs
+
+    def test_single_variant_count_eq_1(self):
+        """Two relays with the SAME raw contact string -> count = 1."""
+        from allium.lib.categorization import sort_relay
+        relays = [self._make_relay('SAME'), self._make_relay('SAME')]
+        rs = self._make_relay_set(relays)
+        for idx, relay in enumerate(relays):
+            sort_relay(rs, relay, idx, 'contact', 'h1', 1, 0.0)
+        sorted_data = rs.json['sorted']['contact']['h1']
+        assert sorted_data.get('contact_variant_count') == 1
+
+    def test_two_variants_yields_count_2(self):
+        """Two relays with DIFFERENT raw contact strings -> count = 2."""
+        from allium.lib.categorization import sort_relay
+        relays = [self._make_relay('VAR_A'), self._make_relay('VAR_B')]
+        rs = self._make_relay_set(relays)
+        for idx, relay in enumerate(relays):
+            sort_relay(rs, relay, idx, 'contact', 'h1', 1, 0.0)
+        sorted_data = rs.json['sorted']['contact']['h1']
+        assert sorted_data.get('contact_variant_count') == 2
+
+    def test_only_tracked_for_contact_groups(self):
+        """family/country/etc groups don't get the variant_count field
+        — it's specific to the contact listing."""
+        from allium.lib.categorization import sort_relay
+        relays = [self._make_relay('R1'), self._make_relay('R2')]
+        rs = self._make_relay_set(relays)
+        # Categorize as 'family' instead of 'contact'.
+        for idx, relay in enumerate(relays):
+            sort_relay(rs, relay, idx, 'family', 'fam_h', 1, 0.0)
+        family_data = rs.json['sorted'].get('family', {}).get('fam_h', {})
+        assert 'contact_variant_count' not in family_data
+
+
+# ============================================================================
+# P1-P4 reviewer-priority hardening
+# ============================================================================
+
+
+class TestRankingMutationSafety:
+    """P1: generate_contact_rankings must isolate BOTH list-level and
+    dict-level mutation — callers receive fresh copies so they cannot
+    accidentally clobber the cached index."""
+
+    def _build_rs(self):
+        rs = MagicMock()
+        rs.json = {'aroi_leaderboards': {'leaderboards': {
+            'bandwidth': [('A', {})],
+            'consensus_weight': [('A', {})],
+        }}}
+        return rs
+
+    def test_list_mutation_isolated(self):
+        from allium.lib.operator_analysis import generate_contact_rankings
+        rs = self._build_rs()
+        first = generate_contact_rankings('A', rs)
+        first.clear()
+        assert len(generate_contact_rankings('A', rs)) == 2
+
+    def test_dict_mutation_isolated(self):
+        """Mutating a returned ranking dict must NOT leak back into the
+        cached index — locks the P1 contract."""
+        from allium.lib.operator_analysis import generate_contact_rankings
+        rs = self._build_rs()
+        first = generate_contact_rankings('A', rs)
+        first[0]['statement'] = 'CLOBBERED'
+        first[0]['injected_field'] = True
+        # Subsequent call must see pristine cached entries.
+        second = generate_contact_rankings('A', rs)
+        assert second[0]['statement'] != 'CLOBBERED'
+        assert 'injected_field' not in second[0]
+
+
+class TestRankingsIndexDedupe:
+    """P2: legacy generate_contact_rankings broke after first match per
+    category, so a malformed leaderboard repeating the same contact
+    within one category never produced duplicate rankings. Lock the
+    new indexer's parity."""
+
+    def test_duplicate_contact_in_same_category_dedupes(self):
+        from allium.lib.operator_analysis import _build_contact_rankings_index
+        rs = MagicMock()
+        rs.json = {'aroi_leaderboards': {'leaderboards': {
+            'bandwidth': [
+                ('A', {}),
+                ('B', {}),
+                ('A', {}),  # duplicate — must be ignored per legacy semantics
+                ('A', {}),  # another duplicate
+            ],
+        }}}
+        idx = _build_contact_rankings_index(rs)
+        # 'A' appears at rank 1 (first occurrence) only.
+        assert len(idx['A']) == 1
+        assert idx['A'][0]['rank'] == 1
+        assert len(idx['B']) == 1
+        assert idx['B'][0]['rank'] == 2
+
+    def test_duplicate_in_different_categories_kept(self):
+        """A contact CAN appear in multiple categories — only same-
+        category duplicates are deduped."""
+        from allium.lib.operator_analysis import _build_contact_rankings_index
+        rs = MagicMock()
+        rs.json = {'aroi_leaderboards': {'leaderboards': {
+            'bandwidth': [('A', {})],
+            'consensus_weight': [('A', {})],
+            'exit_authority': [('A', {})],
+        }}}
+        idx = _build_contact_rankings_index(rs)
+        assert len(idx['A']) == 3
+        cats = {r['category'] for r in idx['A']}
+        assert cats == {'bandwidth', 'consensus_weight', 'exit_authority'}
+
+
+class TestProofTypeVersionSingleSourceOfTruth:
+    """P3: only ONE place defines proof_type -> ciissversion mapping —
+    aroi_validation.PROOF_TYPE_VERSION (with both dashed and underscore
+    keys). api_diagnostics row formatters must reuse it via
+    get_proof_type_version() instead of carrying a local copy."""
+
+    def test_get_proof_type_version_handles_dashed_form(self):
+        from allium.lib.aroi_validation import get_proof_type_version
+        assert get_proof_type_version('dns-rsa') == '2'
+        assert get_proof_type_version('uri-rsa') == '2'
+        assert get_proof_type_version('dns-familyid-ed25519') == '3'
+        assert get_proof_type_version('uri-familyid-ed25519') == '3'
+
+    def test_get_proof_type_version_handles_underscore_form(self):
+        from allium.lib.aroi_validation import get_proof_type_version
+        # Same proof types via the upstream-stats key form.
+        assert get_proof_type_version('dns_rsa') == '2'
+        assert get_proof_type_version('uri_rsa') == '2'
+        assert get_proof_type_version('dns_familyid_ed25519') == '3'
+        assert get_proof_type_version('uri_familyid_ed25519') == '3'
+
+    def test_unknown_proof_type_returns_unknown_not_misclassified(self):
+        """Future proof types added upstream MUST classify as 'unknown'
+        until PROOF_TYPE_VERSION is updated — never silently misclassified
+        as v2 because they happen to contain 'rsa' or as v3 because they
+        contain 'family'."""
+        from allium.lib.aroi_validation import get_proof_type_version
+        # 'rsa-extended' contains 'rsa' but isn't in our dict.
+        assert get_proof_type_version('rsa-extended') == 'unknown'
+        # 'pq-familyid-mlkem' contains 'familyid' but isn't in our dict.
+        assert get_proof_type_version('pq-familyid-mlkem') == 'unknown'
+        assert get_proof_type_version('') == 'unknown'
+        assert get_proof_type_version(None) == 'unknown'
+
+    def test_api_diagnostics_uses_central_helper(self):
+        """Source-level guarantee: api_diagnostics.py MUST NOT carry a
+        local proof-type -> version dict definition. The single source
+        of truth lives in aroi_validation.PROOF_TYPE_VERSION.
+
+        Uses inspect.getsourcefile() to discover the module's file
+        path at test time instead of hard-coding /workspace/..., so
+        the test works regardless of where the repo is mounted.
+        """
+        import inspect, re
+        from allium.lib import api_diagnostics
+        module_file = inspect.getsourcefile(api_diagnostics)
+        assert module_file, "could not resolve api_diagnostics module file"
+        with open(module_file) as f:
+            src = f.read()
+        # No literal dict-definition for the local map. Comments
+        # mentioning the old name are fine — they explain the migration.
+        assert not re.search(r'^\s*_PROOF_TYPE_VERSION_MAP\s*=\s*\{', src, re.MULTILINE), \
+            "Local proof-type map must be removed; use aroi_validation.get_proof_type_version"
+        # And the central helper IS imported/used.
+        assert 'get_proof_type_version' in src
+
+
+class TestCiissversionNumericSort:
+    """P4: future-proof the ciissversion row sort. String-sorting works
+    for v1/v2/v3 today but breaks once a hypothetical v10 ships
+    (string-sort puts '10' between '1' and '2')."""
+
+    def test_v10_sorts_after_v3(self):
+        from allium.lib.api_diagnostics import _format_ciissversion_rows
+        rows = _format_ciissversion_rows({'10': 5, '3': 100, '2': 200, '1': 1})
+        keys = [r['key'] for r in rows]
+        assert keys == ['1', '2', '3', '10']
+
+    def test_none_still_last_with_high_versions(self):
+        from allium.lib.api_diagnostics import _format_ciissversion_rows
+        rows = _format_ciissversion_rows({'10': 1, '2': 1, 'none': 1})
+        assert rows[-1]['key'] == 'none'
+
+    def test_alphabetical_after_numeric(self):
+        """Two non-numeric keys both land at the end, in alpha order."""
+        from allium.lib.api_diagnostics import _format_ciissversion_rows
+        rows = _format_ciissversion_rows({'2': 1, 'none': 1, 'unknown': 1})
+        assert [r['key'] for r in rows] == ['2', 'none', 'unknown']

--- a/tests/unit/test_api_diagnostics.py
+++ b/tests/unit/test_api_diagnostics.py
@@ -885,3 +885,100 @@ class TestCiissversionNumericSort:
         from allium.lib.api_diagnostics import _format_ciissversion_rows
         rows = _format_ciissversion_rows({'2': 1, 'none': 1, 'unknown': 1})
         assert [r['key'] for r in rows] == ['2', 'none', 'unknown']
+
+
+# ============================================================================
+# Reviewer follow-up #2: 17 hardening fixes
+# ============================================================================
+
+
+class TestV3OnlyCategoriesCorrection:
+    """F1: V3_ONLY_ERROR_CATEGORIES used to wrongly include
+    proof-file/TXT-related categories. _build_error_rollup() then
+    treated every v2 URI-RSA / DNS-RSA failure as v3-only."""
+
+    def test_uri_content_mismatch_not_v3_only(self):
+        from allium.lib.aroi_validation import V3_ONLY_ERROR_CATEGORIES
+        # These four MUST NOT be in V3_ONLY — they fire for both v2 and v3.
+        for cat in (
+            'uri_content_mismatch', 'uri_file_missing',
+            'dns_content_mismatch', 'dns_txt_missing',
+        ):
+            assert cat not in V3_ONLY_ERROR_CATEGORIES
+
+    def test_v2_uri_content_mismatch_routes_to_v2_bucket(self):
+        from allium.lib.aroi_validation import _build_error_rollup
+        results = [
+            {'fingerprint': 'A', 'valid': False, 'ciissversion': '2',
+             'error_category': 'uri_content_mismatch'},
+            {'fingerprint': 'B', 'valid': False, 'ciissversion': '3',
+             'error_category': 'uri_content_mismatch'},
+        ]
+        shared, v2_only, v3_only = _build_error_rollup(results)
+        # v2 relay's failure must appear in v2_only — not silently
+        # misclassified as v3-only by the legacy bug.
+        assert any('uri_content_mismatch' == row[0] for row in v2_only)
+        assert any('uri_content_mismatch' == row[0] for row in v3_only)
+
+
+class TestContactVariantSetCleanup:
+    """F2: _contact_variant_set is a Python set and would break
+    json.dumps if it survived past categorisation. It must be removed
+    by the calculate_contact_derived_data finalisation pass."""
+
+    def test_set_removed_after_finalisation(self):
+        import json
+        from allium.lib.categorization import (
+            sort_relay, calculate_contact_derived_data,
+        )
+        rs = MagicMock()
+        rs.json = {'relays': [], 'sorted': {'contact': {}}}
+        base = {
+            'fingerprint': 'F' * 40, 'flags': [], 'observed_bandwidth': 100,
+            'consensus_weight': 1, 'consensus_weight_fraction': 0.0,
+            'guard_consensus_weight_fraction': 0.0,
+            'middle_consensus_weight_fraction': 0.0,
+            'exit_consensus_weight_fraction': 0.0,
+            'first_seen': '2025-01-01 00:00:00', 'country': 'US',
+            'platform': 'Linux', 'as': '111', 'as_name': '',
+            'effective_family': [], 'aroi_domain': 'x.com',
+        }
+        for raw in ('A', 'B', 'A'):
+            r = dict(base, contact=raw, contact_md5='h1')
+            rs.json['relays'].append(r)
+            sort_relay(rs, r, len(rs.json['relays']) - 1, 'contact', 'h1', 1, 0.0)
+        rs.json['sorted']['contact']['h1']['bandwidth'] = 300
+        calculate_contact_derived_data(rs)
+
+        cd = rs.json['sorted']['contact']['h1']
+        # Count survives.
+        assert cd['contact_variant_count'] == 2
+        # Live set is gone.
+        assert '_contact_variant_set' not in cd
+        # And the dict is JSON-serialisable end-to-end.
+        json.dumps(cd, default=str)
+
+
+class TestEarlyReturnPercentageFields:
+    """F19: the early-return fallback branch in
+    calculate_aroi_validation_metrics increments
+    relays_version_proof_mismatch / relays_v3_informational counters
+    but used to forget to compute their _percentage companions —
+    leaving downstream templates with KeyError or None."""
+
+    def test_fallback_branch_populates_new_percentages(self):
+        from allium.lib.aroi_validation import calculate_aroi_validation_metrics
+        m = calculate_aroi_validation_metrics(
+            [{
+                'fingerprint': 'A' * 40,
+                'contact': 'ciissversion:2 proof:uri-rsa url:foo.com',
+                'aroi_domain': 'foo.com', 'aroi_version': '2',
+                'aroi_proof_type': 'uri-rsa', 'aroi_configured': True,
+            }],
+            None,  # validation_data None -> early-return fallback
+        )
+        # Both new percentage keys MUST be present (not missing).
+        assert 'relays_version_proof_mismatch_percentage' in m
+        assert 'relays_v3_informational_percentage' in m
+        assert isinstance(m['relays_version_proof_mismatch_percentage'], float)
+        assert isinstance(m['relays_v3_informational_percentage'], float)

--- a/tests/unit/test_api_diagnostics.py
+++ b/tests/unit/test_api_diagnostics.py
@@ -581,13 +581,17 @@ class TestContactRankingsIndex:
         rs = self._mock_relay_set({
             'bandwidth': [('OLD', {})],
         })
+        rs.leaderboards_version = 1
         first = generate_contact_rankings('OLD', rs)
         assert first  # populates cache
-        # Replace the leaderboards object — cache key (id of leaderboards
-        # dict) should differ, so a fresh build kicks in.
+        # Replace the leaderboards object AND bump the deterministic
+        # version counter — _generate_aroi_leaderboards in production
+        # bumps relay_set.leaderboards_version after every rebuild, so
+        # any cached rankings index is invalidated.
         rs.json['aroi_leaderboards']['leaderboards'] = {
             'bandwidth': [('NEW', {})],
         }
+        rs.leaderboards_version += 1
         assert generate_contact_rankings('NEW', rs)
         assert generate_contact_rankings('OLD', rs) == []
 
@@ -982,3 +986,113 @@ class TestEarlyReturnPercentageFields:
         assert 'relays_v3_informational_percentage' in m
         assert isinstance(m['relays_version_proof_mismatch_percentage'], float)
         assert isinstance(m['relays_v3_informational_percentage'], float)
+
+
+# ============================================================================
+# Reviewer follow-up #3: F1 (v3_informational counter), F6 (version counter)
+# ============================================================================
+
+
+class TestV3InformationalCounter:
+    """F1: the v3_informational branch must bump the dedicated
+    incomplete_v3_informational_count field — it was being missed
+    despite the field being initialised at construction time."""
+
+    def test_v3_informational_relay_increments_counter(self):
+        """A relay with ciissversion:3 + no url: should bump
+        validation_summary.incomplete_v3_informational_count
+        even though it routes to the not_configured bucket."""
+        from allium.lib.aroi_validation import get_contact_validation_status
+        relays = [{
+            'fingerprint': 'A' * 40,
+            # Spec-legal v3 informational form: ciissversion:3 + email
+            # but no url:.
+            'contact': 'ciissversion:3 email:owner[]example.com',
+            # _check_aroi_fields will see has_ciissversion=True,
+            # has_url=False, treat as v3_informational category.
+            'aroi_domain': 'none',
+            'aroi_version': '3',
+            'aroi_proof_type': None,
+            'aroi_configured': False,
+        }]
+        result = get_contact_validation_status(relays, {'results': []})
+        assert result['validation_summary']['incomplete_v3_informational_count'] == 1
+
+    def test_non_v3_informational_does_not_inflate_counter(self):
+        """An unrelated incomplete relay must NOT bump the
+        v3_informational counter."""
+        from allium.lib.aroi_validation import get_contact_validation_status
+        relays = [{
+            'fingerprint': 'B' * 40,
+            'contact': 'noreply@nowhere.invalid',  # plain contact, no AROI
+            'aroi_domain': 'none',
+            'aroi_version': None,
+            'aroi_proof_type': None,
+            'aroi_configured': False,
+        }]
+        result = get_contact_validation_status(relays, {'results': []})
+        assert result['validation_summary']['incomplete_v3_informational_count'] == 0
+
+
+class TestRankingsCacheVersionCounter:
+    """F6: cache key for _get_contact_rankings_index switched from
+    id(leaderboards_obj) to a deterministic monotonic counter
+    (relay_set.leaderboards_version) bumped by _generate_aroi_leaderboards.
+    """
+
+    def test_version_counter_invalidates_cache(self):
+        from allium.lib.operator_analysis import generate_contact_rankings
+        rs = MagicMock()
+        rs.json = {'aroi_leaderboards': {'leaderboards': {
+            'bandwidth': [('OLD', {})],
+        }}}
+        rs.leaderboards_version = 1
+        first = generate_contact_rankings('OLD', rs)
+        assert first
+        # Bump the counter — even WITHOUT replacing the leaderboards
+        # dict object, the cache must invalidate.
+        rs.leaderboards_version = 2
+        rs.json['aroi_leaderboards']['leaderboards'] = {
+            'bandwidth': [('NEW', {})],
+        }
+        new_rankings = generate_contact_rankings('NEW', rs)
+        assert new_rankings
+        assert generate_contact_rankings('OLD', rs) == []
+
+    def test_same_version_serves_cached_results(self):
+        """If leaderboards_version doesn't change, the cached index is
+        reused — even after the underlying leaderboards dict is
+        mutated in-place. This is intentional: the version counter is
+        the authoritative invalidation signal, not object identity."""
+        from allium.lib.operator_analysis import generate_contact_rankings
+        rs = MagicMock()
+        rs.json = {'aroi_leaderboards': {'leaderboards': {
+            'bandwidth': [('A', {})],
+        }}}
+        rs.leaderboards_version = 5
+        # First call populates cache.
+        first = generate_contact_rankings('A', rs)
+        assert first
+        # Mutate underlying data WITHOUT bumping the version. The cache
+        # MUST keep serving the original snapshot — production code is
+        # required to bump leaderboards_version on every rebuild.
+        rs.json['aroi_leaderboards']['leaderboards'] = {
+            'bandwidth': [('B', {})],
+        }
+        # 'A' still resolves (because cache wasn't invalidated).
+        second = generate_contact_rankings('A', rs)
+        assert second
+        # 'B' does NOT resolve (the new entry isn't in the cache).
+        assert generate_contact_rankings('B', rs) == []
+
+    def test_relays_generate_aroi_leaderboards_bumps_version(self):
+        """Source-level guarantee: _generate_aroi_leaderboards must
+        increment leaderboards_version. Locks the production-side
+        contract that the cache invalidation depends on."""
+        import inspect
+        from allium.lib.relays import Relays
+        src = inspect.getsource(Relays._generate_aroi_leaderboards)
+        assert 'leaderboards_version' in src, (
+            "_generate_aroi_leaderboards must bump leaderboards_version "
+            "to invalidate the rankings index cache"
+        )

--- a/tests/unit/test_prometheus_metrics.py
+++ b/tests/unit/test_prometheus_metrics.py
@@ -253,7 +253,7 @@ def test_aroi_state_and_counts(tmp_path, make_relay, make_relay_set, sample_dns_
     assert 'aeo1_aroi_relays_count{state="configured_unchecked"} 1' in content
     assert 'aeo1_aroi_relays_count{state="configured_checked_invalid"} 1' in content
     assert 'aeo1_aroi_relays_count{state="configured_checked_valid"} 1' in content
-    # B7.2: aeo1_aroi_relays_count_by_version emits all 16 (4 state × 4
+    # B7.2: aeo1_aroi_relays_count_by_version emits all 16 (4 state x 4
     # ciissversion) cells with the correct counts.
     assert 'aeo1_aroi_relays_count_by_version{state="configured_checked_valid",ciissversion="2"} 1' in content
     assert 'aeo1_aroi_relays_count_by_version{state="configured_checked_invalid",ciissversion="2"} 1' in content

--- a/tests/unit/test_prometheus_metrics.py
+++ b/tests/unit/test_prometheus_metrics.py
@@ -241,14 +241,26 @@ def test_aroi_state_and_counts(tmp_path, make_relay, make_relay_set, sample_dns_
         tmp_path, make_relay_set, sample_dns_metadata, sample_aroi_metadata, relays, aroi_data=sample_aroi_data()
     )
     assert stats["aroi_relays"] == 3
-    assert 'aeo1_aroi_relay_state{fingerprint="AAAA",familyid="",state="configured_checked_valid"} 1' in content
-    assert 'aeo1_aroi_relay_state{fingerprint="BBBB",familyid="",state="configured_checked_invalid"} 1' in content
-    assert 'aeo1_aroi_relay_state{fingerprint="CCCC",familyid="",state="configured_unchecked"} 1' in content
-    assert 'aeo1_aroi_relay_state{fingerprint="DDDD",familyid="",state="not_configured"} 1' in content
+    # B7.1: aeo1_aroi_relay_state labelset extended with ciissversion +
+    # proof_type_family. All test fixture relays declare ciissversion:2
+    # with rsa proof types via the contact string.
+    assert 'aeo1_aroi_relay_state{fingerprint="AAAA",familyid="",state="configured_checked_valid",ciissversion="2",proof_type_family="rsa"} 1' in content
+    assert 'aeo1_aroi_relay_state{fingerprint="BBBB",familyid="",state="configured_checked_invalid",ciissversion="2",proof_type_family="rsa"} 1' in content
+    assert 'aeo1_aroi_relay_state{fingerprint="CCCC",familyid="",state="configured_unchecked",ciissversion="2",proof_type_family="rsa"} 1' in content
+    # DDDD has plain contact (no ciissversion) — labels: none/none.
+    assert 'aeo1_aroi_relay_state{fingerprint="DDDD",familyid="",state="not_configured",ciissversion="none",proof_type_family="none"} 1' in content
     assert 'aeo1_aroi_relays_count{state="not_configured"} 1' in content
     assert 'aeo1_aroi_relays_count{state="configured_unchecked"} 1' in content
     assert 'aeo1_aroi_relays_count{state="configured_checked_invalid"} 1' in content
     assert 'aeo1_aroi_relays_count{state="configured_checked_valid"} 1' in content
+    # B7.2: aeo1_aroi_relays_count_by_version emits all 16 (4 state × 4
+    # ciissversion) cells with the correct counts.
+    assert 'aeo1_aroi_relays_count_by_version{state="configured_checked_valid",ciissversion="2"} 1' in content
+    assert 'aeo1_aroi_relays_count_by_version{state="configured_checked_invalid",ciissversion="2"} 1' in content
+    assert 'aeo1_aroi_relays_count_by_version{state="configured_unchecked",ciissversion="2"} 1' in content
+    assert 'aeo1_aroi_relays_count_by_version{state="not_configured",ciissversion="none"} 1' in content
+    # Zero-cell present (no v3 in this fixture).
+    assert 'aeo1_aroi_relays_count_by_version{state="configured_checked_valid",ciissversion="3"} 0' in content
 
 
 def test_aroi_exactly_one_state_per_relay(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data,
@@ -269,15 +281,19 @@ def test_aroi_exactly_one_state_per_relay(tmp_path, make_relay, make_relay_set, 
         "DDDD": "not_configured",
     }
     for fp, expected_state in expected_states.items():
+        # B7.1: regex updated for new labelset (ciissversion + proof_type_family).
         matches = re.findall(
-            rf'^aeo1_aroi_relay_state\{{fingerprint="{fp}",familyid="",state="[^"]+"\}} 1$',
+            rf'^aeo1_aroi_relay_state\{{fingerprint="{fp}",familyid="",state="[^"]+",ciissversion="[^"]+",proof_type_family="[^"]+"\}} 1$',
             content,
             re.MULTILINE,
         )
         assert len(matches) == 1, f"expected exactly one state for {fp}"
-        assert (
-            f'aeo1_aroi_relay_state{{fingerprint="{fp}",familyid="",state="{expected_state}"}} 1' in content
-        ), f"expected state {expected_state} for {fp}"
+        # State assertion — accept any ciissversion/proof_type_family combo.
+        state_match = re.search(
+            rf'aeo1_aroi_relay_state\{{fingerprint="{fp}",familyid="",state="{expected_state}",ciissversion="[^"]+",proof_type_family="[^"]+"\}} 1',
+            content,
+        )
+        assert state_match is not None, f"expected state {expected_state} for {fp}"
 
 
 def test_aroi_legacy_metrics_removed(tmp_path, make_relay, make_relay_set, sample_dns_metadata, sample_aroi_data,

--- a/tests/unit/test_prometheus_schema_contract.py
+++ b/tests/unit/test_prometheus_schema_contract.py
@@ -158,6 +158,7 @@ def test_metric_family_contract_and_legacy_absence(render_metrics):
         "aeo1_exit_dns_errors_count",
         "aeo1_aroi_relay_state",
         "aeo1_aroi_relays_count",
+        "aeo1_aroi_relays_count_by_version",
         "aeo1_aroi_scan_timestamp_seconds",
         "aeo1_aroi_relay_info",
     }
@@ -172,9 +173,11 @@ def test_metric_family_contract_and_legacy_absence(render_metrics):
 
 
 def test_frozen_aroi_state_enum_values(render_metrics):
+    # B7.1: regex updated for new labelset (state still extractable as
+    # before; bounded enum unchanged from schema v2).
     states = set(
         re.findall(
-            r'aeo1_aroi_relay_state\{[^}]*state="([^"]+)"\} 1',
+            r'aeo1_aroi_relay_state\{[^}]*?state="([^"]+)"',
             render_metrics,
         )
     )
@@ -197,8 +200,13 @@ def test_frozen_label_keys_for_core_metrics(render_metrics):
         "aeo1_exit_dns_latency_ms": {"fingerprint", "familyid"},
         "aeo1_exit_dns_consecutive_failures": {"fingerprint", "familyid"},
         "aeo1_exit_relay_info": {"fingerprint", "familyid", "nick", "verifiedaroi"},
-        "aeo1_aroi_relay_state": {"fingerprint", "familyid", "state"},
+        # B7.1: aeo1_aroi_relay_state labelset extended with bounded
+        # ciissversion + proof_type_family labels (cardinality cap = 4×5=20).
+        "aeo1_aroi_relay_state": {"fingerprint", "familyid", "state",
+                                   "ciissversion", "proof_type_family"},
         "aeo1_aroi_relays_count": {"state"},
+        # B7.2: new metric for per-version state counts.
+        "aeo1_aroi_relays_count_by_version": {"state", "ciissversion"},
         "aeo1_aroi_relay_info": {"fingerprint", "familyid", "nick", "domain", "proof_type"},
     }
     for metric, expected_keys in expected.items():
@@ -284,14 +292,19 @@ def test_recording_rules_file_exists_and_uses_v2_states():
 def test_alert_and_recording_rule_metric_references_exist(render_metrics):
     emitted = _metric_names_from_content(render_metrics)
 
+    rules_path = _DOCS_DIR / "recording_rules.yml"
+    record_names = _extract_record_names(rules_path)
+    group_names = _extract_group_names(rules_path)
+
     alerts_path = _DOCS_DIR / "alerts_aroi.yml"
     alerts_refs = _extract_non_comment_aeo1_tokens(alerts_path)
     alerts_refs -= _extract_group_names(alerts_path)
-    assert alerts_refs.issubset(emitted), f"unknown alert refs: {sorted(alerts_refs - emitted)}"
+    # B7.2: alerts may reference recording rule outputs (derived metrics)
+    # in addition to directly-emitted metrics. Both are valid sources.
+    valid_alert_targets = emitted | record_names
+    assert alerts_refs.issubset(valid_alert_targets), \
+        f"unknown alert refs: {sorted(alerts_refs - valid_alert_targets)}"
 
-    rules_path = _DOCS_DIR / "recording_rules.yml"
     rules_refs = _extract_non_comment_aeo1_tokens(rules_path)
-    record_names = _extract_record_names(rules_path)
-    group_names = _extract_group_names(rules_path)
     expr_refs = rules_refs - record_names - group_names
     assert expr_refs.issubset(emitted), f"unknown recording expr refs: {sorted(expr_refs - emitted)}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds full support for **CIISS (ContactInfo Information Sharing Specification) version 3** alongside the existing v2 across the entire Allium static-site pipeline. The legacy integration was hard-coded to v2 only and silently ignored v3 relays / their validation status from the upstream `aroivalidator.1aeo.com` service.

After this PR, every operator-facing surface understands BOTH spec versions, surfaces v3 migration progress, and hands operators copy-pasteable fix examples for whichever version they actually use.

## What changed

### Backend (data plumbing)
- `aroi_validation.py`: new constants for v2/v3 proof types, schema-version handshake, error-category cascade, peer-issue buckets (security_incident, pending_onionoo), v3 tier classification, error-rollup helper.
- `network_health.py`: cached AROI metrics across the 4 `_calculate_network_health_metrics` calls per build; `validation_map` cached separately so cache hits don't wipe it.
- `relays.py`, `categorization.py`: 3-tuple AROI parsing returning `(domain, version, proof_type)`; per-contact-group distinct ContactInfo variant tracking.
- `prometheus_metrics.py`: per-version state labels + `aeo1_aroi_relays_count_by_version` metric.
- `api_diagnostics.py`: extended diagnostics block with schema version, version-declared rollup, proof-types summary, top error categories, build-time warning feed.

### Frontend (operator-facing UI)
- **Operator pages** (`contact.html`): condensed v2/v3 summary line (`952 relays, 99% valid, 97% v3, 3% v2`); ContactInfo-variant block when an operator publishes multiple raw strings under the same AROI domain; pasteable curl/DNS examples with the actual fingerprint and operator domain substituted in.
- **Network Health dashboard**: split v2/v3 proof-type panels; ciissversion adoption tile; structured v3-failure-category tooltips.
- **API Diagnostics**: per-proof-type v2/v3 colored pills; `ciissversion declared` row; top v3 error categories; build-time warnings list.
- **Leaderboards** (`misc/aroi-leaderboards.html`): v2 Valid / v3 Valid / v3 Migration columns + tiered migration badges.
- **Listings** (`misc-contacts.html` and bandwidth/count/etc. variants): variant-aware tooltips when an operator has multiple distinct ContactInfo strings; per-relay v2/v3 version badges.
- **Relay-info pages**: per-relay v2/v3 badge + per-relay status flags (🚨 / ⏳ / 🚫 / ⚠) with deduplication so cascade-vs-peer never doubles up.
- **Search index** (`search-index.json` v1.6): adds `vn` (CIISS version) + `v3p` (v3 percentage) + `v3_thresholds` lookup table.

### Critical regressions fixed
- **Cache-hit bug** (commit `d68fcec7ec`): Phase 2 caching used destructive `.pop('_validation_map', {})` which wiped `relay_set.validation_map` on cache hits → every contact page after the first `_calculate_network_health_metrics` call rendered all relays as misconfigured / 0% valid. Fix: cache the validation_map separately and restore it on every call. Locked by 2 dedicated regression tests (`TestAROIValidationMapCacheRegression`).
- **v2 RSA file path on misconfigured relays** (commit `515e51359d`): `URI-RSA fingerprint not found` was rendering the v3 file path (`ed25519-family-id.txt`). Now per-`proof_type`-aware: v2 relays show `https://<domain>/.well-known/tor-relay/rsa-fingerprint.txt   # must contain this relay's 40-char fingerprint <FP>` with the actual operator domain and relay fingerprint substituted in.

### Reviewer-priority follow-ups (last 3 commits)

**Items A, B, D, 3** (commit `120093f7fe`):
- **A**: precompute `contact_hash → rankings` index once via `_build_contact_rankings_index` instead of scanning leaderboard categories per contact (~1.05M iterations → ~3.35K).
- **B**: merge contact-variants and total-data per-period sums into one `for r in members` loop in `compute_contact_display_data`.
- **D**: move dictsort + `'familyid' in pt` string-classification + zero-bucket filtering out of `api-diagnostics.html` into `_format_proof_type_rows` / `_format_ciissversion_rows` Python helpers; output byte-identical.
- **3**: variant-aware tooltips on aggregate listings — `"N distinct ContactInfo strings under this AROI domain — see operator page for breakdown"` when N > 1, falls back to `"Contact: <string>"` otherwise.

**Items P1-P4** (commit `3cf8db14df`):
- **P1**: deep-copy ranking dicts so list-level AND dict-level mutation by callers can't leak into the cached index.
- **P2**: per-category dedupe in `_build_contact_rankings_index` to mirror legacy `break`-after-first-match parity even if upstream leaderboard data ever repeats a contact.
- **P3**: single source of truth for proof-type → version classification — `aroi_validation.PROOF_TYPE_VERSION` (with both dashed and underscored keys) + new `get_proof_type_version()` helper. `api_diagnostics.py`'s local map removed.
- **P4**: numeric-aware ciissversion row sort so a future v10 lands after v3, not between v1 and v2.

**Hard-coded path fix** (this commit, `e53d8bc1fa`):
- 3 source-level test assertions had `/workspace/...` hard-coded. Now use `inspect.getsource()` / `inspect.getsourcefile()` / `Path(__file__).resolve().parents[2]` so the tests work from any checkout location.

## Test coverage

**928 unit/integration tests pass** (was 891 before AROI v3, +37 new tests).

New test classes specific to this PR:
- `TestAROIValidationMapCacheRegression` — cache-hit bug protection (2 tests)
- `TestAROIPasteableExamples` — v2/v3 example resolution (4 tests)
- `TestProofTypeRowFormatter` / `TestCiissversionRowFormatter` — diagnostics rows (10 tests)
- `TestContactRankingsIndex` — legacy parity + cache invalidation (5 tests)
- `TestComputeContactDisplayDataMergedLoop` — single-pass guarantee (2 tests)
- `TestContactVariantCountInCategorization` — variant tracking (3 tests)
- `TestRankingMutationSafety` — list + dict isolation (2 tests)
- `TestRankingsIndexDedupe` — same-category dedupe (2 tests)
- `TestProofTypeVersionSingleSourceOfTruth` — DRY enforcement (4 tests)
- `TestCiissversionNumericSort` — v10-future-proof ordering (3 tests)
- `tests/system/test_aroi_v3_live_smoke.py` — A.10 live-API smoke test (deselected by default in CI; runs only with `-m system`)

## Verification

- Full site rebuild with live upstream data: ✓
- `compare_outputs.py` baseline-vs-after: only intentional content changes detected; 27,067+ files identical-or-timestamp-only.
- Cross-checked rendered numbers against live `aroivalidator.1aeo.com` and `onionoo.torproject.org`: e.g. for **1aeo.com** (mixed v2+v3, 952 relays) the page renders `✓ Validated` with `952 relays, 99% valid, 97% v3, 3% v2` matching upstream's 32/32 v2 valid + 914/920 v3 valid.
- Manual browser review on the rendered site led to 5 UX iterations (commit `75acdbeb38` and onward).

## Branch history

This branch (`cursor/aroi-validator-ciissversion-3-d298`) merged from the prior session branch `cursor/aroi-v3-support` and continued with the reviewer-priority follow-ups. All 50+ commits are on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5628f5cf-67c8-486d-ae30-1c3982c622e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5628f5cf-67c8-486d-ae30-1c3982c622e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dual CIISS v2+v3 support: per-version success rates, per-relay v{n} badges, operator v3 percentages/tiers, leaderboard/operator split columns, pasteable operator fix examples, and expanded UI migration nudges
  * Security-incident & pending-Onionoo surfacing with dedicated badges, sections, and per-relay markers
  * Richer AROI diagnostics and per-relay remediation UI

* **Prometheus**
  * Emits per-version aggregates, per-state-by-version metric, new recording rules and a v3 success-rate alert

* **Documentation**
  * Expanded AROI docs, architecture, README, security guidance, and style conventions

* **Tests**
  * Extensive unit, integration, and opt-in live/system smoke tests for v3, metrics, templates, and diagnostics

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1aeo/allium/pull/207)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->