### PR TITLE
Incorrect relay first seen

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Allium integrates with multiple Tor Project APIs:
 ### Onionoo Uptime API
 
 - **URL**: `https://onionoo.torproject.org/uptime`
-- **Purpose**: Historical uptime statistics and flag history for reliability analysis
+- **Purpose**: Historical uptime statistics, flag history for reliability analysis, **and cross-check source for `first_seen` correction** (see Notable behaviour below)
 - **Memory**: ~2GB during processing (large historical dataset)
 
 <details>
@@ -260,6 +260,21 @@ Allium integrates with multiple Tor Project APIs:
 - **Cache**: Configurable (default: 12 hours)
 
 **Performance Features**: Parallel API fetching, HTTP conditional requests, graceful fallback to cached data
+
+### Notable behaviour: first_seen correction
+
+Allium repairs the `first_seen` field on each relay using onionoo's
+`/uptime` endpoint before page generation. This works around a long-standing
+upstream onionoo bug (issues
+[#40018](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40018),
+[#40028](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40028),
+[#40033](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40033),
+[#40042](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40042))
+which periodically resets `first_seen` for large fractions of the network
+after backend state-loss events. As of 2026-05-13 the correction repairs
+~92% of relays, restoring median network age from a buggy 1 month to a
+realistic 1.5 years. Logic lives in `allium/lib/first_seen_correction.py`
+and will be removed once the upstream bug is fixed.
 
 ## Security & Performance
 

--- a/README.md
+++ b/README.md
@@ -263,9 +263,9 @@ Allium integrates with multiple Tor Project APIs:
 
 ### Notable behaviour: first_seen correction
 
-Allium repairs the `first_seen` field on each relay using onionoo's
+Allium repairs the `first_seen` field on each relay using Onionoo's
 `/uptime` endpoint before page generation. This works around a long-standing
-upstream onionoo bug (issues
+upstream Onionoo bug (issues
 [#40018](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40018),
 [#40028](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40028),
 [#40033](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40033),

--- a/README.md
+++ b/README.md
@@ -271,10 +271,11 @@ upstream onionoo bug (issues
 [#40033](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40033),
 [#40042](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40042))
 which periodically resets `first_seen` for large fractions of the network
-after backend state-loss events. As of 2026-05-13 the correction repairs
-~92% of relays, restoring median network age from a buggy 1 month to a
-realistic 1.5 years. Logic lives in `allium/lib/first_seen_correction.py`
-and will be removed once the upstream bug is fixed.
+after backend state-loss events. When the bug is active, a per-run summary
+log line reports how many relays were repaired and the resulting
+`network_mean_age_formatted` reflects the corrected (older) dates. Logic
+lives in `allium/lib/first_seen_correction.py` and will be removed once
+the upstream bug is fixed.
 
 ## Security & Performance
 

--- a/allium/lib/coordinator.py
+++ b/allium/lib/coordinator.py
@@ -398,7 +398,8 @@ class Coordinator:
         # from /uptime history BEFORE the Relays constructor runs, so
         # categorisation, leaderboards, intelligence engine, templates,
         # and search index all see the corrected value with no rework.
-        # Silent no-op if uptime data is unavailable (e.g. --apis details).
+        # Applies no corrections if uptime data is unavailable (e.g.
+        # --apis details); still emits a summary log line in progress mode.
         # See allium/lib/first_seen_correction.py for full background.
         correct_first_seen(
             relay_data,

--- a/allium/lib/coordinator.py
+++ b/allium/lib/coordinator.py
@@ -391,7 +391,19 @@ class Coordinator:
         if self.progress:
             self.progress_logger.start_section("Data Processing")
             self._log_progress_with_step_increment("Creating relay set with Details API data...")
-        
+
+        # Workaround for onionoo's mass `first_seen` reset bug.
+        # Repair relay['first_seen'] from /uptime history BEFORE the Relays
+        # constructor runs, so categorization, leaderboards, intelligence engine,
+        # templates, and search index all see the corrected value with no rework.
+        # See allium/lib/first_seen_correction.py for details.
+        from .first_seen_correction import correct_first_seen
+        correct_first_seen(
+            relay_data,
+            self.get_uptime_data(),
+            progress_logger=self.progress_logger if self.progress else None,
+        )
+
         relay_set = Relays(
             output_dir=self.output_dir,
             onionoo_url=self.onionoo_details_url,
@@ -411,7 +423,14 @@ class Coordinator:
             if self.progress:
                 self._log_progress_with_step_increment("Failed to create relay set")
             return None
-        
+
+        # Surface first_seen correction stats for diagnostics (api_diagnostics,
+        # tests, future telemetry). Safe to access -- always stamped by
+        # correct_first_seen, even when no correction was applied.
+        relay_set.first_seen_repair_stats = relay_data.get(
+            '_first_seen_correction_summary'
+        )
+
         # Enrich with secondary API data (uptime, bandwidth, AROI, collector)
         # Processing order and dependencies are documented in enrich_with_api_data()
         relay_set.enrich_with_api_data(

--- a/allium/lib/coordinator.py
+++ b/allium/lib/coordinator.py
@@ -392,11 +392,13 @@ class Coordinator:
             self.progress_logger.start_section("Data Processing")
             self._log_progress_with_step_increment("Creating relay set with Details API data...")
 
-        # Workaround for onionoo's mass `first_seen` reset bug.
-        # Repair relay['first_seen'] from /uptime history BEFORE the Relays
-        # constructor runs, so categorization, leaderboards, intelligence engine,
-        # templates, and search index all see the corrected value with no rework.
-        # See allium/lib/first_seen_correction.py for details.
+        # Workaround for onionoo's mass `first_seen` reset bug (upstream
+        # issues #40018/#40028/#40033/#40042). Repair relay['first_seen']
+        # from /uptime history BEFORE the Relays constructor runs, so
+        # categorisation, leaderboards, intelligence engine, templates,
+        # and search index all see the corrected value with no rework.
+        # Silent no-op if uptime data is unavailable (e.g. --apis details).
+        # See allium/lib/first_seen_correction.py for full background.
         from .first_seen_correction import correct_first_seen
         correct_first_seen(
             relay_data,

--- a/allium/lib/coordinator.py
+++ b/allium/lib/coordinator.py
@@ -17,6 +17,7 @@ from .workers import (
 from .relays import Relays
 from .progress_logger import ProgressLogger
 from .error_handlers import handle_worker_errors, handle_calculation_errors
+from .first_seen_correction import correct_first_seen
 
 
 class Coordinator:
@@ -399,7 +400,6 @@ class Coordinator:
         # and search index all see the corrected value with no rework.
         # Silent no-op if uptime data is unavailable (e.g. --apis details).
         # See allium/lib/first_seen_correction.py for full background.
-        from .first_seen_correction import correct_first_seen
         correct_first_seen(
             relay_data,
             self.get_uptime_data(),

--- a/allium/lib/first_seen_correction.py
+++ b/allium/lib/first_seen_correction.py
@@ -44,16 +44,27 @@ Design rules
 - Catastrophic restore where both `NodeStatus` and `UptimeStatus` are lost
   simultaneously cannot be recovered; in that case we degrade silently to
   current (buggy) behaviour. Acceptable because that's the existing baseline.
-- Precision is bucket-aligned: corrected timestamps come from
-  `period.first + index * interval`, which is interval-aligned. The largest
-  bucket (`5_years`) has 10-day intervals, so corrected `first_seen` may
-  be up to 10 days *earlier* than truth, never later. Trading <=10 days
-  backwards uncertainty for the >=365 day backwards error in the raw data
-  is a clear improvement.
+- Precision is bucket-aligned. Per onionoo's protocol spec, the `first`
+  timestamp of an uptime period is the *midpoint* of interval 0, so
+  interval N covers ``[first + N*i - i/2, first + N*i + i/2]`` (where
+  ``i`` = interval seconds). The corrected `first_seen` is set to the
+  lower bound of the earliest non-null interval, guaranteeing it is
+  always ``<=`` the true `first_seen`. Worst-case backwards error is
+  the period's full interval -- 10 days for the `5_years` bucket. We're
+  trading <=10 days backwards uncertainty for the >=365 day backwards
+  error in the raw data, a clear improvement.
 - Relays older than 5 years: the `5_years` bucket saturates at "5 years ago",
   so corrected `first_seen` for very old relays is a lower bound capped at
   5 years ago. The "only move earlier" rule prevents regression for relays
   whose existing `first_seen` is already correctly older than 5 years.
+
+Performance
+===========
+
+On a typical run (~11k relays, ~11k uptime entries), the correction adds
+roughly 0.5 seconds to the build -- a fraction of the ~7-minute total. The
+correction runs once, sequentially, before the multiprocessing page-render
+phase, so there are no concurrency concerns.
 
 Python 3.8 compatible: uses Optional[...]/Dict[...] (not `X | None`) and
 PEP 484 comment-style annotations for the public API.
@@ -150,11 +161,11 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
             continue
 
         uptime_relay = uptime_index[fingerprint]
-        interval = _earliest_uptime_interval(uptime_relay)
-        if interval is None:
+        bounds = _earliest_uptime_interval(uptime_relay)
+        if bounds is None:
             summary['no_signal'] += 1
             continue
-        lower, upper = interval
+        lower, upper = bounds
 
         if lower < FIRST_SEEN_FLOOR:
             summary['rejected_floor'] += 1
@@ -221,13 +232,13 @@ def _earliest_uptime_interval(uptime_relay):
     # whitelist of period names, so that any new periods onionoo introduces
     # are picked up automatically without a code change.
     for period_data in uptime_section.values():
-        interval = _earliest_in_period(period_data)
-        if interval is None:
+        bounds = _earliest_in_period(period_data)
+        if bounds is None:
             continue
         # Pick the period whose upper_bound is earliest (= relay was
         # demonstrably observed at the latest a bit further back in time).
-        if best is None or interval[1] < best[1]:
-            best = interval
+        if best is None or bounds[1] < best[1]:
+            best = bounds
 
     return best
 
@@ -287,10 +298,10 @@ def _earliest_in_period(period_data):
 def _earliest_uptime_timestamp(uptime_relay):
     # type: (Dict[str, Any]) -> Optional[datetime]
     """Return only the lower bound of the earliest uptime observation."""
-    interval = _earliest_uptime_interval(uptime_relay)
-    if interval is None:
+    bounds = _earliest_uptime_interval(uptime_relay)
+    if bounds is None:
         return None
-    return interval[0]
+    return bounds[0]
 
 
 def _build_uptime_index(uptime_data):

--- a/allium/lib/first_seen_correction.py
+++ b/allium/lib/first_seen_correction.py
@@ -146,24 +146,29 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
             continue
 
         uptime_relay = uptime_index[fingerprint]
-        earliest = _earliest_uptime_timestamp(uptime_relay)
-        if earliest is None:
+        interval = _earliest_uptime_interval(uptime_relay)
+        if interval is None:
             summary['no_signal'] += 1
             continue
+        lower, upper = interval
 
-        if earliest < FIRST_SEEN_FLOOR:
+        if lower < FIRST_SEEN_FLOOR:
             summary['rejected_floor'] += 1
             continue
 
-        if earliest >= current_dt:
-            # Uptime says relay was first observed at the same time as, or
-            # later than, /details claims. Nothing to correct.
+        # Only correct if /details' first_seen is strictly *after* the latest
+        # possible time the relay could have been observed in uptime's
+        # earliest interval. Comparing against `upper` (not `lower`) avoids
+        # spurious "corrections" of a few days for relays whose first_seen
+        # is already consistent with uptime to within bucket precision.
+        if upper >= current_dt:
             summary['unchanged'] += 1
             continue
 
-        # Apply the correction.
+        # Apply the correction. Use `lower` so the corrected first_seen is
+        # guaranteed to be <= the true first_seen.
         relay['first_seen_onionoo_raw'] = raw_first_seen
-        relay['first_seen'] = earliest.strftime(_ONIONOO_TIMESTAMP_FORMAT)
+        relay['first_seen'] = lower.strftime(_ONIONOO_TIMESTAMP_FORMAT)
         relay['_first_seen_corrected'] = True
         relay['_first_seen_correction_source'] = 'onionoo_uptime'
         summary['corrected'] += 1
@@ -176,21 +181,29 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
     return relay_data
 
 
-def _earliest_uptime_timestamp(uptime_relay):
-    # type: (Dict[str, Any]) -> Optional[datetime]
-    """Return UTC datetime of the earliest non-null observation in uptime
-    history across all available periods, or ``None`` if no period yields a
-    valid signal.
+def _earliest_uptime_interval(uptime_relay):
+    # type: (Dict[str, Any]) -> Optional[tuple]
+    """Return ``(lower_bound, upper_bound)`` UTC datetimes for the earliest
+    non-null observation in uptime history across all available periods, or
+    ``None`` if no period yields a valid signal.
+
+    The relay was observed *somewhere* in the interval
+    ``[lower_bound, upper_bound]``. ``lower_bound`` is used as the corrected
+    ``first_seen`` (conservative -- never later than truth). ``upper_bound``
+    is used in the "should we correct?" comparison: only if the current
+    onionoo /details first_seen falls *strictly later than* ``upper_bound``
+    do we have evidence the value is wrong.
 
     For each period in ``uptime_relay['uptime']``, find the first index ``i``
     where ``values[i] is not None`` (note: ``0`` is a valid observation
-    meaning "tracked but down"). Compute::
+    meaning "tracked but down"). Per onionoo's protocol spec, ``first`` is
+    the *midpoint* of interval 0, so interval N covers
+    ``[first + N*interval - interval/2, first + N*interval + interval/2]``.
 
-        ts = parse(period['first']) + i * period['interval'] seconds
-
-    Return the minimum ``ts`` across all valid periods. Periods missing
-    ``first``, ``interval``, or with an empty/all-null ``values`` array are
-    skipped silently.
+    Return the period whose ``upper_bound`` is earliest -- this is the
+    longest reliable history that contains the earliest observation.
+    Periods missing ``first``, ``interval``, or with an empty/all-null
+    ``values`` array are skipped silently.
     """
     if not isinstance(uptime_relay, dict):
         return None
@@ -198,24 +211,27 @@ def _earliest_uptime_timestamp(uptime_relay):
     if not isinstance(uptime_section, dict):
         return None
 
-    earliest = None  # type: Optional[datetime]
+    best = None  # type: Optional[tuple]
 
-    # We intentionally iterate over uptime_section.items() rather than the
-    # _UPTIME_PERIODS whitelist, so that any new period names onionoo
-    # introduces are picked up automatically without a code change.
-    for period_name, period_data in uptime_section.items():
-        ts = _earliest_in_period(period_data)
-        if ts is None:
+    # We intentionally iterate over all period_data values rather than a
+    # whitelist of period names, so that any new periods onionoo introduces
+    # are picked up automatically without a code change.
+    for period_data in uptime_section.values():
+        interval = _earliest_in_period(period_data)
+        if interval is None:
             continue
-        if earliest is None or ts < earliest:
-            earliest = ts
+        # Pick the period whose upper_bound is earliest (= relay was
+        # demonstrably observed at the latest a bit further back in time).
+        if best is None or interval[1] < best[1]:
+            best = interval
 
-    return earliest
+    return best
 
 
 def _earliest_in_period(period_data):
-    # type: (Any) -> Optional[datetime]
-    """Find the earliest non-null timestamp in a single uptime period dict.
+    # type: (Any) -> Optional[tuple]
+    """Find the (lower_bound, upper_bound) of the earliest non-null
+    observation in a single uptime period dict.
 
     Returns None for malformed/empty periods. Tolerant of:
 
@@ -249,12 +265,28 @@ def _earliest_in_period(period_data):
             # 0 is a valid observation (tracked but down); only None means
             # "no data for this interval".
             try:
-                return first_dt + timedelta(seconds=int(interval) * idx)
+                interval_int = int(interval)
+                half_interval = interval_int // 2
+                midpoint = first_dt + timedelta(seconds=interval_int * idx)
+                lower = midpoint - timedelta(seconds=half_interval)
+                upper = midpoint + timedelta(seconds=half_interval)
+                return (lower, upper)
             except (OverflowError, ValueError):
                 return None
 
     # All values were None.
     return None
+
+
+# Backwards-compatible wrapper for tests / external callers that only need
+# the lower-bound timestamp.
+def _earliest_uptime_timestamp(uptime_relay):
+    # type: (Dict[str, Any]) -> Optional[datetime]
+    """Return only the lower bound of the earliest uptime observation."""
+    interval = _earliest_uptime_interval(uptime_relay)
+    if interval is None:
+        return None
+    return interval[0]
 
 
 def _build_uptime_index(uptime_data):

--- a/allium/lib/first_seen_correction.py
+++ b/allium/lib/first_seen_correction.py
@@ -172,7 +172,12 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
     if not relays or not isinstance(relays, list):
         # Nothing to correct; still stamp an empty summary so callers that
         # surface .first_seen_repair_stats don't have to special-case None.
-        relay_data['_first_seen_correction_summary'] = _empty_summary(0)
+        # Match the no-uptime fast path: also emit a summary log line so
+        # progress-mode operators see the no-op classification (per the
+        # docstring's promise).
+        summary = _empty_summary(0)
+        relay_data['_first_seen_correction_summary'] = summary
+        _log(progress_logger, _format_summary_message(summary))
         return relay_data
 
     uptime_index = _build_uptime_index(uptime_data)

--- a/allium/lib/first_seen_correction.py
+++ b/allium/lib/first_seen_correction.py
@@ -122,7 +122,7 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
     if not isinstance(relay_data, dict):
         return relay_data
     relays = relay_data.get('relays')
-    if not relays:
+    if not relays or not isinstance(relays, list):
         # Nothing to correct; still stamp an empty summary so callers that
         # surface .first_seen_repair_stats don't have to special-case None.
         relay_data['_first_seen_correction_summary'] = _empty_summary(0)
@@ -133,6 +133,10 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
     summary = _empty_summary(len(relays))
 
     for relay in relays:
+        if not isinstance(relay, dict):
+            # Defensive: a non-dict entry in the relays list. Skip silently
+            # (and don't bump any counter -- we don't know how to classify it).
+            continue
         fingerprint = relay.get('fingerprint')
         raw_first_seen = relay.get('first_seen')
         current_dt = parse_onionoo_timestamp(raw_first_seen) if raw_first_seen else None

--- a/allium/lib/first_seen_correction.py
+++ b/allium/lib/first_seen_correction.py
@@ -1,0 +1,330 @@
+"""
+Short-term workaround for onionoo's mass `first_seen` reset bug.
+
+Background
+==========
+
+Onionoo's `/details` endpoint periodically resets `first_seen` for large
+swathes of relays. The root cause is in `NodeDetailsStatusUpdater.java` in
+the upstream onionoo source: whenever the persisted `NodeStatus` is dropped
+or arrives empty (collector-sync delay, backend desync, fresh deployment),
+`firstSeenMillis` is re-initialised from the next consensus's `valid-after`
+instead of from older data. Issues filed upstream:
+
+    https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40018
+    https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40028
+    https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40033
+    https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40042
+
+A 2022 upstream hack (commit 4dec094) addressed this via `UptimeStatus`
+cross-check but was reverted in commit 85af138 without fixing the underlying
+state-loss. As of 2026-05-13, 87.9% of all running relays share the reset
+timestamp `2026-04-06 23:00:00`.
+
+Crucially, onionoo's `/uptime` endpoint stores history independently of
+`NodeStatus.firstSeenMillis` and survives the reset. Allium already fetches
+`/uptime` in parallel with `/details`, so we can cross-check `first_seen`
+against the earliest non-null entry in uptime history *before* downstream
+processing sees the value.
+
+This module is a self-contained workaround. When upstream fixes the bug, this
+module's call site in coordinator.create_relay_set() can be deleted and the
+file removed with no other changes.
+
+Design rules
+============
+
+- Only ever move `first_seen` *earlier*, never later. The original onionoo
+  value is always a lower bound on "earliest possible first_seen".
+- Treat `None` in uptime `values` as "no data"; treat `0` as a valid
+  observation ("tracked but down").
+- Defensive floor: reject any uptime-derived timestamp before 2004-01-01
+  (Tor's first public relays appeared in 2003-2004; anything earlier is
+  garbage like the epoch-zero bug from issue #40028).
+- Catastrophic restore where both `NodeStatus` and `UptimeStatus` are lost
+  simultaneously cannot be recovered; in that case we degrade silently to
+  current (buggy) behaviour. Acceptable because that's the existing baseline.
+- Precision is bucket-aligned: corrected timestamps come from
+  `period.first + index * interval`, which is interval-aligned. The largest
+  bucket (`5_years`) has 10-day intervals, so corrected `first_seen` may
+  be up to 10 days *earlier* than truth, never later. Trading <=10 days
+  backwards uncertainty for the >=365 day backwards error in the raw data
+  is a clear improvement.
+- Relays older than 5 years: the `5_years` bucket saturates at "5 years ago",
+  so corrected `first_seen` for very old relays is a lower bound capped at
+  5 years ago. The "only move earlier" rule prevents regression for relays
+  whose existing `first_seen` is already correctly older than 5 years.
+
+Python 3.8 compatible: uses Optional[...]/Dict[...] (not `X | None`) and
+PEP 484 comment-style annotations for the public API.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from .time_utils import parse_onionoo_timestamp
+
+
+# Defensive floor: earlier than the first public Tor relays existed.
+# Any uptime-derived timestamp before this is rejected as garbage
+# (cf. onionoo issue #40028, the 1970-01-01 bridge bug).
+FIRST_SEEN_FLOOR = datetime(2004, 1, 1, tzinfo=timezone.utc)
+
+# Onionoo's wire format for timestamp strings (naive UTC, no timezone suffix).
+_ONIONOO_TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'
+
+
+
+def correct_first_seen(relay_data,             # type: Dict[str, Any]
+                       uptime_data,            # type: Optional[Dict[str, Any]]
+                       progress_logger=None,   # type: Any
+                       ):
+    # type: (...) -> Dict[str, Any]
+    """Mutate ``relay_data`` in place, repairing ``first_seen`` from uptime history.
+
+    For each relay in ``relay_data['relays']``, look up the corresponding entry
+    in ``uptime_data['relays']`` by fingerprint. Compute the earliest timestamp
+    at which onionoo's uptime endpoint observed the relay (the first non-null
+    value across all uptime periods; treats ``0`` as a legitimate observation
+    of "tracked but down"). If that timestamp is strictly earlier than
+    ``relay['first_seen']`` AND >= ``FIRST_SEEN_FLOOR``, the function:
+
+    * replaces ``first_seen`` with the onionoo-formatted string;
+    * stamps ``first_seen_onionoo_raw`` with the original value;
+    * stamps ``_first_seen_corrected`` = True and
+      ``_first_seen_correction_source`` = "onionoo_uptime".
+
+    These three fields are only added when a correction is applied, so JSON
+    for unaffected relays is byte-identical to the input.
+
+    A diagnostic summary is stamped under
+    ``relay_data['_first_seen_correction_summary']``::
+
+        {
+            'total':              <N total relays>,
+            'corrected':          <N where first_seen was moved earlier>,
+            'unchanged':          <N where uptime existed but was not earlier>,
+            'missing_uptime':     <N with no entry in uptime_data>,
+            'no_signal':          <N where uptime entry existed but had no
+                                   non-null values>,
+            'rejected_floor':     <N where uptime timestamp was < FIRST_SEEN_FLOOR>,
+            'invalid_first_seen': <N where relay['first_seen'] was unparseable>,
+        }
+
+    The function is a safe no-op when:
+
+    * ``uptime_data`` is ``None`` or missing the ``relays`` key
+    * ``uptime_data['relays']`` is empty
+    * ``relay_data`` is ``None`` / missing ``relays`` / has an empty list
+
+    Returns the same ``relay_data`` dict (for chaining).
+    """
+    if not isinstance(relay_data, dict):
+        return relay_data
+    relays = relay_data.get('relays')
+    if not relays:
+        # Nothing to correct; still stamp an empty summary so callers that
+        # surface .first_seen_repair_stats don't have to special-case None.
+        relay_data['_first_seen_correction_summary'] = _empty_summary(0)
+        return relay_data
+
+    uptime_index = _build_uptime_index(uptime_data)
+
+    summary = _empty_summary(len(relays))
+
+    for relay in relays:
+        fingerprint = relay.get('fingerprint')
+        raw_first_seen = relay.get('first_seen')
+        current_dt = parse_onionoo_timestamp(raw_first_seen) if raw_first_seen else None
+
+        if current_dt is None:
+            summary['invalid_first_seen'] += 1
+            continue
+
+        if not fingerprint or fingerprint not in uptime_index:
+            summary['missing_uptime'] += 1
+            continue
+
+        uptime_relay = uptime_index[fingerprint]
+        earliest = _earliest_uptime_timestamp(uptime_relay)
+        if earliest is None:
+            summary['no_signal'] += 1
+            continue
+
+        if earliest < FIRST_SEEN_FLOOR:
+            summary['rejected_floor'] += 1
+            continue
+
+        if earliest >= current_dt:
+            # Uptime says relay was first observed at the same time as, or
+            # later than, /details claims. Nothing to correct.
+            summary['unchanged'] += 1
+            continue
+
+        # Apply the correction.
+        relay['first_seen_onionoo_raw'] = raw_first_seen
+        relay['first_seen'] = earliest.strftime(_ONIONOO_TIMESTAMP_FORMAT)
+        relay['_first_seen_corrected'] = True
+        relay['_first_seen_correction_source'] = 'onionoo_uptime'
+        summary['corrected'] += 1
+
+    relay_data['_first_seen_correction_summary'] = summary
+
+    message = _format_summary_message(summary)
+    _log(progress_logger, message)
+
+    return relay_data
+
+
+def _earliest_uptime_timestamp(uptime_relay):
+    # type: (Dict[str, Any]) -> Optional[datetime]
+    """Return UTC datetime of the earliest non-null observation in uptime
+    history across all available periods, or ``None`` if no period yields a
+    valid signal.
+
+    For each period in ``uptime_relay['uptime']``, find the first index ``i``
+    where ``values[i] is not None`` (note: ``0`` is a valid observation
+    meaning "tracked but down"). Compute::
+
+        ts = parse(period['first']) + i * period['interval'] seconds
+
+    Return the minimum ``ts`` across all valid periods. Periods missing
+    ``first``, ``interval``, or with an empty/all-null ``values`` array are
+    skipped silently.
+    """
+    if not isinstance(uptime_relay, dict):
+        return None
+    uptime_section = uptime_relay.get('uptime')
+    if not isinstance(uptime_section, dict):
+        return None
+
+    earliest = None  # type: Optional[datetime]
+
+    # We intentionally iterate over uptime_section.items() rather than the
+    # _UPTIME_PERIODS whitelist, so that any new period names onionoo
+    # introduces are picked up automatically without a code change.
+    for period_name, period_data in uptime_section.items():
+        ts = _earliest_in_period(period_data)
+        if ts is None:
+            continue
+        if earliest is None or ts < earliest:
+            earliest = ts
+
+    return earliest
+
+
+def _earliest_in_period(period_data):
+    # type: (Any) -> Optional[datetime]
+    """Find the earliest non-null timestamp in a single uptime period dict.
+
+    Returns None for malformed/empty periods. Tolerant of:
+
+    * non-dict input
+    * missing ``first``
+    * unparseable ``first``
+    * missing/non-numeric ``interval``
+    * missing/empty/non-list ``values``
+    * all-None ``values``
+    """
+    if not isinstance(period_data, dict):
+        return None
+
+    first_str = period_data.get('first')
+    if not first_str:
+        return None
+    first_dt = parse_onionoo_timestamp(first_str)
+    if first_dt is None:
+        return None
+
+    interval = period_data.get('interval')
+    if not isinstance(interval, (int, float)) or interval <= 0:
+        return None
+
+    values = period_data.get('values')
+    if not isinstance(values, list) or not values:
+        return None
+
+    for idx, value in enumerate(values):
+        if value is not None:
+            # 0 is a valid observation (tracked but down); only None means
+            # "no data for this interval".
+            try:
+                return first_dt + timedelta(seconds=int(interval) * idx)
+            except (OverflowError, ValueError):
+                return None
+
+    # All values were None.
+    return None
+
+
+def _build_uptime_index(uptime_data):
+    # type: (Optional[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]
+    """Index uptime_data['relays'] by fingerprint for O(1) lookup.
+
+    Tolerates missing/malformed input by returning an empty dict.
+    """
+    if not isinstance(uptime_data, dict):
+        return {}
+    relays = uptime_data.get('relays')
+    if not isinstance(relays, list):
+        return {}
+    index = {}  # type: Dict[str, Dict[str, Any]]
+    for entry in relays:
+        if not isinstance(entry, dict):
+            continue
+        fp = entry.get('fingerprint')
+        if isinstance(fp, str) and fp:
+            index[fp] = entry
+    return index
+
+
+def _empty_summary(total):
+    # type: (int) -> Dict[str, int]
+    return {
+        'total': total,
+        'corrected': 0,
+        'unchanged': 0,
+        'missing_uptime': 0,
+        'no_signal': 0,
+        'rejected_floor': 0,
+        'invalid_first_seen': 0,
+    }
+
+
+def _format_summary_message(summary):
+    # type: (Dict[str, int]) -> str
+    return (
+        "First-seen correction: repaired {corrected}/{total} relays from "
+        "onionoo uptime history (missing_uptime={missing_uptime}, "
+        "no_signal={no_signal}, rejected_floor={rejected_floor}, "
+        "invalid_first_seen={invalid_first_seen})"
+    ).format(**summary)
+
+
+def _log(progress_logger, message):
+    # type: (Any, str) -> None
+    """Logger-shape-agnostic emit. Accepts:
+
+    * ``ProgressLogger``-like objects (calls ``.log_without_increment(msg)``)
+    * ``logging.Logger``-like objects (calls ``.info(msg)``)
+    * bare callables (calls ``progress_logger(msg)``)
+    * ``None`` (no-op)
+
+    Any exception from the logger is swallowed -- we never break correction
+    because of a noisy logger.
+    """
+    if progress_logger is None:
+        return
+    try:
+        log_method = getattr(progress_logger, 'log_without_increment', None)
+        if callable(log_method):
+            log_method(message)
+            return
+        info_method = getattr(progress_logger, 'info', None)
+        if callable(info_method):
+            info_method(message)
+            return
+        if callable(progress_logger):
+            progress_logger(message)
+    except Exception:  # noqa: BLE001 -- logging must never break the caller.
+        pass

--- a/allium/lib/first_seen_correction.py
+++ b/allium/lib/first_seen_correction.py
@@ -34,8 +34,10 @@ file removed with no other changes.
 Design rules
 ============
 
-- Only ever move `first_seen` *earlier*, never later. The original onionoo
-  value is always a lower bound on "earliest possible first_seen".
+- Only correct `first_seen` when uptime independently confirms an earlier
+  observation. Specifically: only when the current /details `first_seen` is
+  strictly later than the *upper bound* of uptime's earliest non-null
+  interval. This avoids spurious corrections within bucket precision.
 - Treat `None` in uptime `values` as "no data"; treat `0` as a valid
   observation ("tracked but down").
 - Defensive floor: reject any uptime-derived timestamp before 2004-01-01
@@ -48,23 +50,39 @@ Design rules
   timestamp of an uptime period is the *midpoint* of interval 0, so
   interval N covers ``[first + N*i - i/2, first + N*i + i/2]`` (where
   ``i`` = interval seconds). The corrected `first_seen` is set to the
-  lower bound of the earliest non-null interval, guaranteeing it is
-  always ``<=`` the true `first_seen`. Worst-case backwards error is
-  the period's full interval -- 10 days for the `5_years` bucket. We're
-  trading <=10 days backwards uncertainty for the >=365 day backwards
-  error in the raw data, a clear improvement.
+  **midpoint of the earliest non-null interval** (``first + N*i``). This is
+  onionoo's documented point estimate for when an observation occurred in
+  that interval; expected error is +/- interval/2 (~5 days for the
+  `5_years` bucket), with the truth equally likely to be earlier or later.
+  Allium renders `first_seen` to users as an exact date, so we use the
+  best point estimate rather than a strict lower bound that would place the
+  relay before it physically existed. The independent upper-bound *guard*
+  on whether to apply a correction prevents us from regressing relays
+  whose /details and /uptime already agree to within bucket precision.
 - Relays older than 5 years: the `5_years` bucket saturates at "5 years ago",
-  so corrected `first_seen` for very old relays is a lower bound capped at
-  5 years ago. The "only move earlier" rule prevents regression for relays
-  whose existing `first_seen` is already correctly older than 5 years.
+  so corrected `first_seen` for very old relays approximates "5 years ago".
+  The upper-bound guard prevents regressing relays whose existing
+  `first_seen` is already correctly older than 5 years.
+- Exact archive values (per-hour consensuses from CollecTor) are *not*
+  used: parsing them would require downloading gigabytes of `.tar.xz`
+  files per regen, and onionoo offers no "earliest consensus containing
+  fingerprint X" query. Bucketed uptime is the best practical signal we
+  already have cached.
 
 Performance
 ===========
 
 On a typical run (~11k relays, ~11k uptime entries), the correction adds
-roughly 0.5 seconds to the build -- a fraction of the ~7-minute total. The
+roughly 0.3 seconds to the build -- a fraction of the ~7-minute total. The
 correction runs once, sequentially, before the multiprocessing page-render
-phase, so there are no concurrency concerns.
+phase, so there are no concurrency concerns. When uptime data is absent
+(e.g. ``--apis details``) the function short-circuits in well under a
+millisecond.
+
+Logging note: the function always emits one summary log line (when a
+logger is provided) -- including the no-uptime fast path -- so operators
+can observe what happened. There is no "silent" path; "silent no-op"
+in earlier docs was misleading wording.
 
 Python 3.8 compatible: uses Optional[...]/Dict[...] (not `X | None`) and
 PEP 484 comment-style annotations for the public API.
@@ -94,13 +112,15 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
     """Mutate ``relay_data`` in place, repairing ``first_seen`` from uptime history.
 
     For each relay in ``relay_data['relays']``, look up the corresponding entry
-    in ``uptime_data['relays']`` by fingerprint. Compute the earliest timestamp
-    at which onionoo's uptime endpoint observed the relay (the first non-null
-    value across all uptime periods; treats ``0`` as a legitimate observation
-    of "tracked but down"). If that timestamp is strictly earlier than
-    ``relay['first_seen']`` AND >= ``FIRST_SEEN_FLOOR``, the function:
+    in ``uptime_data['relays']`` by fingerprint. Compute the bounds of the
+    earliest interval in which onionoo's uptime endpoint observed the relay
+    (the first non-null value across all uptime periods; treats ``0`` as a
+    legitimate observation of "tracked but down"). If the current /details
+    ``first_seen`` falls *strictly later than* the upper bound of that
+    interval AND the midpoint is >= ``FIRST_SEEN_FLOOR``, the function:
 
-    * replaces ``first_seen`` with the onionoo-formatted string;
+    * replaces ``first_seen`` with the **midpoint** of that interval
+      (onionoo's documented point estimate, naive UTC string);
     * stamps ``first_seen_onionoo_raw`` with the original value;
     * stamps ``_first_seen_corrected`` = True and
       ``_first_seen_correction_source`` = "onionoo_uptime".
@@ -112,7 +132,7 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
     ``relay_data['_first_seen_correction_summary']``::
 
         {
-            'total':              <N total relays>,
+            'total':              <N dict relays in relay_data['relays']>,
             'corrected':          <N where first_seen was moved earlier>,
             'unchanged':          <N where uptime existed but was not earlier>,
             'missing_uptime':     <N with no entry in uptime_data>,
@@ -120,13 +140,21 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
                                    non-null values>,
             'rejected_floor':     <N where uptime timestamp was < FIRST_SEEN_FLOOR>,
             'invalid_first_seen': <N where relay['first_seen'] was unparseable>,
+            'non_dict_skipped':   <N non-dict entries silently skipped>,
         }
 
-    The function is a safe no-op when:
+    The sum of (corrected + unchanged + missing_uptime + no_signal +
+    rejected_floor + invalid_first_seen) equals ``total``. ``non_dict_skipped``
+    is reported separately and is not part of ``total``.
+
+    The function applies no corrections when:
 
     * ``uptime_data`` is ``None`` or missing the ``relays`` key
     * ``uptime_data['relays']`` is empty
     * ``relay_data`` is ``None`` / missing ``relays`` / has an empty list
+
+    A summary is still stamped (and logged in progress mode) in these
+    cases so callers can observe the no-op classification.
 
     Returns the same ``relay_data`` dict (for chaining).
     """
@@ -141,24 +169,29 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
 
     uptime_index = _build_uptime_index(uptime_data)
 
-    summary = _empty_summary(len(relays))
+    # Count dict relays exactly so ``total`` equals the sum of classification
+    # counters. Non-dict entries are tracked under ``non_dict_skipped``
+    # outside ``total``.
+    dict_relay_count = sum(1 for r in relays if isinstance(r, dict))
+    non_dict_skipped = len(relays) - dict_relay_count
+
+    summary = _empty_summary(dict_relay_count)
+    summary['non_dict_skipped'] = non_dict_skipped
 
     # Fast path: when no uptime data is available (e.g. --apis details), every
     # dict relay will fall through to `missing_uptime`. Short-circuit so we
     # don't waste ~11k parse_onionoo_timestamp calls on a guaranteed-no-op
     # main loop.
     if not uptime_index:
-        for relay in relays:
-            if isinstance(relay, dict):
-                summary['missing_uptime'] += 1
+        summary['missing_uptime'] = dict_relay_count
         relay_data['_first_seen_correction_summary'] = summary
         _log(progress_logger, _format_summary_message(summary))
         return relay_data
 
     for relay in relays:
         if not isinstance(relay, dict):
-            # Defensive: a non-dict entry in the relays list. Skip silently
-            # (and don't bump any counter -- we don't know how to classify it).
+            # Defensive: a non-dict entry in the relays list. Tallied in
+            # non_dict_skipped (outside ``total``) above; skip silently here.
             continue
         fingerprint = relay.get('fingerprint')
 
@@ -179,25 +212,28 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
         if bounds is None:
             summary['no_signal'] += 1
             continue
-        lower, upper = bounds
+        midpoint, upper = bounds
 
-        if lower < FIRST_SEEN_FLOOR:
+        if midpoint < FIRST_SEEN_FLOOR:
             summary['rejected_floor'] += 1
             continue
 
         # Only correct if /details' first_seen is strictly *after* the latest
         # possible time the relay could have been observed in uptime's
-        # earliest interval. Comparing against `upper` (not `lower`) avoids
-        # spurious "corrections" of a few days for relays whose first_seen
-        # is already consistent with uptime to within bucket precision.
+        # earliest interval. Comparing against `upper` (not `midpoint`)
+        # avoids spurious "corrections" of a few days for relays whose
+        # first_seen is already consistent with uptime to within bucket
+        # precision.
         if upper >= current_dt:
             summary['unchanged'] += 1
             continue
 
-        # Apply the correction. Use `lower` so the corrected first_seen is
-        # guaranteed to be <= the true first_seen.
+        # Apply the correction. Use the interval midpoint (onionoo's
+        # documented point estimate) so the user-facing first_seen lands on
+        # the most likely actual-observation time, not a strict lower bound
+        # that would predate the relay's existence.
         relay['first_seen_onionoo_raw'] = raw_first_seen
-        relay['first_seen'] = lower.strftime(_ONIONOO_TIMESTAMP_FORMAT)
+        relay['first_seen'] = midpoint.strftime(_ONIONOO_TIMESTAMP_FORMAT)
         relay['_first_seen_corrected'] = True
         relay['_first_seen_correction_source'] = 'onionoo_uptime'
         summary['corrected'] += 1
@@ -212,22 +248,25 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
 
 def _earliest_uptime_interval(uptime_relay):
     # type: (Dict[str, Any]) -> Optional[tuple]
-    """Return ``(lower_bound, upper_bound)`` UTC datetimes for the earliest
+    """Return ``(midpoint, upper_bound)`` UTC datetimes for the earliest
     non-null observation in uptime history across all available periods, or
     ``None`` if no period yields a valid signal.
 
     The relay was observed *somewhere* in the interval
-    ``[lower_bound, upper_bound]``. ``lower_bound`` is used as the corrected
-    ``first_seen`` (conservative -- never later than truth). ``upper_bound``
-    is used in the "should we correct?" comparison: only if the current
-    onionoo /details first_seen falls *strictly later than* ``upper_bound``
-    do we have evidence the value is wrong.
+    ``[midpoint - interval/2, midpoint + interval/2 = upper_bound]``.
+    ``midpoint`` is onionoo's documented point estimate for when the
+    observation occurred and is what we expose as the corrected
+    ``first_seen``. ``upper_bound`` is used in the "should we correct?"
+    comparison: only if the current onionoo /details ``first_seen`` falls
+    *strictly later than* ``upper_bound`` do we have evidence the value
+    is wrong.
 
     For each period in ``uptime_relay['uptime']``, find the first index ``i``
     where ``values[i] is not None`` (note: ``0`` is a valid observation
     meaning "tracked but down"). Per onionoo's protocol spec, ``first`` is
-    the *midpoint* of interval 0, so interval N covers
-    ``[first + N*interval - interval/2, first + N*interval + interval/2]``.
+    the midpoint of interval 0, so interval N covers
+    ``[first + N*interval - interval/2, first + N*interval + interval/2]``
+    and its midpoint is ``first + N*interval``.
 
     Return the period whose ``upper_bound`` is earliest -- this is the
     longest reliable history that contains the earliest observation.
@@ -259,7 +298,7 @@ def _earliest_uptime_interval(uptime_relay):
 
 def _earliest_in_period(period_data):
     # type: (Any) -> Optional[tuple]
-    """Find the (lower_bound, upper_bound) of the earliest non-null
+    """Find the (midpoint, upper_bound) of the earliest non-null
     observation in a single uptime period dict.
 
     Returns None for malformed/empty periods. Tolerant of:
@@ -307,21 +346,21 @@ def _earliest_in_period(period_data):
         interval_int = int(interval)
         half_interval = interval_int // 2
         offset = interval_int * first_nonnull_idx
-        # Compute lower and upper directly without the intermediate midpoint
-        # datetime -- saves one timedelta() construction and one datetime
-        # addition per matched period (~10k savings on a full run).
-        lower = first_dt + timedelta(seconds=offset - half_interval)
+        # Midpoint and upper_bound; lower_bound = midpoint - half_interval
+        # isn't returned because we no longer use it (Allium displays the
+        # midpoint as the user-facing first_seen).
+        midpoint = first_dt + timedelta(seconds=offset)
         upper = first_dt + timedelta(seconds=offset + half_interval)
-        return (lower, upper)
+        return (midpoint, upper)
     except (OverflowError, ValueError):
         return None
 
 
 # Backwards-compatible wrapper for tests / external callers that only need
-# the lower-bound timestamp.
+# the midpoint timestamp.
 def _earliest_uptime_timestamp(uptime_relay):
     # type: (Dict[str, Any]) -> Optional[datetime]
-    """Return only the lower bound of the earliest uptime observation."""
+    """Return only the midpoint of the earliest uptime observation interval."""
     bounds = _earliest_uptime_interval(uptime_relay)
     if bounds is None:
         return None
@@ -359,6 +398,7 @@ def _empty_summary(total):
         'no_signal': 0,
         'rejected_floor': 0,
         'invalid_first_seen': 0,
+        'non_dict_skipped': 0,
     }
 
 
@@ -366,8 +406,9 @@ def _format_summary_message(summary):
     # type: (Dict[str, int]) -> str
     return (
         "First-seen correction: repaired {corrected}/{total} relays from "
-        "onionoo uptime history (missing_uptime={missing_uptime}, "
-        "no_signal={no_signal}, rejected_floor={rejected_floor}, "
+        "onionoo uptime history (unchanged={unchanged}, "
+        "missing_uptime={missing_uptime}, no_signal={no_signal}, "
+        "rejected_floor={rejected_floor}, "
         "invalid_first_seen={invalid_first_seen})"
     ).format(**summary)
 

--- a/allium/lib/first_seen_correction.py
+++ b/allium/lib/first_seen_correction.py
@@ -16,10 +16,15 @@ instead of from older data. Issues filed upstream:
     https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40033
     https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40042
 
-A 2022 upstream hack (commit 4dec094) addressed this via `UptimeStatus`
-cross-check but was reverted in commit 85af138 without fixing the underlying
-state-loss. As of 2026-05-13, 87.9% of all running relays share the reset
-timestamp `2026-04-06 23:00:00`.
+A 2022 upstream hack (commit 4dec094 in the onionoo repo) addressed this
+via `UptimeStatus` cross-check but was reverted in commit 85af138 without
+fixing the underlying state-loss. The bug recurs whenever onionoo's
+backend state is rebuilt or arrives partially: the symptom is a large
+fraction of running relays sharing one identical `first_seen` timestamp
+that matches a specific recent consensus's `valid-after`. Cross-check
+the live network state (e.g. count occurrences of the most common
+`first_seen` value in ``/details``) to confirm whether the bug is
+currently active.
 
 Crucially, onionoo's `/uptime` endpoint stores history independently of
 `NodeStatus.firstSeenMillis` and survives the reset. Allium already fetches
@@ -44,8 +49,11 @@ Design rules
   (Tor's first public relays appeared in 2003-2004; anything earlier is
   garbage like the epoch-zero bug from issue #40028).
 - Catastrophic restore where both `NodeStatus` and `UptimeStatus` are lost
-  simultaneously cannot be recovered; in that case we degrade silently to
-  current (buggy) behaviour. Acceptable because that's the existing baseline.
+  simultaneously cannot be recovered (uptime won't show older data either);
+  in that case the function applies no corrections and the run continues
+  with the existing /details `first_seen` values. The per-run summary log
+  still records the classification (most relays under ``no_signal`` or
+  ``missing_uptime``).
 - Precision is bucket-aligned. Per onionoo's protocol spec, the `first`
   timestamp of an uptime period is the *midpoint* of interval 0, so
   interval N covers ``[first + N*i - i/2, first + N*i + i/2]`` (where

--- a/allium/lib/first_seen_correction.py
+++ b/allium/lib/first_seen_correction.py
@@ -143,21 +143,35 @@ def correct_first_seen(relay_data,             # type: Dict[str, Any]
 
     summary = _empty_summary(len(relays))
 
+    # Fast path: when no uptime data is available (e.g. --apis details), every
+    # dict relay will fall through to `missing_uptime`. Short-circuit so we
+    # don't waste ~11k parse_onionoo_timestamp calls on a guaranteed-no-op
+    # main loop.
+    if not uptime_index:
+        for relay in relays:
+            if isinstance(relay, dict):
+                summary['missing_uptime'] += 1
+        relay_data['_first_seen_correction_summary'] = summary
+        _log(progress_logger, _format_summary_message(summary))
+        return relay_data
+
     for relay in relays:
         if not isinstance(relay, dict):
             # Defensive: a non-dict entry in the relays list. Skip silently
             # (and don't bump any counter -- we don't know how to classify it).
             continue
         fingerprint = relay.get('fingerprint')
-        raw_first_seen = relay.get('first_seen')
-        current_dt = parse_onionoo_timestamp(raw_first_seen) if raw_first_seen else None
 
-        if current_dt is None:
-            summary['invalid_first_seen'] += 1
-            continue
-
+        # Cheap dict-membership check first: skip parsing first_seen for
+        # relays that have no uptime entry (saves a strptime per skipped relay).
         if not fingerprint or fingerprint not in uptime_index:
             summary['missing_uptime'] += 1
+            continue
+
+        raw_first_seen = relay.get('first_seen')
+        current_dt = parse_onionoo_timestamp(raw_first_seen) if raw_first_seen else None
+        if current_dt is None:
+            summary['invalid_first_seen'] += 1
             continue
 
         uptime_relay = uptime_index[fingerprint]
@@ -260,6 +274,28 @@ def _earliest_in_period(period_data):
     if not isinstance(period_data, dict):
         return None
 
+    # Cheapest checks first: skip the parse_onionoo_timestamp call when the
+    # period has no usable values. This avoids ~hundreds of wasted parses
+    # in the `no_signal` path (relays with all-None uptime values).
+    values = period_data.get('values')
+    if not isinstance(values, list) or not values:
+        return None
+
+    first_nonnull_idx = -1
+    for idx, value in enumerate(values):
+        if value is not None:
+            # 0 is a valid observation (tracked but down); only None means
+            # "no data for this interval".
+            first_nonnull_idx = idx
+            break
+    if first_nonnull_idx < 0:
+        # All values were None.
+        return None
+
+    interval = period_data.get('interval')
+    if not isinstance(interval, (int, float)) or interval <= 0:
+        return None
+
     first_str = period_data.get('first')
     if not first_str:
         return None
@@ -267,30 +303,18 @@ def _earliest_in_period(period_data):
     if first_dt is None:
         return None
 
-    interval = period_data.get('interval')
-    if not isinstance(interval, (int, float)) or interval <= 0:
+    try:
+        interval_int = int(interval)
+        half_interval = interval_int // 2
+        offset = interval_int * first_nonnull_idx
+        # Compute lower and upper directly without the intermediate midpoint
+        # datetime -- saves one timedelta() construction and one datetime
+        # addition per matched period (~10k savings on a full run).
+        lower = first_dt + timedelta(seconds=offset - half_interval)
+        upper = first_dt + timedelta(seconds=offset + half_interval)
+        return (lower, upper)
+    except (OverflowError, ValueError):
         return None
-
-    values = period_data.get('values')
-    if not isinstance(values, list) or not values:
-        return None
-
-    for idx, value in enumerate(values):
-        if value is not None:
-            # 0 is a valid observation (tracked but down); only None means
-            # "no data for this interval".
-            try:
-                interval_int = int(interval)
-                half_interval = interval_int // 2
-                midpoint = first_dt + timedelta(seconds=interval_int * idx)
-                lower = midpoint - timedelta(seconds=half_interval)
-                upper = midpoint + timedelta(seconds=half_interval)
-                return (lower, upper)
-            except (OverflowError, ValueError):
-                return None
-
-    # All values were None.
-    return None
 
 
 # Backwards-compatible wrapper for tests / external callers that only need

--- a/docs/reference/api-integration.md
+++ b/docs/reference/api-integration.md
@@ -27,9 +27,35 @@
 | **Required** | Only with `--apis all` |
 | **Failure** | Graceful degradation (reliability features disabled) |
 
-**Fields used**: uptime history (1_month, 6_months, 1_year, 5_years), flag-specific uptime history
+**Fields used**: uptime history (1_month, 6_months, 1_year, 5_years), flag-specific uptime history. Also cross-checked against `/details` first_seen — see below.
 
 **Data format**: Values 0-999 representing uptime percentage (divided by 999 * 100 = percentage)
+
+### Workaround: first_seen correction from Uptime API
+
+Onionoo's `/details` endpoint periodically resets `first_seen` for many
+relays (see upstream issues
+[#40018](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40018),
+[#40028](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40028),
+[#40033](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40033),
+[#40042](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40042)).
+As of 2026-05-13, ~88% of running relays share a single reset timestamp
+of `2026-04-06 23:00:00`. The `/uptime` endpoint stores history
+independently and survives the reset.
+
+Before constructing the relay set, Allium cross-checks each relay's
+`first_seen` against the earliest non-null entry in its uptime history. If
+the uptime endpoint observed the relay earlier than `/details` claims,
+`first_seen` is moved to the uptime-derived timestamp and the original
+value is preserved under `first_seen_onionoo_raw` for diagnostics.
+
+The correction is conservative (only moves `first_seen` earlier, never
+later), defensively bounded (rejects pre-2004 garbage values), and a
+silent no-op when `/uptime` data is unavailable (e.g. `--apis details`).
+Implementation: `allium/lib/first_seen_correction.py`. Repair stats are
+surfaced on the coordinator's relay set as `first_seen_repair_stats` and
+logged once per run. This module is intended to be removed once the
+upstream bug is fixed.
 
 ### Onionoo Bandwidth API
 

--- a/docs/reference/api-integration.md
+++ b/docs/reference/api-integration.md
@@ -39,9 +39,12 @@ relays (see upstream issues
 [#40028](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40028),
 [#40033](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40033),
 [#40042](https://gitlab.torproject.org/tpo/network-health/metrics/onionoo/-/issues/40042)).
-As of 2026-05-13, ~88% of running relays share a single reset timestamp
-of `2026-04-06 23:00:00`. The `/uptime` endpoint stores history
-independently and survives the reset.
+The symptom is a large fraction of running relays sharing one identical
+recent `first_seen` timestamp (matching some specific recent consensus's
+`valid-after`). The `/uptime` endpoint stores history independently and
+survives the reset; you can confirm the bug is currently active by
+checking whether the most common `first_seen` value in `/details`
+accounts for an implausibly large share of the network.
 
 Before constructing the relay set, Allium cross-checks each relay's
 `first_seen` against the earliest non-null entry in its uptime history. If
@@ -50,12 +53,13 @@ the uptime endpoint observed the relay earlier than `/details` claims,
 value is preserved under `first_seen_onionoo_raw` for diagnostics.
 
 The correction is conservative (only moves `first_seen` earlier, never
-later), defensively bounded (rejects pre-2004 garbage values), and a
-silent no-op when `/uptime` data is unavailable (e.g. `--apis details`).
-Implementation: `allium/lib/first_seen_correction.py`. Repair stats are
-surfaced on the coordinator's relay set as `first_seen_repair_stats` and
-logged once per run. This module is intended to be removed once the
-upstream bug is fixed.
+later) and defensively bounded (rejects pre-2004 garbage values). When
+`/uptime` data is unavailable (e.g. `--apis details`) no corrections are
+applied, but a summary log line is still emitted in progress mode so
+operators can observe the no-op classification. Implementation:
+`allium/lib/first_seen_correction.py`. Repair stats are surfaced on the
+coordinator's relay set as `first_seen_repair_stats` and logged once per
+run. This module is intended to be removed once the upstream bug is fixed.
 
 ### Onionoo Bandwidth API
 

--- a/tests/integration/test_first_seen_correction_integration.py
+++ b/tests/integration/test_first_seen_correction_integration.py
@@ -1,0 +1,210 @@
+"""
+Integration test for first_seen correction end-to-end through Relays().
+
+The 1aeo snapshot at ``docs/development/example-data/1aeo_relays_data.json``
+predates the regression and shows *correct* 2025-dated first_seen values, so
+we synthesise the buggy state on top of it: pick a few relays, save their
+true first_seen, overwrite with a reset date, build matching uptime data,
+run the correction, and verify both the raw correction AND the downstream
+Relays() categorisation see the corrected values.
+"""
+
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from allium.lib.first_seen_correction import correct_first_seen
+from allium.lib.relays import Relays
+from allium.lib.time_utils import parse_onionoo_timestamp
+
+
+pytestmark = [pytest.mark.integration]
+
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / 'docs' / 'development' / 'example-data' / '1aeo_relays_data.json'
+)
+
+
+def _load_fixture():
+    with open(FIXTURE_PATH, 'r') as f:
+        return json.load(f)
+
+
+def _floor_to_grid(dt, interval_seconds):
+    """Floor a UTC datetime to the nearest interval-aligned boundary.
+
+    Mirrors onionoo's own bucket alignment: the ``first`` timestamp of a
+    period is always a multiple of the period's interval relative to the
+    epoch.
+    """
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    elapsed = int((dt - epoch).total_seconds())
+    floored = (elapsed // interval_seconds) * interval_seconds
+    return epoch + timedelta(seconds=floored)
+
+
+def test_correction_propagates_to_relays_sorted_categories():
+    """Synthesise buggy state on 1aeo fixture; verify correction + categorisation."""
+    fixture = _load_fixture()
+    relays = list(fixture.get('relays', []))
+    assert len(relays) >= 5, 'fixture must contain at least 5 relays'
+
+    # Use the first 5 relays for our buggy-state synthesis.
+    affected = relays[:5]
+    reset_date = '2026-05-01 00:00:00'
+
+    # For each, save the true first_seen and overwrite with the reset date.
+    true_first_seen = {}
+    for relay in affected:
+        fp = relay['fingerprint']
+        true_first_seen[fp] = relay['first_seen']
+        relay['first_seen'] = reset_date
+
+    # Build a synthetic uptime payload covering only the 5 affected relays.
+    # Each relay's 5_years.first is the true first_seen floored to the 10-day
+    # grid (864000s = 10d, onionoo's actual 5_years interval), with a single
+    # non-null value at index 0.
+    interval = 864000
+    uptime_relays = []
+    expected_corrected = {}
+    for fp, true_str in true_first_seen.items():
+        true_dt = parse_onionoo_timestamp(true_str)
+        assert true_dt is not None
+        first_dt = _floor_to_grid(true_dt, interval)
+        first_str = first_dt.strftime('%Y-%m-%d %H:%M:%S')
+        expected_corrected[fp] = first_str
+        # Synthesise only the 5_years period for this test -- in real onionoo
+        # data, shorter periods (1_year, 6_months, 1_month) only span the
+        # last N units relative to today, so their values would be all-None
+        # for any portion before the relay's true first_seen. Modeling that
+        # accurately is unnecessary noise for this test; the 5_years bucket
+        # is the one that actually provides the older signal in practice.
+        uptime_relays.append({
+            'fingerprint': fp,
+            'uptime': {
+                '5_years': {
+                    'first': first_str,
+                    'last': '2026-05-13 00:00:00',
+                    'interval': interval,
+                    'count': 43,
+                    'values': [999] * 43,
+                },
+            },
+        })
+
+    uptime_data = {
+        'version': '8.0',
+        'relays_published': '2026-05-13 12:00:00',
+        'relays': uptime_relays,
+    }
+
+    relay_data = {
+        'version': fixture.get('version', '8.0'),
+        'relays_published': '2026-05-13 12:00:00',
+        'relays': relays,
+    }
+
+    # ----- 1. Apply the correction. -----
+    correct_first_seen(relay_data, uptime_data)
+
+    # ----- 2. Verify raw-data correction. -----
+    summary = relay_data['_first_seen_correction_summary']
+    # 5 affected relays should be corrected; the remaining 648 lack
+    # uptime entries so they fall under missing_uptime.
+    assert summary['corrected'] == 5
+    assert summary['missing_uptime'] == len(relays) - 5
+    assert summary['total'] == len(relays)
+
+    for relay in affected:
+        fp = relay['fingerprint']
+        # first_seen now equals the floored true value.
+        assert relay['first_seen'] == expected_corrected[fp], (
+            'fingerprint {}: expected {}, got {}'.format(
+                fp, expected_corrected[fp], relay['first_seen']
+            )
+        )
+        # original preserved.
+        assert relay['first_seen_onionoo_raw'] == reset_date
+        # metadata.
+        assert relay['_first_seen_corrected'] is True
+        assert relay['_first_seen_correction_source'] == 'onionoo_uptime'
+        # corrected value is at most 10 days earlier than the true value
+        # (5_years bucket precision).
+        corrected = parse_onionoo_timestamp(relay['first_seen'])
+        true_dt = parse_onionoo_timestamp(true_first_seen[fp])
+        assert corrected <= true_dt
+        assert (true_dt - corrected) <= timedelta(seconds=interval)
+
+    # ----- 3. Construct Relays() with the corrected data; check categorisation. -----
+    with tempfile.TemporaryDirectory() as tmpdir:
+        relay_set = Relays(
+            output_dir=tmpdir,
+            onionoo_url='http://localhost',
+            relay_data=relay_data,
+            progress=False,
+        )
+
+    assert relay_set.json is not None, 'Relays() returned None unexpectedly'
+
+    sorted_first_seen = relay_set.json['sorted']['first_seen']
+
+    # The reset-date bucket must NOT contain all 5 affected relays (some may
+    # legitimately match on date if the floor lands on 2026-05-01, but that's
+    # unlikely for our 1aeo fixture which has 2025-* original dates).
+    reset_date_only = reset_date.split(' ')[0]
+    affected_fps = {r['fingerprint'] for r in affected}
+    relays_in_reset_bucket = set()
+    if reset_date_only in sorted_first_seen:
+        # categorization stores 'relays' as list of indices; resolve them.
+        idx_list = sorted_first_seen[reset_date_only].get('relays', [])
+        for idx in idx_list:
+            relays_in_reset_bucket.add(relay_set.json['relays'][idx]['fingerprint'])
+    overlap = affected_fps & relays_in_reset_bucket
+    assert overlap == set(), (
+        'affected relays should NOT be in the 2026-05-01 bucket; overlap={}'.format(overlap)
+    )
+
+    # Each affected relay's corrected first_seen date should appear as a bucket.
+    for relay in affected:
+        date_part = relay['first_seen'].split(' ')[0]
+        assert date_part in sorted_first_seen, (
+            'corrected date {} missing from sorted[\'first_seen\']'.format(date_part)
+        )
+
+
+def test_coordinator_exposes_first_seen_repair_stats_on_relay_set():
+    """Verify the coordinator's relay_set.first_seen_repair_stats is wired."""
+    # We don't drive the whole coordinator (it does real HTTP); instead we
+    # mimic the wiring: call correct_first_seen, then construct Relays,
+    # then verify the attribute can be set the same way coordinator does it.
+    fixture = _load_fixture()
+    relay_data = {
+        'version': fixture.get('version', '8.0'),
+        'relays_published': '2026-05-13 12:00:00',
+        'relays': list(fixture['relays'])[:3],
+    }
+    uptime_data = {'relays': []}
+
+    correct_first_seen(relay_data, uptime_data)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        relay_set = Relays(
+            output_dir=tmpdir,
+            onionoo_url='http://localhost',
+            relay_data=relay_data,
+            progress=False,
+        )
+
+    # Coordinator does: relay_set.first_seen_repair_stats = relay_data.get(...)
+    relay_set.first_seen_repair_stats = relay_data.get('_first_seen_correction_summary')
+
+    assert relay_set.first_seen_repair_stats is not None
+    assert relay_set.first_seen_repair_stats['total'] == 3
+    assert relay_set.first_seen_repair_stats['missing_uptime'] == 3
+    assert relay_set.first_seen_repair_stats['corrected'] == 0

--- a/tests/integration/test_first_seen_correction_integration.py
+++ b/tests/integration/test_first_seen_correction_integration.py
@@ -71,10 +71,10 @@ def test_correction_propagates_to_relays_sorted_categories():
     # grid (864000s = 10d, onionoo's actual 5_years interval), with a single
     # non-null value at index 0.
     #
-    # The correction module returns the LOWER BOUND of the earliest non-null
-    # interval (= first - interval/2) per onionoo's spec ("first is the
-    # midpoint of interval 0"). So the expected corrected value is
-    # first_dt - 5 days.
+    # The correction module returns the MIDPOINT of the earliest non-null
+    # interval (= `first` itself, when first non-null is at idx 0). This
+    # matches onionoo's documented point estimate for when the observation
+    # occurred.
     interval = 864000
     uptime_relays = []
     expected_corrected = {}
@@ -83,8 +83,8 @@ def test_correction_propagates_to_relays_sorted_categories():
         assert true_dt is not None
         first_dt = _floor_to_grid(true_dt, interval)
         first_str = first_dt.strftime('%Y-%m-%d %H:%M:%S')
-        expected_lower_bound = first_dt - timedelta(seconds=interval // 2)
-        expected_corrected[fp] = expected_lower_bound.strftime('%Y-%m-%d %H:%M:%S')
+        # idx=0 -> midpoint = first.
+        expected_corrected[fp] = first_str
         # Synthesise only the 5_years period for this test -- in real onionoo
         # data, shorter periods (1_year, 6_months, 1_month) only span the
         # last N units relative to today, so their values would be all-None
@@ -140,14 +140,13 @@ def test_correction_propagates_to_relays_sorted_categories():
         # metadata.
         assert relay['_first_seen_corrected'] is True
         assert relay['_first_seen_correction_source'] == 'onionoo_uptime'
-        # Corrected value is the lower bound of interval 0 = first - 5d,
-        # and first is at most `interval` (10 days) earlier than the true
-        # value due to grid-flooring. So corrected is in
-        # [true - interval - interval/2, true] = [true - 15d, true].
+        # Corrected value is the midpoint of interval 0 = `first`, which
+        # is at most one interval (10 days) earlier than the true value
+        # due to grid-flooring. So corrected is in [true - interval, true].
         corrected = parse_onionoo_timestamp(relay['first_seen'])
         true_dt = parse_onionoo_timestamp(true_first_seen[fp])
         assert corrected <= true_dt
-        max_gap = timedelta(seconds=interval + interval // 2)
+        max_gap = timedelta(seconds=interval)
         assert (true_dt - corrected) <= max_gap, (
             'fingerprint {}: gap {} exceeds max {} (true={}, corrected={})'.format(
                 fp, true_dt - corrected, max_gap, true_dt, corrected
@@ -282,31 +281,133 @@ def test_coordinator_create_relay_set_invokes_correction():
     with tempfile.TemporaryDirectory() as tmpdir:
         coord = Coordinator(output_dir=tmpdir, progress=False)
         coord.worker_data = {'onionoo_uptime': uptime_data}
-        # Patch enrich_with_api_data to a no-op; we're testing only the
-        # correction wiring and first_seen_repair_stats exposure here.
-        with patch.object(
-            type(coord),
-            'create_relay_set',
-            Coordinator.create_relay_set,
+        # Patch enrich_with_api_data to a no-op; building synthetic data
+        # complete enough for it would not exercise additional behaviour
+        # that our other tests don't cover.
+        with patch(
+            'allium.lib.relays.Relays.enrich_with_api_data',
+            return_value=None,
         ):
-            with patch(
-                'allium.lib.relays.Relays.enrich_with_api_data',
-                return_value=None,
-            ):
-                relay_set = coord.create_relay_set(relay_data)
+            relay_set = coord.create_relay_set(relay_data)
 
     assert relay_set is not None
     assert relay_set.first_seen_repair_stats['corrected'] == 1
     assert relay_set.first_seen_repair_stats['total'] == 1
 
     relay = relay_set.json['relays'][0]
-    # Lower bound = 2025-03-08 - 5d = 2025-03-03.
-    assert relay['first_seen'] == '2025-03-03 00:00:00'
+    # Midpoint at idx=0 == `first` == 2025-03-08.
+    assert relay['first_seen'] == '2025-03-08 00:00:00'
     assert relay['first_seen_onionoo_raw'] == '2026-04-06 23:00:00'
     assert relay['_first_seen_corrected'] is True
 
-    assert '2025-03-03' in relay_set.json['sorted']['first_seen']
+    assert '2025-03-08' in relay_set.json['sorted']['first_seen']
     assert '2026-04-06' not in relay_set.json['sorted']['first_seen']
+
+
+def test_corrected_first_seen_flows_into_network_health_metrics():
+    """Direct proof that network-health counters consume corrected dates.
+
+    Builds two relays:
+    - relay A: buggy `first_seen` (5 days ago) + uptime showing 18mo old
+    - relay B: legitimate new relay (no correction)
+
+    Asserts that after correction + network-health computation:
+    - new_relays_30d counts only relay B (1), not both
+    - new_relays_1y counts only relay B (1), not both
+    - network_mean_age_formatted reflects the corrected (older) date
+    """
+    from datetime import datetime, timedelta, timezone
+    from allium.lib.first_seen_correction import correct_first_seen
+    from allium.lib.relays import Relays
+
+    now = datetime.now(tz=timezone.utc)
+    five_days_ago = now - timedelta(days=5)
+    eighteen_months_ago = now - timedelta(days=18 * 30)
+
+    fp_a = 'AAAA' + 'A' * 36
+    fp_b = 'BBBB' + 'B' * 36
+
+    # Relay A: buggy reset state -- /details says new, /uptime says old.
+    # Relay B: legitimately new.
+    relay_a = {
+        'fingerprint': fp_a, 'nickname': 'oldrelay',
+        'first_seen': five_days_ago.strftime('%Y-%m-%d %H:%M:%S'),
+        'last_seen': now.strftime('%Y-%m-%d %H:%M:%S'),
+        'running': True, 'flags': ['Running', 'Valid', 'Stable'],
+        'or_addresses': ['10.0.0.1:9001'],
+        'observed_bandwidth': 100000, 'consensus_weight': 100,
+        'country': 'us', 'country_name': 'United States',
+        'platform': 'Tor 0.4.8.10 on Linux',
+    }
+    relay_b = {
+        'fingerprint': fp_b, 'nickname': 'newrelay',
+        'first_seen': five_days_ago.strftime('%Y-%m-%d %H:%M:%S'),
+        'last_seen': now.strftime('%Y-%m-%d %H:%M:%S'),
+        'running': True, 'flags': ['Running', 'Valid'],
+        'or_addresses': ['10.0.0.2:9001'],
+        'observed_bandwidth': 50000, 'consensus_weight': 50,
+        'country': 'us', 'country_name': 'United States',
+        'platform': 'Tor 0.4.8.10 on Linux',
+    }
+    relay_data = {
+        'version': '8.0',
+        'relays_published': now.strftime('%Y-%m-%d %H:%M:%S'),
+        'relays': [relay_a, relay_b],
+    }
+
+    # Uptime: A is 18mo old in uptime history, B is genuinely new (no uptime
+    # entry -- "missing_uptime" path; no correction applied).
+    uptime_data = {
+        'relays': [
+            {
+                'fingerprint': fp_a,
+                'uptime': {
+                    '5_years': {
+                        'first': eighteen_months_ago.strftime('%Y-%m-%d %H:%M:%S'),
+                        'last': now.strftime('%Y-%m-%d %H:%M:%S'),
+                        'interval': 864000,
+                        'count': 55,
+                        'values': [999] * 55,
+                    },
+                },
+            },
+        ],
+    }
+
+    correct_first_seen(relay_data, uptime_data)
+
+    # Sanity: A was corrected to ~18mo old, B was left as-is.
+    assert relay_a['_first_seen_corrected'] is True
+    assert '_first_seen_corrected' not in relay_b
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        relay_set = Relays(
+            output_dir=tmpdir, onionoo_url='http://localhost',
+            relay_data=relay_data, progress=False,
+        )
+        relay_set._calculate_network_health_metrics()
+
+    health = relay_set.json['network_health']
+
+    # With correction, only relay B (genuinely new) should be counted.
+    assert health['new_relays_30d'] == 1, (
+        'expected only 1 new relay in 30d (relay B); got {}; relay_a first_seen={}, '
+        'relay_b first_seen={}'.format(health['new_relays_30d'],
+                                       relay_a['first_seen'], relay_b['first_seen'])
+    )
+    assert health['new_relays_1y'] == 1, (
+        'expected only 1 new relay in 1y (relay B); got {}'.format(health['new_relays_1y'])
+    )
+
+    # Mean age should reflect the corrected (older) A: mean of ~5d and ~18mo.
+    mean_str = health.get('network_mean_age_formatted', '')
+    assert mean_str and 'Unknown' not in mean_str
+    # Loosely: at least 2 months old on average (one ~5d relay, one ~18mo
+    # relay -> mean ~9mo). Without correction it would be ~5d for both.
+    assert ('m' in mean_str or 'mo' in mean_str or 'y' in mean_str), (
+        'mean age {} does not include months/years -- correction may not have '
+        'propagated to network_health'.format(mean_str)
+    )
 
 
 def test_coordinator_create_relay_set_no_uptime_is_silent_noop():

--- a/tests/integration/test_first_seen_correction_integration.py
+++ b/tests/integration/test_first_seen_correction_integration.py
@@ -70,6 +70,11 @@ def test_correction_propagates_to_relays_sorted_categories():
     # Each relay's 5_years.first is the true first_seen floored to the 10-day
     # grid (864000s = 10d, onionoo's actual 5_years interval), with a single
     # non-null value at index 0.
+    #
+    # The correction module returns the LOWER BOUND of the earliest non-null
+    # interval (= first - interval/2) per onionoo's spec ("first is the
+    # midpoint of interval 0"). So the expected corrected value is
+    # first_dt - 5 days.
     interval = 864000
     uptime_relays = []
     expected_corrected = {}
@@ -78,7 +83,8 @@ def test_correction_propagates_to_relays_sorted_categories():
         assert true_dt is not None
         first_dt = _floor_to_grid(true_dt, interval)
         first_str = first_dt.strftime('%Y-%m-%d %H:%M:%S')
-        expected_corrected[fp] = first_str
+        expected_lower_bound = first_dt - timedelta(seconds=interval // 2)
+        expected_corrected[fp] = expected_lower_bound.strftime('%Y-%m-%d %H:%M:%S')
         # Synthesise only the 5_years period for this test -- in real onionoo
         # data, shorter periods (1_year, 6_months, 1_month) only span the
         # last N units relative to today, so their values would be all-None
@@ -134,12 +140,19 @@ def test_correction_propagates_to_relays_sorted_categories():
         # metadata.
         assert relay['_first_seen_corrected'] is True
         assert relay['_first_seen_correction_source'] == 'onionoo_uptime'
-        # corrected value is at most 10 days earlier than the true value
-        # (5_years bucket precision).
+        # Corrected value is the lower bound of interval 0 = first - 5d,
+        # and first is at most `interval` (10 days) earlier than the true
+        # value due to grid-flooring. So corrected is in
+        # [true - interval - interval/2, true] = [true - 15d, true].
         corrected = parse_onionoo_timestamp(relay['first_seen'])
         true_dt = parse_onionoo_timestamp(true_first_seen[fp])
         assert corrected <= true_dt
-        assert (true_dt - corrected) <= timedelta(seconds=interval)
+        max_gap = timedelta(seconds=interval + interval // 2)
+        assert (true_dt - corrected) <= max_gap, (
+            'fingerprint {}: gap {} exceeds max {} (true={}, corrected={})'.format(
+                fp, true_dt - corrected, max_gap, true_dt, corrected
+            )
+        )
 
     # ----- 3. Construct Relays() with the corrected data; check categorisation. -----
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/integration/test_first_seen_correction_integration.py
+++ b/tests/integration/test_first_seen_correction_integration.py
@@ -221,3 +221,131 @@ def test_coordinator_exposes_first_seen_repair_stats_on_relay_set():
     assert relay_set.first_seen_repair_stats['total'] == 3
     assert relay_set.first_seen_repair_stats['missing_uptime'] == 3
     assert relay_set.first_seen_repair_stats['corrected'] == 0
+
+
+def test_coordinator_create_relay_set_invokes_correction():
+    """End-to-end through Coordinator.create_relay_set without real HTTP.
+
+    Drives the full coordinator code path that wires correct_first_seen,
+    using a mocked worker_data dict for uptime. The downstream
+    `enrich_with_api_data` (network-health metrics, AROI leaderboards, etc.)
+    is patched to a no-op because building synthetic data complete enough
+    for it would not exercise anything additional that our other tests
+    don't already cover.
+
+    Verifies:
+    - correct_first_seen is invoked (relay's first_seen is repaired)
+    - relay_set.first_seen_repair_stats is set
+    - sorted['first_seen'] bucket reflects the corrected date
+    """
+    from unittest.mock import patch
+    from allium.lib.coordinator import Coordinator
+
+    fp = '0040E1791755D340BA8109F4C1849666582CF56C'
+    relay_data = {
+        'version': '8.0',
+        'relays_published': '2026-05-13 12:00:00',
+        'relays': [
+            {
+                'fingerprint': fp,
+                'nickname': 'testrelay',
+                'first_seen': '2026-04-06 23:00:00',
+                'last_seen': '2026-05-13 12:00:00',
+                'running': True,
+                'flags': ['Running', 'Valid'],
+                'or_addresses': ['10.0.0.1:9001'],
+                'observed_bandwidth': 100000,
+                'consensus_weight': 100,
+                'country': 'us',
+                'country_name': 'United States',
+            },
+        ],
+    }
+    uptime_data = {
+        'version': '8.0',
+        'relays': [
+            {
+                'fingerprint': fp,
+                'uptime': {
+                    '5_years': {
+                        'first': '2025-03-08 00:00:00',
+                        'last': '2026-05-13 00:00:00',
+                        'interval': 864000,
+                        'count': 43,
+                        'values': [999] * 43,
+                    },
+                },
+            },
+        ],
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coord = Coordinator(output_dir=tmpdir, progress=False)
+        coord.worker_data = {'onionoo_uptime': uptime_data}
+        # Patch enrich_with_api_data to a no-op; we're testing only the
+        # correction wiring and first_seen_repair_stats exposure here.
+        with patch.object(
+            type(coord),
+            'create_relay_set',
+            Coordinator.create_relay_set,
+        ):
+            with patch(
+                'allium.lib.relays.Relays.enrich_with_api_data',
+                return_value=None,
+            ):
+                relay_set = coord.create_relay_set(relay_data)
+
+    assert relay_set is not None
+    assert relay_set.first_seen_repair_stats['corrected'] == 1
+    assert relay_set.first_seen_repair_stats['total'] == 1
+
+    relay = relay_set.json['relays'][0]
+    # Lower bound = 2025-03-08 - 5d = 2025-03-03.
+    assert relay['first_seen'] == '2025-03-03 00:00:00'
+    assert relay['first_seen_onionoo_raw'] == '2026-04-06 23:00:00'
+    assert relay['_first_seen_corrected'] is True
+
+    assert '2025-03-03' in relay_set.json['sorted']['first_seen']
+    assert '2026-04-06' not in relay_set.json['sorted']['first_seen']
+
+
+def test_coordinator_create_relay_set_no_uptime_is_silent_noop():
+    """When --apis details (no uptime), correct_first_seen short-circuits."""
+    from unittest.mock import patch
+    from allium.lib.coordinator import Coordinator
+
+    fp = '0040E1791755D340BA8109F4C1849666582CF56C'
+    relay_data = {
+        'version': '8.0',
+        'relays_published': '2026-05-13 12:00:00',
+        'relays': [
+            {
+                'fingerprint': fp,
+                'nickname': 'testrelay',
+                'first_seen': '2026-04-06 23:00:00',
+                'last_seen': '2026-05-13 12:00:00',
+                'running': True,
+                'flags': ['Running', 'Valid'],
+                'or_addresses': ['10.0.0.1:9001'],
+                'observed_bandwidth': 100000,
+                'consensus_weight': 100,
+                'country': 'us',
+                'country_name': 'United States',
+            },
+        ],
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coord = Coordinator(output_dir=tmpdir, progress=False)
+        coord.worker_data = {}  # no uptime
+        with patch(
+            'allium.lib.relays.Relays.enrich_with_api_data',
+            return_value=None,
+        ):
+            relay_set = coord.create_relay_set(relay_data)
+
+    assert relay_set is not None
+    assert relay_set.first_seen_repair_stats['corrected'] == 0
+    assert relay_set.first_seen_repair_stats['missing_uptime'] == 1
+    assert relay_set.json['relays'][0]['first_seen'] == '2026-04-06 23:00:00'
+    assert 'first_seen_onionoo_raw' not in relay_set.json['relays'][0]

--- a/tests/system/test_first_seen_correction_live.py
+++ b/tests/system/test_first_seen_correction_live.py
@@ -1,0 +1,144 @@
+"""
+Live smoke test for the first_seen correction.
+
+Hits the live onionoo API (details + uptime endpoints) for AS36849 (1aeo.com)
+and verifies the correction either:
+
+* repairs the chali2na relay's first_seen to be at least 6 months earlier
+  than the raw value (current state -- upstream bug still present), OR
+* finds nothing to correct because chali2na already has a sensible
+  first_seen (upstream has been fixed -- treat as pass with info log).
+
+Anything in between (e.g., ~50% of 1aeo relays correctable but not chali2na)
+is treated as a regression.
+
+Marked slow + system so it's excluded from the default `pytest -m "not slow"`
+run. Invoke with:
+
+    pytest -m slow tests/system/test_first_seen_correction_live.py
+"""
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+try:
+    import urllib.request
+    import urllib.error
+except ImportError:  # pragma: no cover -- Py3
+    raise
+
+from allium.lib.first_seen_correction import correct_first_seen
+from allium.lib.time_utils import parse_onionoo_timestamp
+
+
+pytestmark = [pytest.mark.slow, pytest.mark.system]
+
+
+CHALI2NA_FP = '0040E1791755D340BA8109F4C1849666582CF56C'
+AS_QUERY = 'AS36849'
+ONIONOO_DETAILS = 'https://onionoo.torproject.org/details'
+ONIONOO_UPTIME = 'https://onionoo.torproject.org/uptime'
+
+
+def _fetch_json(url, timeout=30):
+    try:
+        req = urllib.request.Request(
+            url, headers={'User-Agent': 'allium-test/first-seen-smoke'}
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode('utf-8'))
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as e:
+        pytest.skip('live onionoo unreachable: {}: {}'.format(type(e).__name__, e))
+
+
+def test_chali2na_first_seen_repaired_or_already_correct():
+    details = _fetch_json(
+        '{}?as={}&fields=fingerprint,first_seen,nickname,running'.format(
+            ONIONOO_DETAILS, AS_QUERY
+        )
+    )
+    uptime = _fetch_json('{}?as={}'.format(ONIONOO_UPTIME, AS_QUERY))
+
+    relays = details.get('relays') or []
+    if not relays:
+        pytest.skip('no relays for AS36849 in live data')
+
+    # Locate chali2na if still present.
+    chali2na = next((r for r in relays if r.get('fingerprint') == CHALI2NA_FP), None)
+    if chali2na is None:
+        pytest.skip('chali2na ({}) not in live 1aeo AS query'.format(CHALI2NA_FP))
+
+    raw_first_seen = chali2na.get('first_seen')
+    assert raw_first_seen, 'chali2na has no first_seen in live details data'
+    raw_dt = parse_onionoo_timestamp(raw_first_seen)
+    assert raw_dt is not None
+
+    # Apply the correction.
+    correct_first_seen(details, uptime)
+
+    six_months_ago = datetime.now(tz=timezone.utc) - timedelta(days=180)
+
+    # Re-fetch chali2na from the (mutated) details.
+    chali2na_post = next(
+        (r for r in details['relays'] if r.get('fingerprint') == CHALI2NA_FP), None
+    )
+    assert chali2na_post is not None
+
+    corrected_first_seen = chali2na_post.get('first_seen')
+    corrected_dt = parse_onionoo_timestamp(corrected_first_seen)
+    assert corrected_dt is not None
+
+    if raw_dt < six_months_ago and not chali2na_post.get('_first_seen_corrected'):
+        # Upstream may have been fixed: raw first_seen is already older
+        # than 6 months ago AND no correction was applied. Pass with info.
+        sys.stderr.write(
+            "\nchali2na: raw first_seen {} is already older than 6mo; "
+            "upstream onionoo may be fixed.\n".format(raw_first_seen)
+        )
+        return
+
+    # Otherwise the bug is still live and we expect a correction.
+    assert chali2na_post.get('_first_seen_corrected') is True, (
+        'expected first_seen correction on chali2na but none was applied. '
+        'raw={}, corrected={}'.format(raw_first_seen, corrected_first_seen)
+    )
+    assert chali2na_post['first_seen_onionoo_raw'] == raw_first_seen
+    # Corrected value must be at least 6 months earlier than raw.
+    assert corrected_dt <= raw_dt - timedelta(days=180), (
+        'corrected first_seen ({}) must be >=6mo earlier than raw ({})'.format(
+            corrected_first_seen, raw_first_seen
+        )
+    )
+
+
+def test_correction_rate_for_1aeo_is_high_or_zero():
+    """Sanity check across the whole 1aeo operator.
+
+    Either:
+    * Upstream still buggy -> correction rate >= 80% across 1aeo.
+    * Upstream fixed       -> correction rate == 0%.
+    Anything in between is a regression worth investigating.
+    """
+    details = _fetch_json(
+        '{}?as={}&fields=fingerprint,first_seen,nickname,running'.format(
+            ONIONOO_DETAILS, AS_QUERY
+        )
+    )
+    uptime = _fetch_json('{}?as={}'.format(ONIONOO_UPTIME, AS_QUERY))
+
+    if not details.get('relays'):
+        pytest.skip('no relays for AS36849 in live data')
+
+    correct_first_seen(details, uptime)
+    stats = details['_first_seen_correction_summary']
+    total = stats['total']
+    corrected = stats['corrected']
+    ratio = corrected / total if total else 0.0
+
+    assert ratio == 0.0 or ratio >= 0.8, (
+        'unexpected correction rate {:.1%} ({}/{}); expected 0% (upstream fixed) '
+        'or >=80% (bug still live); stats={}'.format(ratio, corrected, total, stats)
+    )

--- a/tests/unit/test_first_seen_correction.py
+++ b/tests/unit/test_first_seen_correction.py
@@ -1,0 +1,623 @@
+"""
+Unit tests for allium.lib.first_seen_correction.
+
+Each test is small and focused. The module documentation in
+allium/lib/first_seen_correction.py explains the design rules; these tests
+codify them.
+"""
+
+import logging
+import re
+
+import pytest
+
+from allium.lib.first_seen_correction import (
+    FIRST_SEEN_FLOOR,
+    _earliest_uptime_timestamp,
+    correct_first_seen,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FP = '0040E1791755D340BA8109F4C1849666582CF56C'
+
+
+def _make_uptime(fingerprint=FP, periods=None):
+    """Build a minimal valid onionoo /uptime response.
+
+    ``periods`` is a dict of period name -> {first, interval, values, ...}.
+    """
+    if periods is None:
+        periods = {}
+    return {
+        'version': '8.0',
+        'relays_published': '2026-05-13 12:00:00',
+        'relays': [
+            {
+                'fingerprint': fingerprint,
+                'uptime': periods,
+            },
+        ],
+    }
+
+
+def _make_relay(first_seen='2026-04-06 23:00:00', fingerprint=FP):
+    return {
+        'fingerprint': fingerprint,
+        'first_seen': first_seen,
+        'nickname': 'test',
+    }
+
+
+def _make_relay_data(*relays):
+    return {'relays': list(relays)}
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path
+# ---------------------------------------------------------------------------
+
+def test_corrects_when_uptime_predates_first_seen():
+    relay = _make_relay(first_seen='2026-04-06 23:00:00')
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '2025-03-08 00:00:00',
+            'last': '2026-05-02 00:00:00',
+            'interval': 864000,
+            'count': 43,
+            'values': [999] * 43,
+        },
+    })
+    data = _make_relay_data(relay)
+
+    correct_first_seen(data, uptime)
+
+    assert relay['first_seen'] == '2025-03-08 00:00:00'
+    assert relay['first_seen_onionoo_raw'] == '2026-04-06 23:00:00'
+    assert relay['_first_seen_corrected'] is True
+    assert relay['_first_seen_correction_source'] == 'onionoo_uptime'
+    summary = data['_first_seen_correction_summary']
+    assert summary['corrected'] == 1
+    assert summary['total'] == 1
+
+
+# ---------------------------------------------------------------------------
+# 2-4. No-op short-circuits
+# ---------------------------------------------------------------------------
+
+def test_no_change_when_uptime_data_missing():
+    relay = _make_relay()
+    data = _make_relay_data(relay)
+    correct_first_seen(data, None)
+    assert relay['first_seen'] == '2026-04-06 23:00:00'
+    assert 'first_seen_onionoo_raw' not in relay
+    assert '_first_seen_corrected' not in relay
+    # Summary still stamped so callers (api_diagnostics) don't have to None-check.
+    assert data['_first_seen_correction_summary']['corrected'] == 0
+    assert data['_first_seen_correction_summary']['missing_uptime'] == 1
+
+
+def test_no_change_when_uptime_data_has_no_relays():
+    relay = _make_relay()
+    data = _make_relay_data(relay)
+    correct_first_seen(data, {'relays': []})
+    assert relay['first_seen'] == '2026-04-06 23:00:00'
+    assert 'first_seen_onionoo_raw' not in relay
+    assert data['_first_seen_correction_summary']['missing_uptime'] == 1
+
+
+def test_no_change_when_relay_data_has_no_relays():
+    data = {'relays': []}
+    correct_first_seen(data, _make_uptime())
+    assert data['relays'] == []
+    summary = data['_first_seen_correction_summary']
+    assert summary['total'] == 0
+    assert summary['corrected'] == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. Fingerprint missing from uptime
+# ---------------------------------------------------------------------------
+
+def test_no_change_when_fingerprint_not_in_uptime():
+    relay = _make_relay(fingerprint='AAAA' + 'B' * 36)
+    uptime = _make_uptime(  # different fingerprint
+        fingerprint='CCCC' + 'D' * 36,
+        periods={
+            '5_years': {
+                'first': '2020-01-01 00:00:00',
+                'interval': 864000,
+                'values': [999],
+            },
+        },
+    )
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    assert relay['first_seen'] == '2026-04-06 23:00:00'
+    assert 'first_seen_onionoo_raw' not in relay
+    assert data['_first_seen_correction_summary']['missing_uptime'] == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. Uptime starts AFTER first_seen
+# ---------------------------------------------------------------------------
+
+def test_no_change_when_uptime_starts_after_first_seen():
+    relay = _make_relay(first_seen='2025-01-01 00:00:00')
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '2025-01-03 00:00:00',  # 2 days AFTER first_seen
+            'interval': 864000,
+            'values': [999, 999, 999],
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    assert relay['first_seen'] == '2025-01-01 00:00:00'
+    assert 'first_seen_onionoo_raw' not in relay
+    assert data['_first_seen_correction_summary']['unchanged'] == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. Leading nulls in uptime values
+# ---------------------------------------------------------------------------
+
+def test_uses_first_non_null_index_when_leading_nulls():
+    relay = _make_relay(first_seen='2026-04-06 23:00:00')
+    # 3 leading Nones, then 999. Interval=864000s = 10 days.
+    # first=2025-03-08, idx=3 -> 2025-03-08 + 30 days = 2025-04-07.
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '2025-03-08 00:00:00',
+            'interval': 864000,
+            'values': [None, None, None, 999, 999],
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    assert relay['first_seen'] == '2025-04-07 00:00:00'
+
+
+# ---------------------------------------------------------------------------
+# 8. Zero is a valid observation
+# ---------------------------------------------------------------------------
+
+def test_zero_value_counts_as_observation():
+    relay = _make_relay(first_seen='2026-04-06 23:00:00')
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '2025-03-08 00:00:00',
+            'interval': 864000,
+            'values': [None, None, 0, 999],   # 0 = tracked-but-down, valid signal
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    # Should use idx=2 (the 0), not idx=3.
+    # 2025-03-08 + 20 days = 2025-03-28
+    assert relay['first_seen'] == '2025-03-28 00:00:00'
+
+
+# ---------------------------------------------------------------------------
+# 9. MIN across multiple periods
+# ---------------------------------------------------------------------------
+
+def test_picks_earliest_across_multiple_periods():
+    relay = _make_relay(first_seen='2026-04-06 23:00:00')
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '2024-01-01 00:00:00',
+            'interval': 864000,
+            'values': [None, None, None, None, None, 999],  # idx=5 -> 2024-02-20
+        },
+        '1_year': {
+            'first': '2025-05-13 00:00:00',
+            'interval': 172800,
+            'values': [999],
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    assert relay['first_seen'] == '2024-02-20 00:00:00'
+
+
+# ---------------------------------------------------------------------------
+# 10. All-None values
+# ---------------------------------------------------------------------------
+
+def test_handles_all_null_values():
+    relay = _make_relay()
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '2025-03-08 00:00:00',
+            'interval': 864000,
+            'values': [None] * 43,
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    assert relay['first_seen'] == '2026-04-06 23:00:00'
+    assert 'first_seen_onionoo_raw' not in relay
+    assert data['_first_seen_correction_summary']['no_signal'] == 1
+
+
+# ---------------------------------------------------------------------------
+# 11. Empty uptime dict
+# ---------------------------------------------------------------------------
+
+def test_handles_empty_uptime_dict():
+    relay = _make_relay()
+    uptime = _make_uptime(periods={})  # no periods at all
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    assert relay['first_seen'] == '2026-04-06 23:00:00'
+    assert data['_first_seen_correction_summary']['no_signal'] == 1
+
+
+# ---------------------------------------------------------------------------
+# 12. Malformed period (missing interval)
+# ---------------------------------------------------------------------------
+
+def test_handles_malformed_period_missing_interval():
+    relay = _make_relay(first_seen='2026-04-06 23:00:00')
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '2024-01-01 00:00:00',
+            # no interval
+            'values': [999],
+        },
+        '1_year': {
+            'first': '2025-05-13 00:00:00',
+            'interval': 172800,
+            'values': [999],
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    # 5_years skipped, 1_year used: 2025-05-13.
+    assert relay['first_seen'] == '2025-05-13 00:00:00'
+
+
+# ---------------------------------------------------------------------------
+# 13. Malformed period (unparseable first)
+# ---------------------------------------------------------------------------
+
+def test_handles_malformed_period_unparseable_first():
+    relay = _make_relay(first_seen='2026-04-06 23:00:00')
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': 'not a date',
+            'interval': 864000,
+            'values': [999],
+        },
+        '1_year': {
+            'first': '2025-05-13 00:00:00',
+            'interval': 172800,
+            'values': [999],
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)  # must not crash
+    assert relay['first_seen'] == '2025-05-13 00:00:00'
+
+
+# ---------------------------------------------------------------------------
+# 14. Unparseable relay first_seen
+# ---------------------------------------------------------------------------
+
+def test_handles_unparseable_first_seen_on_relay():
+    relay = _make_relay(first_seen='garbage')
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '2025-03-08 00:00:00',
+            'interval': 864000,
+            'values': [999],
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    # No change because we can't safely compare.
+    assert relay['first_seen'] == 'garbage'
+    assert 'first_seen_onionoo_raw' not in relay
+    assert data['_first_seen_correction_summary']['invalid_first_seen'] == 1
+
+
+def test_handles_missing_first_seen_on_relay():
+    relay = {'fingerprint': FP, 'nickname': 'no_fs'}
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '2025-03-08 00:00:00',
+            'interval': 864000,
+            'values': [999],
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    assert 'first_seen' not in relay
+    assert data['_first_seen_correction_summary']['invalid_first_seen'] == 1
+
+
+# ---------------------------------------------------------------------------
+# 15. Defensive floor (2004-01-01)
+# ---------------------------------------------------------------------------
+
+def test_rejects_pre_floor_timestamp():
+    relay = _make_relay(first_seen='2026-04-06 23:00:00')
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '1970-01-01 00:00:00',  # epoch-zero garbage, cf. issue #40028
+            'interval': 864000,
+            'values': [999],
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    assert relay['first_seen'] == '2026-04-06 23:00:00'
+    assert 'first_seen_onionoo_raw' not in relay
+    assert data['_first_seen_correction_summary']['rejected_floor'] == 1
+
+
+def test_floor_constant_is_2004():
+    """Documents the chosen floor value -- changes should be reviewed."""
+    from datetime import datetime, timezone
+    assert FIRST_SEEN_FLOOR == datetime(2004, 1, 1, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# 16. Original value preserved only when changed
+# ---------------------------------------------------------------------------
+
+def test_first_seen_onionoo_raw_only_added_when_changed():
+    # Two relays: one corrected, one untouched (uptime starts later).
+    relay_a = _make_relay(first_seen='2026-04-06 23:00:00',
+                          fingerprint='AAAA' + 'A' * 36)
+    relay_b = _make_relay(first_seen='2025-01-01 00:00:00',
+                          fingerprint='BBBB' + 'B' * 36)
+    uptime = {
+        'relays': [
+            {
+                'fingerprint': 'AAAA' + 'A' * 36,
+                'uptime': {
+                    '5_years': {
+                        'first': '2025-03-08 00:00:00',
+                        'interval': 864000,
+                        'values': [999],
+                    },
+                },
+            },
+            {
+                'fingerprint': 'BBBB' + 'B' * 36,
+                'uptime': {
+                    '5_years': {
+                        'first': '2025-03-08 00:00:00',  # AFTER B's first_seen
+                        'interval': 864000,
+                        'values': [999],
+                    },
+                },
+            },
+        ],
+    }
+    data = _make_relay_data(relay_a, relay_b)
+    correct_first_seen(data, uptime)
+
+    # A: corrected -> raw preserved
+    assert relay_a['first_seen'] == '2025-03-08 00:00:00'
+    assert relay_a['first_seen_onionoo_raw'] == '2026-04-06 23:00:00'
+    assert relay_a['_first_seen_corrected'] is True
+
+    # B: untouched -> no metadata fields
+    assert relay_b['first_seen'] == '2025-01-01 00:00:00'
+    assert 'first_seen_onionoo_raw' not in relay_b
+    assert '_first_seen_corrected' not in relay_b
+    assert '_first_seen_correction_source' not in relay_b
+
+
+# ---------------------------------------------------------------------------
+# 17. Output format exact
+# ---------------------------------------------------------------------------
+
+def test_output_format_is_onionoo_standard():
+    relay = _make_relay(first_seen='2026-04-06 23:00:00')
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '2025-03-08 00:00:00',
+            'interval': 864000,
+            'values': [999],
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    # No 'T' separator, no timezone suffix, no microseconds.
+    assert re.match(r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$', relay['first_seen'])
+
+
+# ---------------------------------------------------------------------------
+# 18. Summary counters
+# ---------------------------------------------------------------------------
+
+def test_summary_counters():
+    # 6 relays exercising every counter except total.
+    fps = ['{}{}'.format(c, c * 39) for c in 'ABCDEF']
+
+    # Relay A: corrected.
+    relay_a = _make_relay(first_seen='2026-04-06 23:00:00', fingerprint=fps[0])
+    # Relay B: unchanged-newer.
+    relay_b = _make_relay(first_seen='2025-01-01 00:00:00', fingerprint=fps[1])
+    # Relay C: missing-uptime (fingerprint absent from uptime).
+    relay_c = _make_relay(first_seen='2026-04-06 23:00:00', fingerprint=fps[2])
+    # Relay D: no-signal (all None values).
+    relay_d = _make_relay(first_seen='2026-04-06 23:00:00', fingerprint=fps[3])
+    # Relay E: rejected-floor (epoch zero).
+    relay_e = _make_relay(first_seen='2026-04-06 23:00:00', fingerprint=fps[4])
+    # Relay F: invalid first_seen.
+    relay_f = _make_relay(first_seen='garbage', fingerprint=fps[5])
+
+    uptime = {
+        'relays': [
+            {'fingerprint': fps[0], 'uptime': {'5_years': {
+                'first': '2025-03-08 00:00:00', 'interval': 864000, 'values': [999]}}},
+            {'fingerprint': fps[1], 'uptime': {'5_years': {
+                'first': '2025-06-01 00:00:00', 'interval': 864000, 'values': [999]}}},
+            # fps[2]: omitted -> missing_uptime
+            {'fingerprint': fps[3], 'uptime': {'5_years': {
+                'first': '2025-03-08 00:00:00', 'interval': 864000, 'values': [None, None]}}},
+            {'fingerprint': fps[4], 'uptime': {'5_years': {
+                'first': '1970-01-01 00:00:00', 'interval': 864000, 'values': [999]}}},
+            {'fingerprint': fps[5], 'uptime': {'5_years': {
+                'first': '2025-03-08 00:00:00', 'interval': 864000, 'values': [999]}}},
+        ],
+    }
+    data = _make_relay_data(relay_a, relay_b, relay_c, relay_d, relay_e, relay_f)
+
+    correct_first_seen(data, uptime)
+
+    summary = data['_first_seen_correction_summary']
+    assert summary == {
+        'total': 6,
+        'corrected': 1,
+        'unchanged': 1,
+        'missing_uptime': 1,
+        'no_signal': 1,
+        'rejected_floor': 1,
+        'invalid_first_seen': 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 19. Progress logger called once
+# ---------------------------------------------------------------------------
+
+def test_progress_logger_called_once_with_summary():
+    """ProgressLogger-style logger -- the most common case in production."""
+    class FakeProgress(object):
+        def __init__(self):
+            self.calls = []
+
+        def log_without_increment(self, message):
+            self.calls.append(message)
+
+    relay = _make_relay()
+    uptime = _make_uptime(periods={
+        '5_years': {'first': '2025-03-08 00:00:00', 'interval': 864000, 'values': [999]},
+    })
+    data = _make_relay_data(relay)
+    fake = FakeProgress()
+    correct_first_seen(data, uptime, progress_logger=fake)
+    assert len(fake.calls) == 1
+    assert '1/1' in fake.calls[0]
+    assert 'first-seen' in fake.calls[0].lower() or 'first_seen' in fake.calls[0].lower()
+
+
+# ---------------------------------------------------------------------------
+# 20. Logger shape agnostic
+# ---------------------------------------------------------------------------
+
+def test_logger_shape_agnostic():
+    relay = _make_relay()
+    uptime = _make_uptime(periods={
+        '5_years': {'first': '2025-03-08 00:00:00', 'interval': 864000, 'values': [999]},
+    })
+
+    # (a) ProgressLogger-like
+    class ProgressLike(object):
+        def __init__(self):
+            self.calls = []
+
+        def log_without_increment(self, msg):
+            self.calls.append(msg)
+
+    p = ProgressLike()
+    correct_first_seen(_make_relay_data(_make_relay()), uptime, progress_logger=p)
+    assert len(p.calls) == 1
+
+    # (b) logging.Logger-like
+    captured = []
+    logger = logging.getLogger('first_seen_correction_test')
+    logger.setLevel(logging.DEBUG)
+    # Install a handler that captures records.
+    class CaptureHandler(logging.Handler):
+        def emit(self, record):
+            captured.append(record.getMessage())
+    handler = CaptureHandler()
+    logger.addHandler(handler)
+    try:
+        correct_first_seen(_make_relay_data(_make_relay()), uptime,
+                           progress_logger=logger)
+        assert len(captured) == 1
+    finally:
+        logger.removeHandler(handler)
+
+    # (c) bare callable
+    captured_callable = []
+    correct_first_seen(_make_relay_data(_make_relay()), uptime,
+                       progress_logger=lambda msg: captured_callable.append(msg))
+    assert len(captured_callable) == 1
+
+    # (d) None -- no crash
+    correct_first_seen(_make_relay_data(_make_relay()), uptime,
+                       progress_logger=None)
+
+    # (e) noisy logger -- must not propagate
+    def raising_logger(msg):
+        raise RuntimeError('boom')
+
+    correct_first_seen(_make_relay_data(_make_relay()), uptime,
+                       progress_logger=raising_logger)
+
+
+# ---------------------------------------------------------------------------
+# 21. Correction metadata fields gated on actual change
+# ---------------------------------------------------------------------------
+
+def test_correction_metadata_fields_set_only_on_corrected_relays():
+    # Already tested in test_first_seen_onionoo_raw_only_added_when_changed,
+    # but assert the two metadata fields specifically here too.
+    relay_corrected = _make_relay(fingerprint='AAAA' + 'A' * 36)
+    relay_unchanged = _make_relay(first_seen='2024-01-01 00:00:00',
+                                  fingerprint='BBBB' + 'B' * 36)
+
+    uptime = {
+        'relays': [
+            {'fingerprint': 'AAAA' + 'A' * 36, 'uptime': {'5_years': {
+                'first': '2025-03-08 00:00:00', 'interval': 864000, 'values': [999]}}},
+            {'fingerprint': 'BBBB' + 'B' * 36, 'uptime': {'5_years': {
+                'first': '2024-06-01 00:00:00', 'interval': 864000, 'values': [999]}}},
+        ],
+    }
+    data = _make_relay_data(relay_corrected, relay_unchanged)
+    correct_first_seen(data, uptime)
+
+    assert relay_corrected.get('_first_seen_corrected') is True
+    assert relay_corrected.get('_first_seen_correction_source') == 'onionoo_uptime'
+
+    assert '_first_seen_corrected' not in relay_unchanged
+    assert '_first_seen_correction_source' not in relay_unchanged
+
+
+# ---------------------------------------------------------------------------
+# Direct tests of _earliest_uptime_timestamp helper
+# ---------------------------------------------------------------------------
+
+def test_earliest_uptime_timestamp_returns_none_for_non_dict():
+    assert _earliest_uptime_timestamp(None) is None
+    assert _earliest_uptime_timestamp('garbage') is None
+    assert _earliest_uptime_timestamp([]) is None
+    assert _earliest_uptime_timestamp({'uptime': 'not-a-dict'}) is None
+
+
+def test_earliest_uptime_timestamp_skips_negative_interval():
+    """Defensive: a negative or zero interval must not be used."""
+    uptime_relay = {
+        'fingerprint': FP,
+        'uptime': {
+            '5_years': {
+                'first': '2025-03-08 00:00:00',
+                'interval': -1,
+                'values': [999],
+            },
+        },
+    }
+    assert _earliest_uptime_timestamp(uptime_relay) is None

--- a/tests/unit/test_first_seen_correction.py
+++ b/tests/unit/test_first_seen_correction.py
@@ -75,7 +75,10 @@ def test_corrects_when_uptime_predates_first_seen():
 
     correct_first_seen(data, uptime)
 
-    assert relay['first_seen'] == '2025-03-08 00:00:00'
+    # Per onionoo spec, `first` is the midpoint of interval 0; the strict
+    # lower bound for "earliest possible observation in interval 0" is
+    # `first - interval/2 = 2025-03-08 - 5d = 2025-03-03`.
+    assert relay['first_seen'] == '2025-03-03 00:00:00'
     assert relay['first_seen_onionoo_raw'] == '2026-04-06 23:00:00'
     assert relay['_first_seen_corrected'] is True
     assert relay['_first_seen_correction_source'] == 'onionoo_uptime'
@@ -167,8 +170,10 @@ def test_no_change_when_uptime_starts_after_first_seen():
 
 def test_uses_first_non_null_index_when_leading_nulls():
     relay = _make_relay(first_seen='2026-04-06 23:00:00')
-    # 3 leading Nones, then 999. Interval=864000s = 10 days.
-    # first=2025-03-08, idx=3 -> 2025-03-08 + 30 days = 2025-04-07.
+    # 3 leading Nones, then 999. Interval=864000s = 10 days, half = 5 days.
+    # first=2025-03-08 (midpoint of interval 0), idx=3 -> midpoint of interval 3
+    # is 2025-03-08 + 30 days = 2025-04-07; lower bound = 2025-04-07 - 5d
+    # = 2025-04-02.
     uptime = _make_uptime(periods={
         '5_years': {
             'first': '2025-03-08 00:00:00',
@@ -178,7 +183,7 @@ def test_uses_first_non_null_index_when_leading_nulls():
     })
     data = _make_relay_data(relay)
     correct_first_seen(data, uptime)
-    assert relay['first_seen'] == '2025-04-07 00:00:00'
+    assert relay['first_seen'] == '2025-04-02 00:00:00'
 
 
 # ---------------------------------------------------------------------------
@@ -197,8 +202,9 @@ def test_zero_value_counts_as_observation():
     data = _make_relay_data(relay)
     correct_first_seen(data, uptime)
     # Should use idx=2 (the 0), not idx=3.
-    # 2025-03-08 + 20 days = 2025-03-28
-    assert relay['first_seen'] == '2025-03-28 00:00:00'
+    # Midpoint of interval 2 = 2025-03-08 + 20 days = 2025-03-28
+    # Lower bound = 2025-03-28 - 5d = 2025-03-23
+    assert relay['first_seen'] == '2025-03-23 00:00:00'
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +227,9 @@ def test_picks_earliest_across_multiple_periods():
     })
     data = _make_relay_data(relay)
     correct_first_seen(data, uptime)
-    assert relay['first_seen'] == '2024-02-20 00:00:00'
+    # idx=5 in 5_years bucket: midpoint = 2024-01-01 + 50d = 2024-02-20
+    # Lower bound = 2024-02-20 - 5d = 2024-02-15.
+    assert relay['first_seen'] == '2024-02-15 00:00:00'
 
 
 # ---------------------------------------------------------------------------
@@ -277,8 +285,9 @@ def test_handles_malformed_period_missing_interval():
     })
     data = _make_relay_data(relay)
     correct_first_seen(data, uptime)
-    # 5_years skipped, 1_year used: 2025-05-13.
-    assert relay['first_seen'] == '2025-05-13 00:00:00'
+    # 5_years skipped (no interval), 1_year used: 2025-05-13 minus 1_year
+    # half-interval (172800s / 2 = 1d) = 2025-05-12.
+    assert relay['first_seen'] == '2025-05-12 00:00:00'
 
 
 # ---------------------------------------------------------------------------
@@ -301,7 +310,9 @@ def test_handles_malformed_period_unparseable_first():
     })
     data = _make_relay_data(relay)
     correct_first_seen(data, uptime)  # must not crash
-    assert relay['first_seen'] == '2025-05-13 00:00:00'
+    # 5_years skipped (unparseable `first`), 1_year used: 2025-05-13 - 1d
+    # (half of 172800s interval).
+    assert relay['first_seen'] == '2025-05-12 00:00:00'
 
 
 # ---------------------------------------------------------------------------
@@ -403,8 +414,10 @@ def test_first_seen_onionoo_raw_only_added_when_changed():
     data = _make_relay_data(relay_a, relay_b)
     correct_first_seen(data, uptime)
 
-    # A: corrected -> raw preserved
-    assert relay_a['first_seen'] == '2025-03-08 00:00:00'
+    # A: corrected -> raw preserved.
+    # idx=0 with first=2025-03-08, interval=864000 (half=5d), lower bound
+    # = 2025-03-03.
+    assert relay_a['first_seen'] == '2025-03-03 00:00:00'
     assert relay_a['first_seen_onionoo_raw'] == '2026-04-06 23:00:00'
     assert relay_a['_first_seen_corrected'] is True
 
@@ -621,3 +634,54 @@ def test_earliest_uptime_timestamp_skips_negative_interval():
         },
     }
     assert _earliest_uptime_timestamp(uptime_relay) is None
+
+
+# ---------------------------------------------------------------------------
+# Upper-bound comparison: avoid spurious "corrections" when /details and
+# /uptime are already in agreement to within bucket precision.
+# ---------------------------------------------------------------------------
+
+def test_no_spurious_correction_when_first_seen_falls_inside_uptime_interval():
+    """If /details' first_seen falls inside the uptime interval, the relay
+    could have been first observed at that exact time -- /details and /uptime
+    don't disagree, so no correction.
+    """
+    # Uptime: first=2025-01-03 (midpoint), interval=864000 (10d, half=5d).
+    # Interval 0 covers [2024-12-29, 2025-01-08].
+    # /details first_seen=2025-01-05 falls INSIDE this interval -- consistent.
+    relay = _make_relay(first_seen='2025-01-05 00:00:00')
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '2025-01-03 00:00:00',
+            'interval': 864000,
+            'values': [999, 999],
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    assert relay['first_seen'] == '2025-01-05 00:00:00'
+    assert 'first_seen_onionoo_raw' not in relay
+    assert data['_first_seen_correction_summary']['unchanged'] == 1
+
+
+def test_corrects_when_first_seen_just_past_upper_bound():
+    """When /details first_seen is just past the upper bound of uptime's
+    earliest non-null interval, correction must trigger and yield the lower
+    bound of that interval.
+    """
+    # Uptime: first=2025-01-03 (midpoint), interval=864000s (10d, half=5d).
+    # Interval 0 covers [2024-12-29, 2025-01-08].
+    # /details first_seen=2025-01-09 is 1 day past upper bound -> correct.
+    relay = _make_relay(first_seen='2025-01-09 00:00:00')
+    uptime = _make_uptime(periods={
+        '5_years': {
+            'first': '2025-01-03 00:00:00',
+            'interval': 864000,
+            'values': [999],
+        },
+    })
+    data = _make_relay_data(relay)
+    correct_first_seen(data, uptime)
+    # Corrected to lower bound = 2025-01-03 - 5d = 2024-12-29
+    assert relay['first_seen'] == '2024-12-29 00:00:00'
+    assert relay['first_seen_onionoo_raw'] == '2025-01-09 00:00:00'

--- a/tests/unit/test_first_seen_correction.py
+++ b/tests/unit/test_first_seen_correction.py
@@ -75,10 +75,11 @@ def test_corrects_when_uptime_predates_first_seen():
 
     correct_first_seen(data, uptime)
 
-    # Per onionoo spec, `first` is the midpoint of interval 0; the strict
-    # lower bound for "earliest possible observation in interval 0" is
-    # `first - interval/2 = 2025-03-08 - 5d = 2025-03-03`.
-    assert relay['first_seen'] == '2025-03-03 00:00:00'
+    # Per onionoo spec, `first` is the midpoint of interval 0 -- onionoo's
+    # documented point estimate for when the observation occurred. Allium
+    # displays first_seen as an exact date, so we use the midpoint rather
+    # than the lower bound that would predate the relay's existence.
+    assert relay['first_seen'] == '2025-03-08 00:00:00'
     assert relay['first_seen_onionoo_raw'] == '2026-04-06 23:00:00'
     assert relay['_first_seen_corrected'] is True
     assert relay['_first_seen_correction_source'] == 'onionoo_uptime'
@@ -170,10 +171,9 @@ def test_no_change_when_uptime_starts_after_first_seen():
 
 def test_uses_first_non_null_index_when_leading_nulls():
     relay = _make_relay(first_seen='2026-04-06 23:00:00')
-    # 3 leading Nones, then 999. Interval=864000s = 10 days, half = 5 days.
+    # 3 leading Nones, then 999. Interval=864000s = 10 days.
     # first=2025-03-08 (midpoint of interval 0), idx=3 -> midpoint of interval 3
-    # is 2025-03-08 + 30 days = 2025-04-07; lower bound = 2025-04-07 - 5d
-    # = 2025-04-02.
+    # is 2025-03-08 + 30 days = 2025-04-07.
     uptime = _make_uptime(periods={
         '5_years': {
             'first': '2025-03-08 00:00:00',
@@ -183,7 +183,7 @@ def test_uses_first_non_null_index_when_leading_nulls():
     })
     data = _make_relay_data(relay)
     correct_first_seen(data, uptime)
-    assert relay['first_seen'] == '2025-04-02 00:00:00'
+    assert relay['first_seen'] == '2025-04-07 00:00:00'
 
 
 # ---------------------------------------------------------------------------
@@ -202,9 +202,8 @@ def test_zero_value_counts_as_observation():
     data = _make_relay_data(relay)
     correct_first_seen(data, uptime)
     # Should use idx=2 (the 0), not idx=3.
-    # Midpoint of interval 2 = 2025-03-08 + 20 days = 2025-03-28
-    # Lower bound = 2025-03-28 - 5d = 2025-03-23
-    assert relay['first_seen'] == '2025-03-23 00:00:00'
+    # Midpoint of interval 2 = 2025-03-08 + 20 days = 2025-03-28.
+    assert relay['first_seen'] == '2025-03-28 00:00:00'
 
 
 # ---------------------------------------------------------------------------
@@ -227,9 +226,8 @@ def test_picks_earliest_across_multiple_periods():
     })
     data = _make_relay_data(relay)
     correct_first_seen(data, uptime)
-    # idx=5 in 5_years bucket: midpoint = 2024-01-01 + 50d = 2024-02-20
-    # Lower bound = 2024-02-20 - 5d = 2024-02-15.
-    assert relay['first_seen'] == '2024-02-15 00:00:00'
+    # idx=5 in 5_years bucket: midpoint = 2024-01-01 + 50d = 2024-02-20.
+    assert relay['first_seen'] == '2024-02-20 00:00:00'
 
 
 # ---------------------------------------------------------------------------
@@ -285,9 +283,9 @@ def test_handles_malformed_period_missing_interval():
     })
     data = _make_relay_data(relay)
     correct_first_seen(data, uptime)
-    # 5_years skipped (no interval), 1_year used: 2025-05-13 minus 1_year
-    # half-interval (172800s / 2 = 1d) = 2025-05-12.
-    assert relay['first_seen'] == '2025-05-12 00:00:00'
+    # 5_years skipped (no interval), 1_year used: midpoint at idx=0 is
+    # exactly `first` = 2025-05-13.
+    assert relay['first_seen'] == '2025-05-13 00:00:00'
 
 
 # ---------------------------------------------------------------------------
@@ -310,9 +308,9 @@ def test_handles_malformed_period_unparseable_first():
     })
     data = _make_relay_data(relay)
     correct_first_seen(data, uptime)  # must not crash
-    # 5_years skipped (unparseable `first`), 1_year used: 2025-05-13 - 1d
-    # (half of 172800s interval).
-    assert relay['first_seen'] == '2025-05-12 00:00:00'
+    # 5_years skipped (unparseable `first`), 1_year used: midpoint at idx=0
+    # is exactly `first` = 2025-05-13.
+    assert relay['first_seen'] == '2025-05-13 00:00:00'
 
 
 # ---------------------------------------------------------------------------
@@ -415,9 +413,8 @@ def test_first_seen_onionoo_raw_only_added_when_changed():
     correct_first_seen(data, uptime)
 
     # A: corrected -> raw preserved.
-    # idx=0 with first=2025-03-08, interval=864000 (half=5d), lower bound
-    # = 2025-03-03.
-    assert relay_a['first_seen'] == '2025-03-03 00:00:00'
+    # idx=0 with first=2025-03-08 -- midpoint at idx=0 is exactly `first`.
+    assert relay_a['first_seen'] == '2025-03-08 00:00:00'
     assert relay_a['first_seen_onionoo_raw'] == '2026-04-06 23:00:00'
     assert relay_a['_first_seen_corrected'] is True
 
@@ -496,7 +493,13 @@ def test_summary_counters():
         'no_signal': 1,
         'rejected_floor': 1,
         'invalid_first_seen': 1,
+        'non_dict_skipped': 0,
     }
+    # The classification counters sum exactly to `total`.
+    classified = (summary['corrected'] + summary['unchanged']
+                  + summary['missing_uptime'] + summary['no_signal']
+                  + summary['rejected_floor'] + summary['invalid_first_seen'])
+    assert classified == summary['total']
 
 
 # ---------------------------------------------------------------------------
@@ -665,7 +668,8 @@ def test_no_spurious_correction_when_first_seen_falls_inside_uptime_interval():
 
 
 def test_relays_list_with_non_dict_entries_is_robust():
-    """Defensive: a non-dict entry in relays must not crash anything."""
+    """Defensive: a non-dict entry in relays must not crash anything; it's
+    counted under non_dict_skipped (outside ``total``)."""
     data = {'relays': [_make_relay(), 'garbage', None, 42]}
     uptime = _make_uptime(periods={
         '5_years': {'first': '2025-03-08 00:00:00', 'interval': 864000,
@@ -674,6 +678,10 @@ def test_relays_list_with_non_dict_entries_is_robust():
     correct_first_seen(data, uptime)
     # The real relay was corrected; the garbage entries were silently skipped.
     assert data['relays'][0]['_first_seen_corrected'] is True
+    summary = data['_first_seen_correction_summary']
+    assert summary['total'] == 1, 'total counts only dict relays'
+    assert summary['corrected'] == 1
+    assert summary['non_dict_skipped'] == 3, '3 garbage entries skipped'
 
 
 def test_relays_field_is_dict_not_list_is_robust():
@@ -701,8 +709,8 @@ def test_uptime_data_is_garbage_string():
 
 def test_corrects_when_first_seen_just_past_upper_bound():
     """When /details first_seen is just past the upper bound of uptime's
-    earliest non-null interval, correction must trigger and yield the lower
-    bound of that interval.
+    earliest non-null interval, correction must trigger and yield the
+    interval midpoint.
     """
     # Uptime: first=2025-01-03 (midpoint), interval=864000s (10d, half=5d).
     # Interval 0 covers [2024-12-29, 2025-01-08].
@@ -717,6 +725,6 @@ def test_corrects_when_first_seen_just_past_upper_bound():
     })
     data = _make_relay_data(relay)
     correct_first_seen(data, uptime)
-    # Corrected to lower bound = 2025-01-03 - 5d = 2024-12-29
-    assert relay['first_seen'] == '2024-12-29 00:00:00'
+    # Corrected to midpoint = 2025-01-03 (== `first` for idx=0).
+    assert relay['first_seen'] == '2025-01-03 00:00:00'
     assert relay['first_seen_onionoo_raw'] == '2025-01-09 00:00:00'

--- a/tests/unit/test_first_seen_correction.py
+++ b/tests/unit/test_first_seen_correction.py
@@ -664,6 +664,41 @@ def test_no_spurious_correction_when_first_seen_falls_inside_uptime_interval():
     assert data['_first_seen_correction_summary']['unchanged'] == 1
 
 
+def test_relays_list_with_non_dict_entries_is_robust():
+    """Defensive: a non-dict entry in relays must not crash anything."""
+    data = {'relays': [_make_relay(), 'garbage', None, 42]}
+    uptime = _make_uptime(periods={
+        '5_years': {'first': '2025-03-08 00:00:00', 'interval': 864000,
+                    'values': [999]},
+    })
+    correct_first_seen(data, uptime)
+    # The real relay was corrected; the garbage entries were silently skipped.
+    assert data['relays'][0]['_first_seen_corrected'] is True
+
+
+def test_relays_field_is_dict_not_list_is_robust():
+    """Defensive: relay_data['relays'] is a dict, not a list."""
+    data = {'relays': {'oops': 'this should be a list'}}
+    correct_first_seen(data, _make_uptime())
+    # Short-circuited; summary has total=0.
+    assert data['_first_seen_correction_summary']['total'] == 0
+
+
+def test_relay_data_none_returns_none():
+    """correct_first_seen(None, ...) must not crash."""
+    result = correct_first_seen(None, _make_uptime())
+    assert result is None
+
+
+def test_uptime_data_is_garbage_string():
+    """If uptime_data is not a dict at all, treat as missing."""
+    relay = _make_relay()
+    data = _make_relay_data(relay)
+    correct_first_seen(data, 'not a dict')
+    assert relay['first_seen'] == '2026-04-06 23:00:00'
+    assert data['_first_seen_correction_summary']['missing_uptime'] == 1
+
+
 def test_corrects_when_first_seen_just_past_upper_bound():
     """When /details first_seen is just past the upper bound of uptime's
     earliest non-null interval, correction must trigger and yield the lower

--- a/tests/unit/test_first_seen_correction.py
+++ b/tests/unit/test_first_seen_correction.py
@@ -122,6 +122,20 @@ def test_no_change_when_relay_data_has_no_relays():
     assert summary['corrected'] == 0
 
 
+def test_empty_relays_branch_emits_summary_log():
+    """Docstring promises the no-corrections branches also log in progress
+    mode. Lock that contract in for the empty-relays branch (other branches
+    are covered by test_progress_logger_called_once_with_summary)."""
+    captured = []
+    correct_first_seen(
+        {'relays': []},
+        _make_uptime(),
+        progress_logger=lambda msg: captured.append(msg),
+    )
+    assert len(captured) == 1
+    assert '0/0' in captured[0]
+
+
 # ---------------------------------------------------------------------------
 # 5. Fingerprint missing from uptime
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This pull request contains changes generated by a Cursor Cloud Agent
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b481f75-90c9-494b-9043-1da6c0f1280b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b481f75-90c9-494b-9043-1da6c0f1280b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic correction of relay first-seen timestamps using Onionoo uptime history; per-run repair statistics are surfaced and improve relay-age and network-health metrics.

* **Documentation**
  * README and API integration docs updated with first-seen correction behavior and uptime-history details.

* **Tests**
  * New unit, integration, and live system tests validating correction logic, metrics propagation, and no-op behavior when uptime is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1aeo/allium/pull/210)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->