### PR TITLE
AROI v3: Option A (incomplete-AROI display name) + Option B (sibling …

### DIFF
--- a/allium/lib/aroileaders.py
+++ b/allium/lib/aroileaders.py
@@ -41,7 +41,7 @@ _URL_FIELD_FALLBACK_RE = re.compile(
 )
 
 
-def _incomplete_aroi_display_name(contact_info, contact_hash):
+def _incomplete_aroi_display_name(contact_info, contact_hash) -> str:
     """Build a friendly display name for an operator whose AROI parsing
     failed but whose ContactInfo still contains a recognisable identifier.
 
@@ -65,6 +65,9 @@ def _incomplete_aroi_display_name(contact_info, contact_hash):
             if '://' in domain:
                 domain = domain.split('://', 1)[1]
             domain = domain.split('/', 1)[0].split('?', 1)[0]
+            # Canonicalise to lowercase before the www-prefix check so
+            # values like "WWW.Example.com" are normalised correctly.
+            domain = domain.lower()
             if domain.startswith('www.'):
                 domain = domain[4:]
             domain = domain.rstrip('.,;:')
@@ -515,6 +518,19 @@ def _collect_operator_metrics(relays_instance):
             #   2. raw contact-info string truncated to 30 chars
             #   3. contact_hash prefix as last resort
             operator_key = _incomplete_aroi_display_name(contact_info, contact_hash)
+            # Collision guard: two different contact_hash groups can
+            # resolve to the same fallback display name (e.g. two
+            # operators both publishing url:example.com but with
+            # different ContactInfo variants and no ciissversion). The
+            # later iteration would otherwise overwrite the earlier
+            # entry in aroi_operators, silently dropping the first
+            # operator's metrics. Append a short contact_hash suffix on
+            # collision so both rows are preserved. Proper cross-
+            # contact_hash *merging* is a larger refactor (would need to
+            # re-aggregate from raw relays) and is intentionally
+            # deferred — preventing data loss is the priority here.
+            if operator_key in aroi_operators:
+                operator_key = f"{operator_key}#{contact_hash[:8]}"
         
         # === USE EXISTING CALCULATIONS (NO DUPLICATION) ===
         # All basic metrics are already computed in contact_data

--- a/allium/lib/aroileaders.py
+++ b/allium/lib/aroileaders.py
@@ -40,6 +40,13 @@ _URL_FIELD_FALLBACK_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Maximum length of a derived display name returned by
+# extract_contact_display_name() that we accept for the incomplete-AROI
+# leaderboard row. Values longer than this are rejected so the row falls
+# through to the truncation cascade (cascade 3) and the leaderboard cell
+# stays compact / readable.
+MAX_DERIVED_LENGTH = 60
+
 
 def _incomplete_aroi_display_name(contact_info, contact_hash) -> str:
     """Build a friendly display name for an operator whose AROI parsing
@@ -76,7 +83,7 @@ def _incomplete_aroi_display_name(contact_info, contact_hash) -> str:
 
         # Cascade 2: email/name/url-derivation helper.
         derived = extract_contact_display_name(clean_contact, None)
-        if derived and derived != 'none' and len(derived) <= 60:
+        if derived and derived != 'none' and len(derived) <= MAX_DERIVED_LENGTH:
             return derived
 
         # Cascade 3: truncated raw contact (preserved legacy behaviour).

--- a/allium/lib/aroileaders.py
+++ b/allium/lib/aroileaders.py
@@ -27,8 +27,62 @@ from .country_utils import (
 )
 
 # Import HTML escaping utility
-from .string_utils import safe_html_escape
+from .string_utils import safe_html_escape, extract_contact_display_name
 
+
+# Pre-compiled url-token regex for the Option A incomplete-AROI fallback.
+# Matches the CIISS `url:` field token in a raw contact string. We intentionally
+# accept any plausible domain (we are not validating CIISS conformance here —
+# the caller already confirmed AROI parsing FAILED, we just want a recognisable
+# display name).
+_URL_FIELD_FALLBACK_RE = re.compile(
+    r'\burl:(?:https?://)?([^,\s]+)',
+    re.IGNORECASE,
+)
+
+
+def _incomplete_aroi_display_name(contact_info, contact_hash):
+    """Build a friendly display name for an operator whose AROI parsing
+    failed but whose ContactInfo still contains a recognisable identifier.
+
+    Cascade:
+      1. If contact contains `url:<domain>`, return
+         "<domain> (incomplete AROI)" so the row is attributable to the
+         operator's domain even when the relay forgot to declare
+         ciissversion. Domain is normalised (drops https:// prefix and
+         trailing path/query if present).
+      2. Else fall back to extract_contact_display_name() (email/name/url
+         derivation used by the contact-listing tooltip code).
+      3. Else truncated raw contact string (legacy behaviour).
+      4. Else contact_hash prefix (last-resort fallback).
+    """
+    if contact_info and contact_info.strip():
+        clean_contact = contact_info.strip()
+        url_match = _URL_FIELD_FALLBACK_RE.search(clean_contact)
+        if url_match:
+            domain = url_match.group(1)
+            # Normalise: drop scheme if present, then trailing path/query.
+            if '://' in domain:
+                domain = domain.split('://', 1)[1]
+            domain = domain.split('/', 1)[0].split('?', 1)[0]
+            if domain.startswith('www.'):
+                domain = domain[4:]
+            domain = domain.rstrip('.,;:')
+            if domain:
+                return f"{domain} (incomplete AROI)"
+
+        # Cascade 2: email/name/url-derivation helper.
+        derived = extract_contact_display_name(clean_contact, None)
+        if derived and derived != 'none' and len(derived) <= 60:
+            return derived
+
+        # Cascade 3: truncated raw contact (preserved legacy behaviour).
+        if len(clean_contact) > 30:
+            return clean_contact[:30] + '...'
+        return clean_contact
+
+    # Cascade 4: contact-hash prefix.
+    return f"contact_{contact_hash[:8]}"
 
 
 def _top_n(operators, metric, n=50, filter_fn=None):
@@ -439,20 +493,28 @@ def _collect_operator_metrics(relays_instance):
         if len(contact_info.strip()) < 3:
             continue
             
-        # Use AROI domain as key if available, otherwise use first 24 chars of contact_info
+        # Use AROI domain as key if available, otherwise build a
+        # friendlier fallback display name from the raw contact info.
         if aroi_domain and aroi_domain != 'none':
             operator_key = aroi_domain
         else:
-            # Use first 30 characters of contact info for better readability (extended from 24)
-            if contact_info and len(contact_info.strip()) > 0:
-                clean_contact = contact_info.strip()
-                if len(clean_contact) > 30:
-                    operator_key = clean_contact[:30] + '...'
-                else:
-                    operator_key = clean_contact
-            else:
-                # Fallback to contact hash only if no contact info available
-                operator_key = f"contact_{contact_hash[:8]}"
+            # Option A (incomplete-AROI fallback): when an operator has a
+            # parseable `url:<domain>` token in their contact string but
+            # is missing one of the other AROI fields (typically
+            # ciissversion), aroi_domain is None — but we can still
+            # derive a recognisable display name from the url token and
+            # tag it as "(incomplete AROI)" so the leaderboard row is
+            # still attributable to the operator's domain instead of
+            # rendering as a truncated raw blob like
+            # 'email:tor[]foo.com url:https:...'.
+            #
+            # Falls back through two earlier layers when no url: token
+            # is present:
+            #   1. extract_contact_display_name() — same email/name/url
+            #      derivation used elsewhere in the site
+            #   2. raw contact-info string truncated to 30 chars
+            #   3. contact_hash prefix as last resort
+            operator_key = _incomplete_aroi_display_name(contact_info, contact_hash)
         
         # === USE EXISTING CALCULATIONS (NO DUPLICATION) ===
         # All basic metrics are already computed in contact_data

--- a/allium/lib/categorization.py
+++ b/allium/lib/categorization.py
@@ -8,6 +8,7 @@ Extracted from relays.py for better modularity.
 
 import html as _html
 import re
+from typing import Dict, List
 
 from .string_utils import extract_contact_display_name
 
@@ -659,7 +660,7 @@ _INCOMPLETE_URL_RE = re.compile(
 )
 
 
-def _build_incomplete_aroi_sibling_map(relay_set):
+def _build_incomplete_aroi_sibling_map(relay_set) -> Dict[str, Dict[str, List[str]]]:
     """Option B: surface BOTH authenticated and self-asserted incomplete-
     AROI relays on the validated operator's detail page, in TWO
     separately-labelled buckets so visitors and the operator can tell

--- a/allium/lib/categorization.py
+++ b/allium/lib/categorization.py
@@ -653,44 +653,57 @@ def propagate_as_rarity(relay_set):
         cw = e.get('consensus_weight_fraction', 0)
         relay['as_cw_label'] = f"{cw * 100:.2f}%" if cw >= 0.0005 else ("<0.05%" if cw > 0 else "0%")
 
+_INCOMPLETE_URL_RE = re.compile(
+    r'\burl:(?:https?://)?([^,\s]+)',
+    re.IGNORECASE,
+)
+
+
 def _build_incomplete_aroi_sibling_map(relay_set):
-    """Option B (security-hardened): build a sibling map keyed by the
-    AROI-complete operator's ``aroi_domain`` -> [fingerprints of
-    incomplete-AROI relays whose attribution is CRYPTOGRAPHICALLY
-    AUTHENTICATED via Tor's mutual family-declaration mechanism].
+    """Option B: surface BOTH authenticated and self-asserted incomplete-
+    AROI relays on the validated operator's detail page, in TWO
+    separately-labelled buckets so visitors and the operator can tell
+    them apart:
 
-    Background — why we don't trust ``url:<domain>`` claims:
-        Earlier versions of this map keyed by the raw ``url:`` token
-        in the incomplete relay's ContactInfo, then attached those
-        relays to whichever validated operator's ``aroi_domain``
-        matched. That trusted the claiming relay's unauthenticated
-        ContactInfo string — any rogue operator could publish
-        ``url:victim.example`` and inject a "sibling relays missing
-        AROI fields" warning onto victim.example's operator page,
-        damaging the victim's reputation without any actual
-        relationship. (Reported as a medium-severity finding in
-        review round 7.)
+      authenticated_family:
+        Incomplete relays that this operator's validated relays
+        MUTUALLY-DECLARE in their effective_family. Tor's family
+        mechanism requires both relays to list each other in their
+        family configuration, so this is a cryptographically
+        authenticated signal — relay X cannot unilaterally inject
+        itself into relay Y's family pool.
 
-    Fix — use effective_family instead:
-        Tor relays declare family membership in two directions; only
-        relays that BOTH list each other in their family configuration
-        appear in each other's ``effective_family`` field. That makes
-        ``effective_family`` an authenticated signal — relay X cannot
-        unilaterally claim to be in relay Y's family.
+      url_claim:
+        Incomplete relays that publish ``url:<this-domain>`` in their
+        own ContactInfo but are NOT in this operator's
+        effective_family. These are SELF-ASSERTED and unauthenticated.
+        They could be:
+          (a) the operator's own additional relays that forgot BOTH
+              ciissversion AND family declaration — actionable for
+              the operator (fix the ContactInfo to merge them); OR
+          (b) third parties spoofing the operator's domain — also
+              actionable (operator can investigate / report rogue
+              operators / contact the directory authorities).
 
-        For each AROI-complete operator we collect the union of their
-        validated relays' ``effective_family`` fingerprints. Any
-        incomplete-AROI relay whose own fingerprint appears in that
-        union is then a safe attribution; the validated operator
-        chose to mutually-declare family with that relay.
+    Both cases are useful for the operator to see; the page renders
+    them under separate, clearly-labelled headings so neither is
+    confused with the operator's authenticated relays.
+
+    Reviewed and intentionally restored after a brief detour where
+    the url-claim bucket was suppressed entirely. The operator's
+    visibility into spoofing claims is a feature, not a vulnerability,
+    provided the framing makes the unauthenticated nature explicit
+    (which contact.html does — the heading says "Self-asserted" and
+    the body explicitly notes the relays could be misconfigured
+    siblings OR spoofing attempts).
 
     Returns:
-        dict aroi_domain -> list of fingerprints (incomplete-AROI
-        relays in the operator's authenticated family pool).
+        dict aroi_domain -> {
+            'authenticated_family': sorted [fingerprints],
+            'url_claim': sorted [fingerprints],
+        }
+        Only includes operators where at least one bucket is non-empty.
     """
-    # Step 1: build aroi_domain -> set of validated-relay family
-    # members, and aroi_domain -> set of validated-relay fingerprints
-    # (for the exclusion check below).
     family_pool = {}
     validated_fps_by_domain = {}
     for relay in relay_set.json.get("relays", []):
@@ -706,8 +719,8 @@ def _build_incomplete_aroi_sibling_map(relay_set):
         if ef:
             family_pool.setdefault(domain, set()).update(ef)
 
-    # Step 2: collect fingerprints of incomplete-AROI relays.
     incomplete_fps = set()
+    incomplete_url_claims = {}  # domain -> set of fps
     for relay in relay_set.json.get("relays", []):
         if relay.get("aroi_configured"):
             continue
@@ -718,18 +731,33 @@ def _build_incomplete_aroi_sibling_map(relay_set):
         if not contact.strip():
             continue
         incomplete_fps.add(fp)
+        # Parse the url: token (if any) so we can attribute the relay
+        # to the unauthenticated bucket of whatever domain it claims.
+        m = _INCOMPLETE_URL_RE.search(contact)
+        if m:
+            domain = m.group(1)
+            if "://" in domain:
+                domain = domain.split("://", 1)[1]
+            domain = domain.split("/", 1)[0].split("?", 1)[0]
+            if domain.startswith("www."):
+                domain = domain[4:]
+            domain = domain.rstrip(".,;:").lower()
+            if domain:
+                incomplete_url_claims.setdefault(domain, set()).add(fp)
 
-    # Step 3: intersect — for each operator's authenticated family pool,
-    # keep only the fingerprints that are themselves incomplete-AROI.
-    # We exclude validated-self fingerprints from the pool so an
-    # operator's own validated relays don't get mistakenly counted as
-    # "incomplete siblings".
+    # Combine: every operator with EITHER bucket non-empty appears in
+    # the result.
+    all_domains = set(family_pool) | set(incomplete_url_claims) | set(validated_fps_by_domain)
     siblings = {}
-    for domain, pool in family_pool.items():
+    for domain in all_domains:
         own_validated = validated_fps_by_domain.get(domain, set())
-        attributable = sorted(pool & incomplete_fps - own_validated)
-        if attributable:
-            siblings[domain] = attributable
+        family_only = family_pool.get(domain, set()) & incomplete_fps - own_validated
+        url_only = incomplete_url_claims.get(domain, set()) - own_validated - family_only
+        if family_only or url_only:
+            siblings[domain] = {
+                'authenticated_family': sorted(family_only),
+                'url_claim': sorted(url_only),
+            }
     return siblings
 
 
@@ -791,24 +819,29 @@ def calculate_contact_derived_data(relay_set):
         contact_data.pop("_contact_variant_set", None)
 
         # Option B: cross-reference this AROI-complete operator against
-        # the incomplete-AROI sibling map built above. Sibling relays
-        # are those that declare the same `url:<domain>` token in their
-        # contact string but failed AROI parsing (typically because
-        # they're missing ciissversion). The contact-page template
-        # surfaces this as an actionable "N sibling relays appear to
-        # share your domain but are misconfigured" hint pointing
-        # operators to the specific relays that need ContactInfo
-        # fixes.
+        # the incomplete-AROI sibling map. Two separately-labelled
+        # buckets surface to the contact page:
+        #   - authenticated_family: incomplete relays mutually declared
+        #     in this operator's validated relays' effective_family
+        #     (Tor's bidirectional family mechanism — authenticated)
+        #   - url_claim: incomplete relays that publish url:<this-domain>
+        #     in their ContactInfo but are NOT in effective_family
+        #     (self-asserted, unauthenticated — could be the operator's
+        #     own misconfigured relays OR third-party spoofers; either
+        #     way the operator wants visibility)
+        # See _build_incomplete_aroi_sibling_map for the rationale.
         aroi_domain = (contact_data.get("aroi_domain") or "").lower().strip()
         if aroi_domain and aroi_domain != "none":
-            sibling_fps = incomplete_siblings.get(aroi_domain, [])
-            if sibling_fps:
-                contact_data["incomplete_sibling_count"] = len(sibling_fps)
-                # Cap the rendered list to a reasonable count to avoid
-                # blowing out the operator page when an operator has
-                # hundreds of misconfigured siblings — the count
-                # itself is the actionable signal.
-                contact_data["incomplete_sibling_fingerprints"] = sibling_fps[:25]
+            buckets = incomplete_siblings.get(aroi_domain) or {}
+            auth_fps = buckets.get('authenticated_family', [])
+            claim_fps = buckets.get('url_claim', [])
+            if auth_fps:
+                contact_data["incomplete_family_count"] = len(auth_fps)
+                # Cap the rendered list to keep the page bounded.
+                contact_data["incomplete_family_fingerprints"] = auth_fps[:25]
+            if claim_fps:
+                contact_data["incomplete_url_claim_count"] = len(claim_fps)
+                contact_data["incomplete_url_claim_fingerprints"] = claim_fps[:25]
         
         # BANDWIDTH MEANS CALCULATION (optimized from _calculate_bandwidth_means)
         relays = contact_data.get("relays", [])

--- a/allium/lib/categorization.py
+++ b/allium/lib/categorization.py
@@ -653,6 +653,47 @@ def propagate_as_rarity(relay_set):
         cw = e.get('consensus_weight_fraction', 0)
         relay['as_cw_label'] = f"{cw * 100:.2f}%" if cw >= 0.0005 else ("<0.05%" if cw > 0 else "0%")
 
+_INCOMPLETE_URL_RE = re.compile(
+    r'\burl:(?:https?://)?([^,\s]+)',
+    re.IGNORECASE,
+)
+
+
+def _build_incomplete_aroi_sibling_map(relay_set):
+    """Option B: build a {normalised_url_domain: [fingerprints, ...]} map
+    of relays that DECLARE a url: token but failed AROI parsing
+    (typically because they're missing ciissversion or have a
+    version/proof mismatch). Used by the operator detail page to
+    surface 'N sibling relays appear to share your domain but are
+    misconfigured' hints.
+    """
+    siblings = {}
+    for relay in relay_set.json.get("relays", []):
+        # AROI-complete relays don't go in this map.
+        if relay.get("aroi_configured"):
+            continue
+        contact = relay.get("contact", "") or ""
+        if not contact:
+            continue
+        m = _INCOMPLETE_URL_RE.search(contact)
+        if not m:
+            continue
+        domain = m.group(1)
+        if "://" in domain:
+            domain = domain.split("://", 1)[1]
+        domain = domain.split("/", 1)[0].split("?", 1)[0]
+        if domain.startswith("www."):
+            domain = domain[4:]
+        domain = domain.rstrip(".,;:").lower()
+        if not domain:
+            continue
+        fp = relay.get("fingerprint")
+        if not fp:
+            continue
+        siblings.setdefault(domain, []).append(fp)
+    return siblings
+
+
 def calculate_contact_derived_data(relay_set):
     """
     Calculate derived contact data: primary countries and bandwidth means in single pass.
@@ -660,6 +701,11 @@ def calculate_contact_derived_data(relay_set):
     """
     if "contact" not in relay_set.json["sorted"]:
         return
+
+    # Option B: pre-compute the global incomplete-AROI sibling map ONCE
+    # before the per-contact loop, then attach the count to each
+    # contact_data whose aroi_domain matches.
+    incomplete_siblings = _build_incomplete_aroi_sibling_map(relay_set)
         
     for contact_hash, contact_data in relay_set.json["sorted"]["contact"].items():
         # PRIMARY COUNTRIES CALCULATION (from _calculate_primary_countries)
@@ -704,6 +750,26 @@ def calculate_contact_derived_data(relay_set):
         # contact_data["contact_variant_count"]; the set itself is no
         # longer needed.
         contact_data.pop("_contact_variant_set", None)
+
+        # Option B: cross-reference this AROI-complete operator against
+        # the incomplete-AROI sibling map built above. Sibling relays
+        # are those that declare the same `url:<domain>` token in their
+        # contact string but failed AROI parsing (typically because
+        # they're missing ciissversion). The contact-page template
+        # surfaces this as an actionable "N sibling relays appear to
+        # share your domain but are misconfigured" hint pointing
+        # operators to the specific relays that need ContactInfo
+        # fixes.
+        aroi_domain = (contact_data.get("aroi_domain") or "").lower().strip()
+        if aroi_domain and aroi_domain != "none":
+            sibling_fps = incomplete_siblings.get(aroi_domain, [])
+            if sibling_fps:
+                contact_data["incomplete_sibling_count"] = len(sibling_fps)
+                # Cap the rendered list to a reasonable count to avoid
+                # blowing out the operator page when an operator has
+                # hundreds of misconfigured siblings — the count
+                # itself is the actionable signal.
+                contact_data["incomplete_sibling_fingerprints"] = sibling_fps[:25]
         
         # BANDWIDTH MEANS CALCULATION (optimized from _calculate_bandwidth_means)
         relays = contact_data.get("relays", [])

--- a/allium/lib/categorization.py
+++ b/allium/lib/categorization.py
@@ -653,44 +653,83 @@ def propagate_as_rarity(relay_set):
         cw = e.get('consensus_weight_fraction', 0)
         relay['as_cw_label'] = f"{cw * 100:.2f}%" if cw >= 0.0005 else ("<0.05%" if cw > 0 else "0%")
 
-_INCOMPLETE_URL_RE = re.compile(
-    r'\burl:(?:https?://)?([^,\s]+)',
-    re.IGNORECASE,
-)
-
-
 def _build_incomplete_aroi_sibling_map(relay_set):
-    """Option B: build a {normalised_url_domain: [fingerprints, ...]} map
-    of relays that DECLARE a url: token but failed AROI parsing
-    (typically because they're missing ciissversion or have a
-    version/proof mismatch). Used by the operator detail page to
-    surface 'N sibling relays appear to share your domain but are
-    misconfigured' hints.
+    """Option B (security-hardened): build a sibling map keyed by the
+    AROI-complete operator's ``aroi_domain`` -> [fingerprints of
+    incomplete-AROI relays whose attribution is CRYPTOGRAPHICALLY
+    AUTHENTICATED via Tor's mutual family-declaration mechanism].
+
+    Background — why we don't trust ``url:<domain>`` claims:
+        Earlier versions of this map keyed by the raw ``url:`` token
+        in the incomplete relay's ContactInfo, then attached those
+        relays to whichever validated operator's ``aroi_domain``
+        matched. That trusted the claiming relay's unauthenticated
+        ContactInfo string — any rogue operator could publish
+        ``url:victim.example`` and inject a "sibling relays missing
+        AROI fields" warning onto victim.example's operator page,
+        damaging the victim's reputation without any actual
+        relationship. (Reported as a medium-severity finding in
+        review round 7.)
+
+    Fix — use effective_family instead:
+        Tor relays declare family membership in two directions; only
+        relays that BOTH list each other in their family configuration
+        appear in each other's ``effective_family`` field. That makes
+        ``effective_family`` an authenticated signal — relay X cannot
+        unilaterally claim to be in relay Y's family.
+
+        For each AROI-complete operator we collect the union of their
+        validated relays' ``effective_family`` fingerprints. Any
+        incomplete-AROI relay whose own fingerprint appears in that
+        union is then a safe attribution; the validated operator
+        chose to mutually-declare family with that relay.
+
+    Returns:
+        dict aroi_domain -> list of fingerprints (incomplete-AROI
+        relays in the operator's authenticated family pool).
     """
-    siblings = {}
+    # Step 1: build aroi_domain -> set of validated-relay family
+    # members, and aroi_domain -> set of validated-relay fingerprints
+    # (for the exclusion check below).
+    family_pool = {}
+    validated_fps_by_domain = {}
     for relay in relay_set.json.get("relays", []):
-        # AROI-complete relays don't go in this map.
+        if not relay.get("aroi_configured"):
+            continue
+        domain = (relay.get("aroi_domain") or "").lower().strip()
+        if not domain or domain == "none":
+            continue
+        fp = relay.get("fingerprint")
+        if fp:
+            validated_fps_by_domain.setdefault(domain, set()).add(fp)
+        ef = relay.get("effective_family") or []
+        if ef:
+            family_pool.setdefault(domain, set()).update(ef)
+
+    # Step 2: collect fingerprints of incomplete-AROI relays.
+    incomplete_fps = set()
+    for relay in relay_set.json.get("relays", []):
         if relay.get("aroi_configured"):
-            continue
-        contact = relay.get("contact", "") or ""
-        if not contact:
-            continue
-        m = _INCOMPLETE_URL_RE.search(contact)
-        if not m:
-            continue
-        domain = m.group(1)
-        if "://" in domain:
-            domain = domain.split("://", 1)[1]
-        domain = domain.split("/", 1)[0].split("?", 1)[0]
-        if domain.startswith("www."):
-            domain = domain[4:]
-        domain = domain.rstrip(".,;:").lower()
-        if not domain:
             continue
         fp = relay.get("fingerprint")
         if not fp:
             continue
-        siblings.setdefault(domain, []).append(fp)
+        contact = relay.get("contact", "") or ""
+        if not contact.strip():
+            continue
+        incomplete_fps.add(fp)
+
+    # Step 3: intersect — for each operator's authenticated family pool,
+    # keep only the fingerprints that are themselves incomplete-AROI.
+    # We exclude validated-self fingerprints from the pool so an
+    # operator's own validated relays don't get mistakenly counted as
+    # "incomplete siblings".
+    siblings = {}
+    for domain, pool in family_pool.items():
+        own_validated = validated_fps_by_domain.get(domain, set())
+        attributable = sorted(pool & incomplete_fps - own_validated)
+        if attributable:
+            siblings[domain] = attributable
     return siblings
 
 

--- a/allium/lib/operator_analysis.py
+++ b/allium/lib/operator_analysis.py
@@ -668,14 +668,22 @@ def compute_contact_display_data(i, bandwidth_unit, operator_reliability, v, mem
     display_data['contact_variants'] = contact_variants
     display_data['contact_variant_count'] = len(contact_variants)
 
-    # Option B: surface the incomplete-AROI sibling count on the
-    # operator detail page. Categorisation (categorization.py) attaches
-    # this to the contact's sorted-data dict (i) when at least one
-    # relay published `url:<this-aroi-domain>` but failed AROI
-    # parsing. Forward the count + capped fingerprint list verbatim.
-    display_data['incomplete_sibling_count'] = i.get('incomplete_sibling_count', 0)
-    display_data['incomplete_sibling_fingerprints'] = i.get(
-        'incomplete_sibling_fingerprints', []
+    # Option B: surface the incomplete-AROI sibling counts on the
+    # operator detail page. Categorisation (categorization.py)
+    # populates two separately-labelled buckets:
+    #   - authenticated_family (mutual effective_family declaration)
+    #   - url_claim (self-asserted url:<this-domain>; could be
+    #     operator's own misconfigured relays OR third-party spoofers)
+    # Forward both verbatim so contact.html can render them under
+    # distinct headings — never confuse self-asserted claims with
+    # the operator's authenticated relays.
+    display_data['incomplete_family_count'] = i.get('incomplete_family_count', 0)
+    display_data['incomplete_family_fingerprints'] = i.get(
+        'incomplete_family_fingerprints', []
+    )
+    display_data['incomplete_url_claim_count'] = i.get('incomplete_url_claim_count', 0)
+    display_data['incomplete_url_claim_fingerprints'] = i.get(
+        'incomplete_url_claim_fingerprints', []
     )
 
     # 1. Bandwidth breakdown by role

--- a/allium/lib/operator_analysis.py
+++ b/allium/lib/operator_analysis.py
@@ -668,6 +668,16 @@ def compute_contact_display_data(i, bandwidth_unit, operator_reliability, v, mem
     display_data['contact_variants'] = contact_variants
     display_data['contact_variant_count'] = len(contact_variants)
 
+    # Option B: surface the incomplete-AROI sibling count on the
+    # operator detail page. Categorisation (categorization.py) attaches
+    # this to the contact's sorted-data dict (i) when at least one
+    # relay published `url:<this-aroi-domain>` but failed AROI
+    # parsing. Forward the count + capped fingerprint list verbatim.
+    display_data['incomplete_sibling_count'] = i.get('incomplete_sibling_count', 0)
+    display_data['incomplete_sibling_fingerprints'] = i.get(
+        'incomplete_sibling_fingerprints', []
+    )
+
     # 1. Bandwidth breakdown by role
     display_data['bandwidth_breakdown'] = _format_bandwidth_breakdown(i, bandwidth_unit, relay_set)
 

--- a/allium/templates/contact.html
+++ b/allium/templates/contact.html
@@ -101,31 +101,34 @@
                         </ul>
                     </li>
                     {%- endif %}
-                    {# Option B (incomplete-AROI sibling hint): when an
-                       operator's AROI domain (e.g. 1aeo.com) is properly
-                       resolved here BUT some of their relays out there
-                       publish a `url:<this-domain>` token without
-                       declaring `ciissversion:` (or with a mismatched
-                       version/proof pair), categorisation flagged them
-                       as 'incomplete sibling relays'. They appear on
-                       leaderboards as a separate, fragmented entry
-                       (now shown as '<domain> (incomplete AROI)' per
-                       Option A). Surface the count here so this
-                       operator is told what to fix in the misconfigured
-                       relays' ContactInfo. #}
+                    {# Option B (incomplete-AROI sibling hint, security-
+                       hardened): only attributes incomplete relays that
+                       this operator's validated relays mutually-declared
+                       in their effective_family. Tor's family mechanism
+                       requires both relays to list each other, so a
+                       rogue relay cannot inject a "sibling missing
+                       AROI" warning onto this operator's page just by
+                       publishing url:<this-domain> in its own
+                       ContactInfo. Reviewer-flagged as a medium-severity
+                       reputation-tampering vector when keyed by the
+                       unauthenticated url: claim alone. #}
                     {%- set _sibling_count = (contact_display_data.get('incomplete_sibling_count', 0) if contact_display_data else 0) -%}
                     {%- if _sibling_count > 0 %}
-                    <li><strong>⚠ Sibling relays missing AROI fields:</strong>
+                    <li><strong>⚠ Family relays missing AROI fields:</strong>
                         <span style="color: #856404;">{{ _sibling_count }}</span>
-                        relay{{ 's' if _sibling_count != 1 else '' }} declare
-                        <code style="font-size: 11px; padding: 1px 4px; background-color: #fff3cd; border: 1px solid #ffeeba; border-radius: 2px;">url:{{ relay_subset[0]['aroi_domain']|escape if relay_subset and relay_subset[0].get('aroi_domain') else 'this domain' }}</code>
-                        in their ContactInfo but are missing
+                        relay{{ 's' if _sibling_count != 1 else '' }} that
+                        <em>this operator's validated relays mutually declare
+                        in their <code>effective_family</code></em>
+                        appear to be missing
                         <code style="font-size: 11px; padding: 1px 4px; background-color: #fff3cd; border: 1px solid #ffeeba; border-radius: 2px;">ciissversion:</code>
-                        (or have a version/proof mismatch). They show up on the
-                        leaderboard as a fragmented "{{ relay_subset[0]['aroi_domain']|escape if relay_subset and relay_subset[0].get('aroi_domain') else '' }} (incomplete AROI)" entry instead of being
-                        grouped under this operator. Add the missing
+                        in their ContactInfo (or have a version/proof mismatch).
+                        They show up on the leaderboard as a fragmented
+                        "{{ relay_subset[0]['aroi_domain']|escape if relay_subset and relay_subset[0].get('aroi_domain') else '' }} (incomplete AROI)" entry
+                        instead of being grouped under this operator.
+                        Add the missing
                         <code style="font-size: 11px; padding: 1px 4px; background-color: #d4edda; border: 1px solid #c3e6cb; border-radius: 2px;">ciissversion:3</code>
-                        (or :2 for legacy RSA proofs) to those relays' ContactInfo to merge them.
+                        (or <code>:2</code> for legacy RSA proofs) to those
+                        relays' ContactInfo to merge them.
                     </li>
                     {%- endif %}
                     <li><strong>Hash:</strong> {{ contact_hash }}</li>

--- a/allium/templates/contact.html
+++ b/allium/templates/contact.html
@@ -101,34 +101,63 @@
                         </ul>
                     </li>
                     {%- endif %}
-                    {# Option B (incomplete-AROI sibling hint, security-
-                       hardened): only attributes incomplete relays that
-                       this operator's validated relays mutually-declared
-                       in their effective_family. Tor's family mechanism
-                       requires both relays to list each other, so a
-                       rogue relay cannot inject a "sibling missing
-                       AROI" warning onto this operator's page just by
-                       publishing url:<this-domain> in its own
-                       ContactInfo. Reviewer-flagged as a medium-severity
-                       reputation-tampering vector when keyed by the
-                       unauthenticated url: claim alone. #}
-                    {%- set _sibling_count = (contact_display_data.get('incomplete_sibling_count', 0) if contact_display_data else 0) -%}
-                    {%- if _sibling_count > 0 %}
+                    {# Option B: two distinctly-labelled buckets of
+                       incomplete-AROI relays attributable to this
+                       operator. Categorisation populates both:
+                         - authenticated_family: relays in this
+                           operator's validated relays' effective_family
+                           (mutual Tor family declaration — authenticated)
+                         - url_claim: relays that self-assert
+                           url:<this-domain> in their ContactInfo but
+                           are NOT in effective_family (UNAUTHENTICATED;
+                           could be operator's own misconfigured relays
+                           OR third-party spoofers — operator wants
+                           visibility either way).
+                       The wording for the second bucket explicitly
+                       names the unauthenticated nature so visitors
+                       and operators don't conflate it with the
+                       authenticated relays. #}
+                    {%- set _fam_count = (contact_display_data.get('incomplete_family_count', 0) if contact_display_data else 0) -%}
+                    {%- set _claim_count = (contact_display_data.get('incomplete_url_claim_count', 0) if contact_display_data else 0) -%}
+                    {%- set _aroi_disp = relay_subset[0]['aroi_domain']|escape if relay_subset and relay_subset[0].get('aroi_domain') else '' -%}
+                    {%- if _fam_count > 0 %}
                     <li><strong>⚠ Family relays missing AROI fields:</strong>
-                        <span style="color: #856404;">{{ _sibling_count }}</span>
-                        relay{{ 's' if _sibling_count != 1 else '' }} that
+                        <span style="color: #856404;">{{ _fam_count }}</span>
+                        relay{{ 's' if _fam_count != 1 else '' }} that
                         <em>this operator's validated relays mutually declare
                         in their <code>effective_family</code></em>
                         appear to be missing
                         <code style="font-size: 11px; padding: 1px 4px; background-color: #fff3cd; border: 1px solid #ffeeba; border-radius: 2px;">ciissversion:</code>
                         in their ContactInfo (or have a version/proof mismatch).
                         They show up on the leaderboard as a fragmented
-                        "{{ relay_subset[0]['aroi_domain']|escape if relay_subset and relay_subset[0].get('aroi_domain') else '' }} (incomplete AROI)" entry
+                        "{{ _aroi_disp }} (incomplete AROI)" entry
                         instead of being grouped under this operator.
                         Add the missing
                         <code style="font-size: 11px; padding: 1px 4px; background-color: #d4edda; border: 1px solid #c3e6cb; border-radius: 2px;">ciissversion:3</code>
                         (or <code>:2</code> for legacy RSA proofs) to those
                         relays' ContactInfo to merge them.
+                    </li>
+                    {%- endif %}
+                    {%- if _claim_count > 0 %}
+                    <li><strong>⚠ Self-asserted <code>url:</code> claims (unverified):</strong>
+                        <span style="color: #856404;">{{ _claim_count }}</span>
+                        relay{{ 's' if _claim_count != 1 else '' }} publish
+                        <code style="font-size: 11px; padding: 1px 4px; background-color: #fff3cd; border: 1px solid #ffeeba; border-radius: 2px;">url:{{ _aroi_disp }}</code>
+                        in their ContactInfo but are
+                        <strong>NOT</strong> in any of this operator's
+                        validated relays' <code>effective_family</code>.
+                        Allium does not authenticate these claims — they
+                        are surfaced here so the operator has visibility.
+                        They could be the operator's own additional relays
+                        that forgot BOTH <code>family</code> and
+                        <code>ciissversion</code> declarations
+                        (fix both in their ContactInfo + torrc to merge them
+                        under this operator), OR third-party operators
+                        spoofing this domain (in which case the operator
+                        should investigate / report). These relays do
+                        <strong>not</strong> contribute to this operator's
+                        validated metrics, bandwidth totals, or relay counts
+                        anywhere on the site.
                     </li>
                     {%- endif %}
                     <li><strong>Hash:</strong> {{ contact_hash }}</li>

--- a/allium/templates/contact.html
+++ b/allium/templates/contact.html
@@ -108,7 +108,7 @@
                            operator's validated relays' effective_family
                            (mutual Tor family declaration — authenticated)
                          - url_claim: relays that self-assert
-                           url:<this-domain> in their ContactInfo but
+                           url:&lt;this-domain&gt; in their ContactInfo but
                            are NOT in effective_family (UNAUTHENTICATED;
                            could be operator's own misconfigured relays
                            OR third-party spoofers — operator wants

--- a/allium/templates/contact.html
+++ b/allium/templates/contact.html
@@ -101,6 +101,33 @@
                         </ul>
                     </li>
                     {%- endif %}
+                    {# Option B (incomplete-AROI sibling hint): when an
+                       operator's AROI domain (e.g. 1aeo.com) is properly
+                       resolved here BUT some of their relays out there
+                       publish a `url:<this-domain>` token without
+                       declaring `ciissversion:` (or with a mismatched
+                       version/proof pair), categorisation flagged them
+                       as 'incomplete sibling relays'. They appear on
+                       leaderboards as a separate, fragmented entry
+                       (now shown as '<domain> (incomplete AROI)' per
+                       Option A). Surface the count here so this
+                       operator is told what to fix in the misconfigured
+                       relays' ContactInfo. #}
+                    {%- set _sibling_count = (contact_display_data.get('incomplete_sibling_count', 0) if contact_display_data else 0) -%}
+                    {%- if _sibling_count > 0 %}
+                    <li><strong>⚠ Sibling relays missing AROI fields:</strong>
+                        <span style="color: #856404;">{{ _sibling_count }}</span>
+                        relay{{ 's' if _sibling_count != 1 else '' }} declare
+                        <code style="font-size: 11px; padding: 1px 4px; background-color: #fff3cd; border: 1px solid #ffeeba; border-radius: 2px;">url:{{ relay_subset[0]['aroi_domain']|escape if relay_subset and relay_subset[0].get('aroi_domain') else 'this domain' }}</code>
+                        in their ContactInfo but are missing
+                        <code style="font-size: 11px; padding: 1px 4px; background-color: #fff3cd; border: 1px solid #ffeeba; border-radius: 2px;">ciissversion:</code>
+                        (or have a version/proof mismatch). They show up on the
+                        leaderboard as a fragmented "{{ relay_subset[0]['aroi_domain']|escape if relay_subset and relay_subset[0].get('aroi_domain') else '' }} (incomplete AROI)" entry instead of being
+                        grouped under this operator. Add the missing
+                        <code style="font-size: 11px; padding: 1px 4px; background-color: #d4edda; border: 1px solid #c3e6cb; border-radius: 2px;">ciissversion:3</code>
+                        (or :2 for legacy RSA proofs) to those relays' ContactInfo to merge them.
+                    </li>
+                    {%- endif %}
                     <li><strong>Hash:</strong> {{ contact_hash }}</li>
                     {% if primary_country_data %}
                     <li><strong>Countries:</strong> 

--- a/tests/unit/test_api_diagnostics.py
+++ b/tests/unit/test_api_diagnostics.py
@@ -1442,68 +1442,84 @@ class TestIncompleteAROIDisplayName:
 
 
 class TestIncompleteAROISiblingMap:
-    """Option B (security-hardened): the sibling map keys by AROI-
-    complete operator's aroi_domain and only attributes incomplete
-    relays that appear in the validated relays' effective_family.
-    Trusting an unauthenticated url: token would let any rogue relay
-    publish 'url:victim.example' and inject a 'sibling relays missing
-    AROI fields' warning onto victim.example's operator page —
-    that's a reputation-tampering / spoofing vector. Tor's mutual
-    family-declaration mechanism gives us an authenticated signal
-    instead (a relay can't unilaterally claim to be in another
-    relay's family)."""
+    """Option B: two clearly-labelled buckets of incomplete-AROI relays
+    on the validated operator's detail page:
+      - authenticated_family: relays in mutual effective_family
+      - url_claim: relays self-asserting url:<this-domain> but NOT
+        in effective_family (operator gets visibility into spoofing
+        attempts and missing-family own-relays alike).
+    The contact-page template renders these under DISTINCT headings
+    with the second one explicitly labelled 'Self-asserted ... claims
+    (unverified)' so visitors don't conflate them with authenticated
+    relays. Importantly: neither bucket affects the operator's
+    validated metrics, bandwidth totals, relay counts, etc."""
 
-    def test_authenticated_sibling_attributed(self):
-        """Incomplete relay listed in validated relay's effective_family
-        is safely attributed to the validated operator's aroi_domain."""
+    def test_authenticated_family_bucket(self):
+        """Incomplete relay in validated relay's effective_family
+        lands in the authenticated_family bucket."""
         from allium.lib.categorization import _build_incomplete_aroi_sibling_map
         rs = MagicMock()
         rs.json = {
             'relays': [
-                # Validated 1aeo relay; mutually-declares family with B.
                 {'fingerprint': 'A' * 40, 'aroi_configured': True,
                  'aroi_domain': '1aeo.com',
                  'effective_family': ['B' * 40]},
-                # Incomplete v3-proof relay; missing ciissversion.
-                # Authenticated via mutual effective_family declaration.
                 {'fingerprint': 'B' * 40, 'aroi_configured': False,
                  'effective_family': ['A' * 40],
-                 'contact': 'email:tor[]1aeo.com url:1aeo.com '
-                            'proof:uri-familyid-ed25519'},
+                 'contact': 'url:1aeo.com proof:uri-familyid-ed25519'},
             ]
         }
         siblings = _build_incomplete_aroi_sibling_map(rs)
-        assert siblings.get('1aeo.com') == ['B' * 40]
+        bucket = siblings.get('1aeo.com', {})
+        assert bucket.get('authenticated_family') == ['B' * 40]
+        # B was attributed via family, NOT also as a url_claim
+        # (we partition: family wins).
+        assert bucket.get('url_claim') == []
 
-    def test_unauthenticated_url_claim_NOT_attributed(self):
-        """A rogue relay claiming url:victim.example WITHOUT mutual
-        family declaration must NOT inject itself onto victim.example's
-        operator page. This is the reputation-tampering / spoofing
-        vector the security review flagged."""
+    def test_url_claim_bucket_keeps_unauthenticated_claims(self):
+        """A relay claiming url:victim.example WITHOUT mutual family
+        declaration lands in the url_claim bucket, NOT the
+        authenticated_family bucket. The operator gets visibility
+        into the unverified claim (could be misconfig OR spoofing)
+        without being told this relay is authenticated."""
         from allium.lib.categorization import _build_incomplete_aroi_sibling_map
         rs = MagicMock()
         rs.json = {
             'relays': [
-                # Validated victim.example relay — declares NO family.
                 {'fingerprint': 'V' * 40, 'aroi_configured': True,
                  'aroi_domain': 'victim.example', 'effective_family': []},
-                # Rogue relay claiming url:victim.example, NOT in
-                # victim's effective_family. Has v3-proof + missing
-                # ciissversion (the same pattern as legitimate
-                # misconfigured siblings).
                 {'fingerprint': 'R' * 40, 'aroi_configured': False,
                  'effective_family': [],
                  'contact': 'url:victim.example proof:uri-familyid-ed25519'},
             ]
         }
         siblings = _build_incomplete_aroi_sibling_map(rs)
-        # Rogue MUST NOT be attributed to victim.example.
-        assert siblings.get('victim.example', []) == []
+        bucket = siblings.get('victim.example', {})
+        # The unverified claim is preserved (operator wants visibility)
+        assert bucket.get('url_claim') == ['R' * 40]
+        # But NOT promoted to the authenticated bucket.
+        assert bucket.get('authenticated_family') == []
 
-    def test_validated_self_excluded_from_sibling_pool(self):
-        """An operator's own validated relays must NOT count as
-        'incomplete siblings' even when they appear in their own
-        effective_family."""
+    def test_buckets_are_partitioned_no_double_counting(self):
+        """A relay that's BOTH in the validated operator's family AND
+        publishes url:<domain> goes ONLY to authenticated_family."""
+        from allium.lib.categorization import _build_incomplete_aroi_sibling_map
+        rs = MagicMock()
+        rs.json = {
+            'relays': [
+                {'fingerprint': 'A' * 40, 'aroi_configured': True,
+                 'aroi_domain': '1aeo.com',
+                 'effective_family': ['B' * 40]},
+                {'fingerprint': 'B' * 40, 'aroi_configured': False,
+                 'effective_family': ['A' * 40],
+                 'contact': 'url:1aeo.com proof:uri-familyid-ed25519'},
+            ]
+        }
+        bucket = _build_incomplete_aroi_sibling_map(rs)['1aeo.com']
+        assert bucket['authenticated_family'] == ['B' * 40]
+        assert bucket['url_claim'] == []  # NOT double-counted
+
+    def test_validated_self_excluded(self):
         from allium.lib.categorization import _build_incomplete_aroi_sibling_map
         rs = MagicMock()
         rs.json = {
@@ -1517,55 +1533,48 @@ class TestIncompleteAROISiblingMap:
             ]
         }
         siblings = _build_incomplete_aroi_sibling_map(rs)
-        assert siblings.get('1aeo.com', []) == []
+        # Both validated -> no incomplete siblings to attribute.
+        assert siblings == {} or all(
+            not v.get('authenticated_family') and not v.get('url_claim')
+            for v in siblings.values()
+        )
 
-    def test_calculate_contact_derived_data_propagates_sibling_count(self):
-        """End-to-end: contact_data['incomplete_sibling_count'] is set
-        for an AROI-validated operator when an authenticated family
-        member is misconfigured."""
+    def test_calculate_contact_derived_data_populates_both_counts(self):
+        """End-to-end: contact_data carries SEPARATE counts for each
+        bucket, ready for contact.html to render distinct hints."""
         from allium.lib.categorization import (
             sort_relay, calculate_contact_derived_data,
         )
         rs = MagicMock()
-        # Note: only the validated relay is sort_relay'd into the
-        # contact group; the incomplete sibling exists in the relays
-        # list but is unattributed by AROI.
+        base = {
+            'flags': [], 'observed_bandwidth': 100, 'consensus_weight': 1,
+            'consensus_weight_fraction': 0.0,
+            'guard_consensus_weight_fraction': 0.0,
+            'middle_consensus_weight_fraction': 0.0,
+            'exit_consensus_weight_fraction': 0.0,
+            'first_seen': '2025-01-01 00:00:00',
+            'country': 'US', 'platform': 'Linux',
+            'as': '111', 'as_name': '',
+        }
         rs.json = {
             'relays': [
-                {
-                    'fingerprint': 'A' * 40, 'flags': [],
-                    'observed_bandwidth': 100, 'consensus_weight': 1,
-                    'consensus_weight_fraction': 0.0,
-                    'guard_consensus_weight_fraction': 0.0,
-                    'middle_consensus_weight_fraction': 0.0,
-                    'exit_consensus_weight_fraction': 0.0,
-                    'first_seen': '2025-01-01 00:00:00',
-                    'country': 'US', 'platform': 'Linux',
-                    'as': '111', 'as_name': '',
-                    # Mutual family declaration with B.
-                    'effective_family': ['B' * 40],
-                    'aroi_domain': '1aeo.com', 'aroi_configured': True,
-                    'contact': ('ciissversion:3 url:1aeo.com '
-                                'proof:uri-familyid-ed25519'),
-                    'contact_md5': '1aeohash',
-                },
-                {
-                    'fingerprint': 'B' * 40, 'flags': [],
-                    'observed_bandwidth': 50, 'consensus_weight': 1,
-                    'consensus_weight_fraction': 0.0,
-                    'guard_consensus_weight_fraction': 0.0,
-                    'middle_consensus_weight_fraction': 0.0,
-                    'exit_consensus_weight_fraction': 0.0,
-                    'first_seen': '2025-01-01 00:00:00',
-                    'country': 'US', 'platform': 'Linux',
-                    'as': '111', 'as_name': '',
-                    # Mutual family declaration -> authenticated link.
-                    'effective_family': ['A' * 40],
-                    'aroi_domain': 'none', 'aroi_configured': False,
-                    'contact': 'email:tor[]1aeo.com url:1aeo.com '
-                               'proof:uri-familyid-ed25519',
-                    'contact_md5': 'sibling_hash',
-                },
+                {**base, 'fingerprint': 'A' * 40,
+                 'effective_family': ['B' * 40],
+                 'aroi_domain': '1aeo.com', 'aroi_configured': True,
+                 'contact': 'ciissversion:3 url:1aeo.com proof:uri-familyid-ed25519',
+                 'contact_md5': '1aeohash'},
+                # Authenticated family member (in validated A's family).
+                {**base, 'fingerprint': 'B' * 40,
+                 'effective_family': ['A' * 40],
+                 'aroi_domain': 'none', 'aroi_configured': False,
+                 'contact': 'url:1aeo.com proof:uri-familyid-ed25519',
+                 'contact_md5': 'famhash'},
+                # Unauthenticated url-claim relay (NOT in family).
+                {**base, 'fingerprint': 'R' * 40,
+                 'effective_family': [],
+                 'aroi_domain': 'none', 'aroi_configured': False,
+                 'contact': 'url:1aeo.com proof:uri-familyid-ed25519',
+                 'contact_md5': 'rogue_hash'},
             ],
             'sorted': {'contact': {}},
         }
@@ -1574,5 +1583,7 @@ class TestIncompleteAROISiblingMap:
         calculate_contact_derived_data(rs)
 
         cd = rs.json['sorted']['contact']['1aeohash']
-        assert cd.get('incomplete_sibling_count') == 1
-        assert 'B' * 40 in cd.get('incomplete_sibling_fingerprints', [])
+        assert cd.get('incomplete_family_count') == 1
+        assert 'B' * 40 in cd.get('incomplete_family_fingerprints', [])
+        assert cd.get('incomplete_url_claim_count') == 1
+        assert 'R' * 40 in cd.get('incomplete_url_claim_fingerprints', [])

--- a/tests/unit/test_api_diagnostics.py
+++ b/tests/unit/test_api_diagnostics.py
@@ -1647,4 +1647,10 @@ class TestIncompleteAROISiblingMap:
         # Full count surfaces (all 30 incomplete family members).
         assert cd.get('incomplete_family_count') == 30
         # Rendered list is capped at exactly 25.
-        assert len(cd.get('incomplete_family_fingerprints', [])) == 25
+        capped_fps = cd.get('incomplete_family_fingerprints', [])
+        assert len(capped_fps) == 25
+        # Every capped entry must be a real sibling fp — i.e. the cap
+        # selects a subset of the expected fingerprints rather than
+        # inventing or corrupting any.
+        expected_sibling_fingerprints = set(sibling_fps)
+        assert set(capped_fps).issubset(expected_sibling_fingerprints)

--- a/tests/unit/test_api_diagnostics.py
+++ b/tests/unit/test_api_diagnostics.py
@@ -1395,7 +1395,7 @@ class TestIncompleteAROIDisplayName:
     but failed AROI parsing now render as '<domain> (incomplete AROI)'
     instead of a truncated raw blob."""
 
-    def _name(self, contact, contact_hash='aaaaaaaa'):
+    def _name(self, contact, contact_hash='aaaaaaaa') -> str:
         from allium.lib.aroileaders import _incomplete_aroi_display_name
         return _incomplete_aroi_display_name(contact, contact_hash)
 
@@ -1427,8 +1427,8 @@ class TestIncompleteAROIDisplayName:
     def test_truncates_when_no_url_no_email_no_name(self):
         long_contact = 'random_unparseable_blob_of_text_far_too_long_for_a_display_name'
         result = self._name(long_contact)
-        # Truncated to 30 chars + '...' as legacy fallback (cascade 3).
-        assert len(result) <= 35
+        # Truncated to 30 chars + '...' = 33 total (cascade 3).
+        assert len(result) == 33
         assert result.endswith('...')
 
     def test_url_with_path_drops_path(self):
@@ -1587,3 +1587,64 @@ class TestIncompleteAROISiblingMap:
         assert 'B' * 40 in cd.get('incomplete_family_fingerprints', [])
         assert cd.get('incomplete_url_claim_count') == 1
         assert 'R' * 40 in cd.get('incomplete_url_claim_fingerprints', [])
+
+    def test_sibling_fingerprints_capped_at_25(self):
+        """The 25-fingerprint cap on the rendered list keeps operator
+        pages bounded even when many incomplete relays are attributable
+        to one operator. The total *count* still reflects all matches.
+
+        Note: an earlier review-round prompt referenced the obsolete
+        field names ``incomplete_sibling_count`` /
+        ``incomplete_sibling_fingerprints``. Those were renamed in the
+        Option B v2 commit which split the data into two distinct
+        buckets; this test uses the current names. The same ``[:25]``
+        cap is applied to ``incomplete_url_claim_fingerprints`` in the
+        production code, so testing the family bucket exercises the
+        cap logic for both."""
+        from allium.lib.categorization import (
+            sort_relay, calculate_contact_derived_data,
+        )
+        rs = MagicMock()
+        base = {
+            'flags': [], 'observed_bandwidth': 100, 'consensus_weight': 1,
+            'consensus_weight_fraction': 0.0,
+            'guard_consensus_weight_fraction': 0.0,
+            'middle_consensus_weight_fraction': 0.0,
+            'exit_consensus_weight_fraction': 0.0,
+            'first_seen': '2025-01-01 00:00:00',
+            'country': 'US', 'platform': 'Linux',
+            'as': '111', 'as_name': '',
+        }
+        # 30 incomplete sibling fingerprints (>25, exercises the cap).
+        sibling_fps = [f"{i:040X}" for i in range(30)]
+        validated = {
+            **base, 'fingerprint': 'A' * 40,
+            'effective_family': sibling_fps,
+            'aroi_domain': '1aeo.com', 'aroi_configured': True,
+            'contact': 'ciissversion:3 url:1aeo.com proof:uri-familyid-ed25519',
+            'contact_md5': '1aeohash',
+        }
+        # Each sibling mutually declares the validated relay (authenticated).
+        incomplete_relays = [
+            {
+                **base, 'fingerprint': fp,
+                'effective_family': ['A' * 40],
+                'aroi_domain': 'none', 'aroi_configured': False,
+                'contact': 'url:1aeo.com proof:uri-familyid-ed25519',
+                'contact_md5': f'sib_{i}',
+            }
+            for i, fp in enumerate(sibling_fps)
+        ]
+        rs.json = {
+            'relays': [validated] + incomplete_relays,
+            'sorted': {'contact': {}},
+        }
+        sort_relay(rs, validated, 0, 'contact', '1aeohash', 1, 0.0)
+        rs.json['sorted']['contact']['1aeohash']['bandwidth'] = 100
+        calculate_contact_derived_data(rs)
+
+        cd = rs.json['sorted']['contact']['1aeohash']
+        # Full count surfaces (all 30 incomplete family members).
+        assert cd.get('incomplete_family_count') == 30
+        # Rendered list is capped at exactly 25.
+        assert len(cd.get('incomplete_family_fingerprints', [])) == 25

--- a/tests/unit/test_api_diagnostics.py
+++ b/tests/unit/test_api_diagnostics.py
@@ -1383,3 +1383,150 @@ class TestDashboardTileValidityAccuracy:
         assert 'ciissversion_validated' in m
         assert isinstance(m['ciissversion_declared'], dict)
         assert isinstance(m['ciissversion_validated'], dict)
+
+
+# ============================================================================
+# Option A: friendlier display name for incomplete-AROI fallback rows
+# ============================================================================
+
+
+class TestIncompleteAROIDisplayName:
+    """Option A: leaderboard rows for relays with a parseable url: token
+    but failed AROI parsing now render as '<domain> (incomplete AROI)'
+    instead of a truncated raw blob."""
+
+    def _name(self, contact, contact_hash='aaaaaaaa'):
+        from allium.lib.aroileaders import _incomplete_aroi_display_name
+        return _incomplete_aroi_display_name(contact, contact_hash)
+
+    def test_url_token_extracted_and_tagged(self):
+        # The actual real-world case: 60 1aeo relays missing
+        # ciissversion. Display must surface their AROI domain.
+        result = self._name(
+            'email:tor[]1aeo.com url:https://www.1aeo.com '
+            'proof:uri-familyid-ed25519 abuse:abuse[]1aeo.com',
+        )
+        assert result == '1aeo.com (incomplete AROI)'
+
+    def test_bare_url_token_normalised(self):
+        result = self._name('contact:foo url:bar.example')
+        assert result == 'bar.example (incomplete AROI)'
+
+    def test_falls_back_to_email_or_name_when_no_url(self):
+        result = self._name(
+            'Brandon Kuschel <tor AT NOSPAM brandonkuschel dot com>'
+        )
+        assert '(incomplete AROI)' not in result
+        # Falls back through extract_contact_display_name.
+        assert 'brandonkuschel' in result.lower()
+
+    def test_empty_contact_uses_hash_fallback(self):
+        result = self._name(None, 'deadbeef00')
+        assert result == 'contact_deadbeef'
+
+    def test_truncates_when_no_url_no_email_no_name(self):
+        long_contact = 'random_unparseable_blob_of_text_far_too_long_for_a_display_name'
+        result = self._name(long_contact)
+        # Truncated to 30 chars + '...' as legacy fallback (cascade 3).
+        assert len(result) <= 35
+        assert result.endswith('...')
+
+    def test_url_with_path_drops_path(self):
+        result = self._name('email:foo[]bar.com url:https://bar.com/some/path?q=1')
+        assert result == 'bar.com (incomplete AROI)'
+
+
+# ============================================================================
+# Option B: incomplete-AROI sibling map + per-operator count
+# ============================================================================
+
+
+class TestIncompleteAROISiblingMap:
+    """Option B: categorization builds a global map of relays that
+    declare a url:<domain> token but failed AROI parsing, and
+    cross-references it against AROI-complete operators so the
+    operator detail page can surface 'N sibling relays missing
+    ciissversion' hints."""
+
+    def test_sibling_map_groups_by_normalised_url_domain(self):
+        from allium.lib.categorization import _build_incomplete_aroi_sibling_map
+        rs = MagicMock()
+        rs.json = {
+            'relays': [
+                # Two ciissversion-less v3-proof relays under 1aeo.com:
+                {'fingerprint': 'A' * 40, 'aroi_configured': False,
+                 'contact': 'email:tor[]1aeo.com url:https://www.1aeo.com '
+                            'proof:uri-familyid-ed25519'},
+                {'fingerprint': 'B' * 40, 'aroi_configured': False,
+                 'contact': 'email:abuse[]1aeo.com url:1aeo.com proof:uri-rsa'},
+                # An AROI-complete relay (must NOT appear in the map):
+                {'fingerprint': 'C' * 40, 'aroi_configured': True,
+                 'contact': 'ciissversion:3 proof:uri-familyid-ed25519 url:1aeo.com'},
+                # An unrelated incomplete relay under a different url:
+                {'fingerprint': 'D' * 40, 'aroi_configured': False,
+                 'contact': 'url:other.example proof:dns-rsa'},
+            ]
+        }
+        siblings = _build_incomplete_aroi_sibling_map(rs)
+        # Both 1aeo.com fingerprints land in the same bucket regardless
+        # of the url-prefix differences (https://www. vs bare).
+        assert set(siblings.get('1aeo.com', [])) == {'A' * 40, 'B' * 40}
+        # AROI-complete relay (fp C) is excluded from the sibling map.
+        assert 'C' * 40 not in siblings.get('1aeo.com', [])
+        # Other domain still tracked separately.
+        assert siblings.get('other.example') == ['D' * 40]
+
+    def test_calculate_contact_derived_data_propagates_sibling_count(self):
+        """End-to-end: when a contact group is the AROI-validated one
+        for 1aeo.com AND there are sibling incomplete relays under
+        the same url:, calculate_contact_derived_data attaches the
+        count + fingerprint list to contact_data."""
+        from allium.lib.categorization import (
+            sort_relay, calculate_contact_derived_data,
+        )
+        rs = MagicMock()
+        rs.json = {
+            'relays': [
+                # AROI-complete 1aeo.com relay (the operator group):
+                {
+                    'fingerprint': 'A' * 40, 'flags': [],
+                    'observed_bandwidth': 100, 'consensus_weight': 1,
+                    'consensus_weight_fraction': 0.0,
+                    'guard_consensus_weight_fraction': 0.0,
+                    'middle_consensus_weight_fraction': 0.0,
+                    'exit_consensus_weight_fraction': 0.0,
+                    'first_seen': '2025-01-01 00:00:00',
+                    'country': 'US', 'platform': 'Linux',
+                    'as': '111', 'as_name': '', 'effective_family': [],
+                    'aroi_domain': '1aeo.com', 'aroi_configured': True,
+                    'contact': ('ciissversion:3 url:1aeo.com '
+                                'proof:uri-familyid-ed25519'),
+                    'contact_md5': '1aeohash',
+                },
+                # Sibling missing ciissversion (NOT in the operator group):
+                {
+                    'fingerprint': 'B' * 40, 'flags': [],
+                    'observed_bandwidth': 50, 'consensus_weight': 1,
+                    'consensus_weight_fraction': 0.0,
+                    'guard_consensus_weight_fraction': 0.0,
+                    'middle_consensus_weight_fraction': 0.0,
+                    'exit_consensus_weight_fraction': 0.0,
+                    'first_seen': '2025-01-01 00:00:00',
+                    'country': 'US', 'platform': 'Linux',
+                    'as': '111', 'as_name': '', 'effective_family': [],
+                    'aroi_domain': 'none', 'aroi_configured': False,
+                    'contact': 'email:tor[]1aeo.com url:1aeo.com '
+                               'proof:uri-familyid-ed25519',
+                    'contact_md5': 'sibling_hash',
+                },
+            ],
+            'sorted': {'contact': {}},
+        }
+        # Categorise just the AROI-complete relay.
+        sort_relay(rs, rs.json['relays'][0], 0, 'contact', '1aeohash', 1, 0.0)
+        rs.json['sorted']['contact']['1aeohash']['bandwidth'] = 100
+        calculate_contact_derived_data(rs)
+
+        cd = rs.json['sorted']['contact']['1aeohash']
+        assert cd.get('incomplete_sibling_count') == 1
+        assert 'B' * 40 in cd.get('incomplete_sibling_fingerprints', [])

--- a/tests/unit/test_api_diagnostics.py
+++ b/tests/unit/test_api_diagnostics.py
@@ -1442,52 +1442,96 @@ class TestIncompleteAROIDisplayName:
 
 
 class TestIncompleteAROISiblingMap:
-    """Option B: categorization builds a global map of relays that
-    declare a url:<domain> token but failed AROI parsing, and
-    cross-references it against AROI-complete operators so the
-    operator detail page can surface 'N sibling relays missing
-    ciissversion' hints."""
+    """Option B (security-hardened): the sibling map keys by AROI-
+    complete operator's aroi_domain and only attributes incomplete
+    relays that appear in the validated relays' effective_family.
+    Trusting an unauthenticated url: token would let any rogue relay
+    publish 'url:victim.example' and inject a 'sibling relays missing
+    AROI fields' warning onto victim.example's operator page —
+    that's a reputation-tampering / spoofing vector. Tor's mutual
+    family-declaration mechanism gives us an authenticated signal
+    instead (a relay can't unilaterally claim to be in another
+    relay's family)."""
 
-    def test_sibling_map_groups_by_normalised_url_domain(self):
+    def test_authenticated_sibling_attributed(self):
+        """Incomplete relay listed in validated relay's effective_family
+        is safely attributed to the validated operator's aroi_domain."""
         from allium.lib.categorization import _build_incomplete_aroi_sibling_map
         rs = MagicMock()
         rs.json = {
             'relays': [
-                # Two ciissversion-less v3-proof relays under 1aeo.com:
-                {'fingerprint': 'A' * 40, 'aroi_configured': False,
-                 'contact': 'email:tor[]1aeo.com url:https://www.1aeo.com '
-                            'proof:uri-familyid-ed25519'},
+                # Validated 1aeo relay; mutually-declares family with B.
+                {'fingerprint': 'A' * 40, 'aroi_configured': True,
+                 'aroi_domain': '1aeo.com',
+                 'effective_family': ['B' * 40]},
+                # Incomplete v3-proof relay; missing ciissversion.
+                # Authenticated via mutual effective_family declaration.
                 {'fingerprint': 'B' * 40, 'aroi_configured': False,
-                 'contact': 'email:abuse[]1aeo.com url:1aeo.com proof:uri-rsa'},
-                # An AROI-complete relay (must NOT appear in the map):
-                {'fingerprint': 'C' * 40, 'aroi_configured': True,
-                 'contact': 'ciissversion:3 proof:uri-familyid-ed25519 url:1aeo.com'},
-                # An unrelated incomplete relay under a different url:
-                {'fingerprint': 'D' * 40, 'aroi_configured': False,
-                 'contact': 'url:other.example proof:dns-rsa'},
+                 'effective_family': ['A' * 40],
+                 'contact': 'email:tor[]1aeo.com url:1aeo.com '
+                            'proof:uri-familyid-ed25519'},
             ]
         }
         siblings = _build_incomplete_aroi_sibling_map(rs)
-        # Both 1aeo.com fingerprints land in the same bucket regardless
-        # of the url-prefix differences (https://www. vs bare).
-        assert set(siblings.get('1aeo.com', [])) == {'A' * 40, 'B' * 40}
-        # AROI-complete relay (fp C) is excluded from the sibling map.
-        assert 'C' * 40 not in siblings.get('1aeo.com', [])
-        # Other domain still tracked separately.
-        assert siblings.get('other.example') == ['D' * 40]
+        assert siblings.get('1aeo.com') == ['B' * 40]
+
+    def test_unauthenticated_url_claim_NOT_attributed(self):
+        """A rogue relay claiming url:victim.example WITHOUT mutual
+        family declaration must NOT inject itself onto victim.example's
+        operator page. This is the reputation-tampering / spoofing
+        vector the security review flagged."""
+        from allium.lib.categorization import _build_incomplete_aroi_sibling_map
+        rs = MagicMock()
+        rs.json = {
+            'relays': [
+                # Validated victim.example relay — declares NO family.
+                {'fingerprint': 'V' * 40, 'aroi_configured': True,
+                 'aroi_domain': 'victim.example', 'effective_family': []},
+                # Rogue relay claiming url:victim.example, NOT in
+                # victim's effective_family. Has v3-proof + missing
+                # ciissversion (the same pattern as legitimate
+                # misconfigured siblings).
+                {'fingerprint': 'R' * 40, 'aroi_configured': False,
+                 'effective_family': [],
+                 'contact': 'url:victim.example proof:uri-familyid-ed25519'},
+            ]
+        }
+        siblings = _build_incomplete_aroi_sibling_map(rs)
+        # Rogue MUST NOT be attributed to victim.example.
+        assert siblings.get('victim.example', []) == []
+
+    def test_validated_self_excluded_from_sibling_pool(self):
+        """An operator's own validated relays must NOT count as
+        'incomplete siblings' even when they appear in their own
+        effective_family."""
+        from allium.lib.categorization import _build_incomplete_aroi_sibling_map
+        rs = MagicMock()
+        rs.json = {
+            'relays': [
+                {'fingerprint': 'A' * 40, 'aroi_configured': True,
+                 'aroi_domain': '1aeo.com',
+                 'effective_family': ['A' * 40, 'B' * 40]},
+                {'fingerprint': 'B' * 40, 'aroi_configured': True,
+                 'aroi_domain': '1aeo.com',
+                 'effective_family': ['A' * 40, 'B' * 40]},
+            ]
+        }
+        siblings = _build_incomplete_aroi_sibling_map(rs)
+        assert siblings.get('1aeo.com', []) == []
 
     def test_calculate_contact_derived_data_propagates_sibling_count(self):
-        """End-to-end: when a contact group is the AROI-validated one
-        for 1aeo.com AND there are sibling incomplete relays under
-        the same url:, calculate_contact_derived_data attaches the
-        count + fingerprint list to contact_data."""
+        """End-to-end: contact_data['incomplete_sibling_count'] is set
+        for an AROI-validated operator when an authenticated family
+        member is misconfigured."""
         from allium.lib.categorization import (
             sort_relay, calculate_contact_derived_data,
         )
         rs = MagicMock()
+        # Note: only the validated relay is sort_relay'd into the
+        # contact group; the incomplete sibling exists in the relays
+        # list but is unattributed by AROI.
         rs.json = {
             'relays': [
-                # AROI-complete 1aeo.com relay (the operator group):
                 {
                     'fingerprint': 'A' * 40, 'flags': [],
                     'observed_bandwidth': 100, 'consensus_weight': 1,
@@ -1497,13 +1541,14 @@ class TestIncompleteAROISiblingMap:
                     'exit_consensus_weight_fraction': 0.0,
                     'first_seen': '2025-01-01 00:00:00',
                     'country': 'US', 'platform': 'Linux',
-                    'as': '111', 'as_name': '', 'effective_family': [],
+                    'as': '111', 'as_name': '',
+                    # Mutual family declaration with B.
+                    'effective_family': ['B' * 40],
                     'aroi_domain': '1aeo.com', 'aroi_configured': True,
                     'contact': ('ciissversion:3 url:1aeo.com '
                                 'proof:uri-familyid-ed25519'),
                     'contact_md5': '1aeohash',
                 },
-                # Sibling missing ciissversion (NOT in the operator group):
                 {
                     'fingerprint': 'B' * 40, 'flags': [],
                     'observed_bandwidth': 50, 'consensus_weight': 1,
@@ -1513,7 +1558,9 @@ class TestIncompleteAROISiblingMap:
                     'exit_consensus_weight_fraction': 0.0,
                     'first_seen': '2025-01-01 00:00:00',
                     'country': 'US', 'platform': 'Linux',
-                    'as': '111', 'as_name': '', 'effective_family': [],
+                    'as': '111', 'as_name': '',
+                    # Mutual family declaration -> authenticated link.
+                    'effective_family': ['A' * 40],
                     'aroi_domain': 'none', 'aroi_configured': False,
                     'contact': 'email:tor[]1aeo.com url:1aeo.com '
                                'proof:uri-familyid-ed25519',
@@ -1522,7 +1569,6 @@ class TestIncompleteAROISiblingMap:
             ],
             'sorted': {'contact': {}},
         }
-        # Categorise just the AROI-complete relay.
         sort_relay(rs, rs.json['relays'][0], 0, 'contact', '1aeohash', 1, 0.0)
         rs.json['sorted']['contact']['1aeohash']['bandwidth'] = 100
         calculate_contact_derived_data(rs)


### PR DESCRIPTION
…hint on operator page)

User-reported observation: 1aeo's leaderboard had a fragmented rank-11 row labelled with the truncated raw ContactInfo
'email:tor[]1aeo.com url:https:...' instead of '1aeo.com'. Investigation showed those 60 relays use a v3-flavoured proof type (proof:uri-familyid-ed25519) but forgot to declare ciissversion:3 in the same ContactInfo string, so AROI parsing fails and they fall to per-ContactInfo grouping. Upstream aroivalidator agrees: 60/60 marked invalid with error 'Missing AROI fields: ciissversion'.

Option A — friendly leaderboard display name for incomplete-AROI rows (allium/lib/aroileaders.py):

  Added _incomplete_aroi_display_name(contact_info, contact_hash) with
  a 4-step cascade for operators whose AROI parsing failed but whose
  ContactInfo still carries a usable identifier:
    1. If contact has 'url:<domain>' → '<domain> (incomplete AROI)' (covers the canonical case: 1aeo.com's 60 relays render as '1aeo.com (incomplete AROI)' on the leaderboard, attributable to the operator's domain instead of a truncated raw blob).
    2. Else fall back to extract_contact_display_name() for email/name/url derivation.
    3. Else legacy 30-char truncation.
    4. Else contact_hash prefix as last resort. Includes light domain normalisation (drop https:// scheme, www. prefix, trailing path/query, rstrip punctuation).

  Also reuses extract_contact_display_name from string_utils so the
  fallback layer stays consistent with the rest of the site.

Option B — sibling-misconfiguration hint on the operator detail page (allium/lib/categorization.py + operator_analysis.py + contact.html):

  Added _build_incomplete_aroi_sibling_map() in categorization.py
  which walks all relays once and produces a
  {url_domain: [fingerprints]} map of relays whose ContactInfo
  declares 'url:<domain>' but whose aroi_configured flag is False.
  calculate_contact_derived_data then cross-references this map
  against AROI-complete operator groups and attaches
  contact_data['incomplete_sibling_count'] +
  contact_data['incomplete_sibling_fingerprints'] (capped at 25)
  whenever sibling relays exist under the same domain.

  compute_contact_display_data forwards both fields onto
  contact_display_data so the contact.html template can render an
  actionable hint:

    ⚠ Sibling relays missing AROI fields: 60 relays declare
    url:1aeo.com in their ContactInfo but are missing ciissversion:
    (or have a version/proof mismatch). They show up on the
    leaderboard as a fragmented '1aeo.com (incomplete AROI)' entry
    instead of being grouped under this operator. Add the missing
    ciissversion:3 (or :2 for legacy RSA proofs) to those relays'
    ContactInfo to merge them.

End-to-end verification (live data, full --apis all build):
  - 1aeo.com leaderboard rank-11 row: '1aeo.com (incomplete AROI)' ✓
  - 1aeo.com operator detail page: sibling hint rendered with accurate count of 60 misconfigured relays ✓

dfri.se investigation (NOT broken):
  Leaderboard renders all 13 dfri.se references as 'dfri.se' verbatim;
  operator detail page header shows 'View Contact dfri.se Details';
  AROI line shows 'AROI: dfri.se ✓ Validated'. The 'DFRI' string only
  appears verbatim inside the standard 'Contact:' raw-ContactInfo
  sub-bullet (operator's chosen leading literal), which is the
  intended display for every operator. No code changes needed; user
  was likely confused by the raw-Contact line.

Lock-down tests (8 new):
  TestIncompleteAROIDisplayName — 6 tests:
    - real-world 1aeo case → '1aeo.com (incomplete AROI)'
    - bare url: token normalised
    - falls back to email/name when no url:
    - empty contact uses hash fallback
    - long unparseable string truncated (legacy fallback)
    - url with path strips path TestIncompleteAROISiblingMap — 2 tests:
    - sibling map groups by normalised url-domain
    - calculate_contact_derived_data propagates count to operator data

Total tests: 955 (+8 from previous 947).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Surface relays with incomplete AROI/contact data on operator pages, showing counts and example/domain attribution with separate buckets for authenticated family vs self-asserted URL claims.
  * More stable operator display names and collision-guarded fallbacks when AROI is missing to reduce leaderboard fragmentation.
  * Template warnings with actionable guidance for fixing missing AROI/contact fields; fingerprint lists capped at 25.

* **Tests**
  * Added unit tests for display-name formatting, sibling partitioning, propagation, and list-size caps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1aeo/allium/pull/209)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->