### PR TITLE
Add codebase review plans: simplification, LOC reduction, and bug fixes

### DIFF
--- a/docs/development/plans/bug-fix-plan.md
+++ b/docs/development/plans/bug-fix-plan.md
@@ -54,12 +54,21 @@ as `&lt;admin AT my-mail dot rocks&gt;`):
 - `index.html` (AROI leaderboards): 71 occurrences
 - `top500.html`: 61 occurrences
 
-**Fix.** Pick one escaping strategy. Recommended: keep autoescape as the single source of
-truth — change the pre-computed fields to carry **raw** values (or drop the `_escaped`
-suffix fields and reference raw fields in templates), and remove the redundant
-`html.escape()` calls in `html_escape_utils.py` / `aroileaders.py`
-(`contact_info_escaped`). Do NOT sprinkle `|safe` on the pre-escaped fields — that
-re-introduces XSS risk if any call site forgets to pre-escape.
+**Fix. DECISION: keep escaping logic in Python (Jinja2 is slower); wrap pre-escaped
+strings in `markupsafe.Markup`.** Python-side pre-escaping stays — it was introduced
+for render performance and template logic should stay minimal. To stop the
+double-escaping, have the Python escaping helpers (`html_escape_utils.py`,
+`contact_info_escaped` in `aroileaders.py`, and any other `*_escaped` producers) return
+`markupsafe.Markup(html.escape(value))` instead of a plain `str`. Autoescape treats
+`Markup` as already-safe and will not re-escape it, while remaining on as the safety
+net for every raw field. Rules:
+
+- Only wrap strings in `Markup` at the point they pass through `html.escape()` (or are
+  built exclusively from already-escaped parts, like `_flags_html`). Never wrap raw
+  onionoo data.
+- Do NOT sprinkle `|safe` in templates — `Markup` at the Python source centralizes the
+  safety decision at the same place the escaping happens.
+- `markupsafe` is a hard dependency of Jinja2, so this adds no new dependency.
 
 **Expected diff.** Large but mechanical: affected pages change `&amp;amp;` → `&amp;`,
 `&amp;lt;` → `&lt;`, etc. Verify by grepping the after-output:
@@ -108,10 +117,21 @@ and `Exit` flags increments `guard`, `exit`, **and** `middle` buckets. `contact.
 (line ~328) sums the three buckets into `total_offline`, so one offline Guard+Exit relay
 counts as 3. Per-role offline bandwidth percentages can also exceed 100%.
 
-**Fix.** Count each relay once for the total (unique fingerprints); keep per-role detail
-lists if desired but make the headline count exclusive (use the same primary-role rule
-used elsewhere: Exit > Guard > Middle), or compute `total_offline` in Python from the
-number of offline relays instead of summing buckets in the template.
+**Fix. DECISION: exclusive buckets with the codebase's priority order, all math in
+Python.** Two parts:
+
+1. Classify each offline relay into exactly one bucket using the same priority rule
+   used elsewhere (`contact_sorting.py` role_rank and `categorization.py` role
+   counting both use **Exit > Guard > Middle**): `if 'Exit' in flags → exit;
+   elif 'Guard' in flags → guard; else → middle`. This also aligns the per-role
+   offline bandwidth sums with the `guard_bandwidth`/`exit_bandwidth`/
+   `middle_bandwidth` denominators, which `categorization.py` already computes with
+   the same exclusive rule — so per-role percentages can no longer exceed 100%.
+2. Compute `total_offline` in Python (`len(offline_relays)`) and put it in
+   `downtime_alerts`; remove the `{% set total_offline = ... %}` arithmetic from
+   `contact.html`. Jinja2 is slower than Python — templates should render
+   precomputed values, not do math (this is the established pattern:
+   `_preprocess_template_data`, `preformat_network_health_template_strings`).
 
 **Expected diff.** Contact pages of operators that currently have offline dual-role
 relays; verify a sampled contact page shows the corrected count.
@@ -152,21 +172,34 @@ parenthetical uses `total_relays`. `v3_tier` and `is_v3_adopter` already use
 
 **Options considered.**
 
-- **A — standardize on `total_relays`** (chosen): matches `classify_v3_tier` (documented
-  single source of truth), `is_v3_adopter`, and the existing "(N of M)" template copy.
+- A — standardize on `total_relays`: matches `classify_v3_tier`, `is_v3_adopter`, and
+  the existing "(N of M)" template copy, but the mixed-migration pill would undersell
+  migration progress for operators where only a few relays declare AROI.
 - B — standardize on `v2 + v3` ("migration progress among AROI-declaring relays"):
-  would require rewording contact copy and changing leaderboard columns.
-- C — keep both semantics under two distinct field names: most precise but adds surface.
+  would misstate the leaderboard "share of relays on v3" columns.
+- **C — keep both semantics under two distinct field names** (chosen): most precise;
+  each surface gets the number that matches its copy.
 
-**DECISION: Option A.** Compute `v3_relay_percentage = v3_relay_count / total_relays`
-in `aroi_validation.get_contact_validation_status` (delete the `v2+v3` variant); the
-leaderboard formula is already correct. Accept that the "🔁 X% v3" mixed-migration pill
-now measures share of all relays, consistent with the tier badge next to it.
+**DECISION: Option C.** Replace the ambiguous `v3_relay_percentage` with two
+explicitly-named fields, both computed in Python (`aroi_validation.py`), never in
+templates:
 
-**Files.** `allium/lib/aroi_validation.py` (formula), templates
-`contact-relay-list.html`, `macros.html` (verify copy still reads correctly).
-Verify with the diff on contact pages and leaderboard v3 columns; cross-check one
-mixed-migration operator by hand.
+- `v3_pct_of_total = v3_relay_count / total_relays * 100` — used by leaderboard
+  columns, `v3_tier`, `is_v3_adopter`, and the contact-page sentence
+  "X% of this operator's relays already declare ciissversion:3 (N of TOTAL)"
+  (fixing the self-contradiction, since the parenthetical already uses totals).
+- `v3_migration_progress_pct = v3_relay_count / (v2_relay_count + v3_relay_count) * 100`
+  — used by the "🔁 X% v3" mixed-migration pill (only shown when both v2 and v3
+  exist), with tooltip copy updated to say "of AROI-declaring relays".
+
+Deleting the old name (rather than keeping it as an alias) forces every consumer —
+templates, search index, Prometheus — to pick the right semantics explicitly.
+
+**Files.** `allium/lib/aroi_validation.py`, `allium/lib/aroileaders.py`,
+`allium/lib/page_writer.py` (`aroi_v3_pct`), templates `contact-relay-list.html`,
+`macros.html`; grep for `v3_relay_percentage` / `v3_relay_pct_str` to catch all
+consumers. Verify with the diff on contact pages and leaderboard v3 columns;
+cross-check one mixed-migration operator by hand on both surfaces.
 
 ---
 
@@ -182,12 +215,25 @@ mixed-migration operator by hand.
    deprecated in Python 3.12; (C) leave as-is and rely on UTC hosts — silently
    re-breaks on any non-UTC machine.
    **DECISION: Option A.** On a UTC host the diff must be noise-floor only.
-2. **Leaderboard ties are nondeterministic.** `_top_n` sorts by a single metric; ties
-   break by dict insertion order. Fix: secondary sort key `(-metric, operator_key)`.
-   This also reduces spurious diffs in the comparison workflow itself.
+2. **Leaderboard ties are nondeterministic.** `_top_n` (`aroileaders.py` line 98) sorts
+   by a single metric; ties currently break by dict insertion order. (The *operator
+   key* is the dict key of `aroi_operators` — the operator's AROI domain when one is
+   declared, otherwise the derived incomplete-AROI display name /
+   `contact_<hash-prefix>` from `_incomplete_aroi_display_name`.)
+   **DECISION:** break ties by relay count so the tied operator with more relays wins,
+   then by operator key only as a final determinism guarantee:
+   `key=lambda x: (-x[1][metric], -x[1]['total_relays'], x[0])`. The operator-key
+   tertiary never affects who "wins" a meaningful tie — it only pins the order when
+   metric AND relay count are both identical, so output is byte-stable across runs.
 3. **`total_steps` comment is stale.** `allium.py` line 296 says "59 total steps" but the
-   computed value is 61 (4+22+35) and the run logs `[61/61]` (verified). Fix the comment
-   (or derive counts from the registries). No HTML impact.
+   computed value is 61 (4+22+35) and the run logs `[61/61]` (verified).
+   **DECISION: derive the count dynamically** so it stays correct going forward:
+   compute coordinator steps from the enabled API worker registry (per-API step count ×
+   number of enabled APIs + fixed data-processing steps) and page-generation steps from
+   `site_generator` page definitions (`STANDALONE_PAGES`, `MISC_SORTED_PAGE_TYPES`,
+   detail-page categories, search index, Prometheus) instead of hard-coded literals.
+   Expose the derivation next to the registries it counts, so adding an API or page
+   type updates the total automatically. No HTML impact (stdout progress only).
 
 **Files.** `allium/lib/aroileaders.py`, `allium/allium.py`.
 
@@ -252,14 +298,18 @@ mixed-migration operator by hand.
 
 ---
 
-## Phase 9 — Latent bugs (no HTML diff expected; fix + unit test only)
+## Phase 9 — Latent bugs (mostly no HTML diff expected; fix + unit test)
 
 1. **Rare-country loop iterates category names.** `country_utils.py` lines 574–592
    iterate `GEOPOLITICAL_CLASSIFICATIONS.keys()` (`'conflict_zones'`, `'authoritarian'`, …)
    instead of country codes, adding those strings to the rare-country set. Currently
-   masked because both consumers filter to 2-letter codes; still wrong. Fix: iterate the
-   union of the classification **sets**, or delete the block (zero-relay countries score
-   from geopolitical factors only). Confirm the diff is clean.
+   masked because both consumers filter to 2-letter codes; still wrong.
+   **DECISION: iterate the union of the classification sets** — i.e.
+   `set().union(*GEOPOLITICAL_CLASSIFICATIONS.values())` — so zero-relay but
+   geopolitically significant countries are scored as intended (the block's original
+   purpose). Note this may legitimately add real country codes to the rare set that
+   were previously missing; review the resulting diff on AROI rare-country leaderboards
+   and network-health rare-country metrics rather than expecting a noise-floor result.
 2. **`first_seen_date` re-escapes instead of unescaping.** `html_escape_utils.py`
    line 297: comment says "Unescape" but code does `.replace('&', '&amp;')`. Field is
    unused in templates — remove it (also covered by Phase 1 rework).
@@ -281,11 +331,11 @@ mixed-migration operator by hand.
 | 2 | Noise floor only | new unit test for 304 fallback |
 | 3 | Contact pages with offline dual-role relays | sample page inspection |
 | 4 | Leaderboard + contact reliability sections | recompute one operator by hand |
-| 5 | Contact + leaderboard v3 columns | one operator cross-checked on both surfaces |
-| 6 | Ties may reorder once, then stable | re-run twice; second diff must be noise-floor only |
+| 5 | Contact pill/copy + leaderboard v3 columns (two named fields) | one mixed-migration operator cross-checked on both surfaces |
+| 6 | Ties may reorder once (relay-count tiebreak), then stable | re-run twice; second diff must be noise-floor only |
 | 7 | Nav/breadcrumb markup diffs; 4 files removed if variants dropped | — |
 | 8 | Relay pages with burst-limit/overload data; authorities page expected unchanged (IPv6 fix is latent) | — |
-| 9 | Noise floor only | unit tests per fix |
+| 9 | Noise floor except item 1 (rare-country fix may add zero-relay countries — review AROI/network-health rare-country surfaces) | unit tests per fix |
 
 After each phase: `pytest` must pass, then commit that phase separately so each diff
 review maps to one class of change.

--- a/docs/development/plans/bug-fix-plan.md
+++ b/docs/development/plans/bug-fix-plan.md
@@ -1,0 +1,256 @@
+# Plan 3: Bug Fix Plan
+
+Scope: fix verified and suspected bugs found during a full-codebase review. Every phase
+follows the output comparison workflow so each fix's HTML impact is observed and reviewed,
+not guessed.
+
+## Workflow (applies to every phase)
+
+```bash
+# 1. Generate baseline BEFORE the change (full APIs)
+python3 allium/allium.py --out allium/www_baseline --apis all --progress
+
+# 2. Apply the fix(es) for one phase
+
+# 3. Regenerate AFTER the change (full APIs, same command)
+python3 allium/allium.py --out allium/www_after --apis all --progress
+
+# 4. Diff every generated file (~28k files, ~10s)
+python3 compare_outputs.py            # exit 0 = clean, 1 = diffs to review
+python3 compare_outputs.py --quiet    # summary only
+
+# 5. Run the test suite
+pytest
+flake8 . --select=E9,F63,F7,F82 --show-source
+```
+
+Environment notes (verified in this repo):
+
+- A full `--apis all` run completes in ~3.5 min and needs ~7 GB RSS.
+- Running baseline and after back-to-back reuses warm API caches; the observed noise
+  floor is **~25 content-diff files** (relay uptime ticking, root page timestamps).
+  Any diff beyond that must be attributable to the fix being verified.
+- If onionoo drifts between runs, regenerate the baseline immediately before the
+  after-run to keep the cache warm.
+
+Fixes are grouped into phases by risk and by expected HTML impact, so the diff for each
+phase isolates one class of change.
+
+---
+
+## Phase 1 — Double-escaped HTML entities (verified, visible to users)
+
+**Bug.** `page_writer.py` enables Jinja2 `autoescape=True`, but `relays.py` /
+`html_escape_utils.py` still pre-escape fields (`contact_escaped`,
+`nickname_escaped`, `as_name_escaped`, `platform_escaped`, `flags_escaped`,
+`first_seen_date_escaped`, `contact_info_escaped` in `aroileaders.py`, …) and templates
+render them without `|safe`. Autoescape escapes them a second time.
+
+**Verified evidence.** Generated output contains double-escaped entities rendered as
+literal text in the browser (e.g. `&amp;lt;admin AT my-mail dot rocks&amp;gt;` displays
+as `&lt;admin AT my-mail dot rocks&gt;`):
+
+- `misc/all.html`: 1,275 occurrences
+- `index.html` (AROI leaderboards): 71 occurrences
+- `top500.html`: 61 occurrences
+
+**Fix.** Pick one escaping strategy. Recommended: keep autoescape as the single source of
+truth — change the pre-computed fields to carry **raw** values (or drop the `_escaped`
+suffix fields and reference raw fields in templates), and remove the redundant
+`html.escape()` calls in `html_escape_utils.py` / `aroileaders.py`
+(`contact_info_escaped`). Do NOT sprinkle `|safe` on the pre-escaped fields — that
+re-introduces XSS risk if any call site forgets to pre-escape.
+
+**Expected diff.** Large but mechanical: affected pages change `&amp;amp;` → `&amp;`,
+`&amp;lt;` → `&lt;`, etc. Verify by grepping the after-output:
+`rg -c "&amp;amp;|&amp;lt;" allium/www_after/misc/all.html` should return 0 (or only
+legitimately double-escaped operator strings that literally contain `&amp;`).
+Spot-check that single escaping is still present (no raw `<script>` in output):
+`rg -l "<script" allium/www_after/misc/all.html` should only match the intentional
+page scripts.
+
+**Files.** `allium/lib/html_escape_utils.py`, `allium/lib/relays.py`,
+`allium/lib/aroileaders.py`, templates using `*_escaped` fields
+(`relay-list.html`, `contact-relay-list.html`, `aroi_macros.html`).
+
+---
+
+## Phase 2 — HTTP 304/error cache fallback never finds the cache (verified, no HTML diff expected)
+
+**Bug.** `error_handlers.handle_http_errors(api_name, cache_loader, ...)` is invoked with
+display names — `"onionoo details"`, `"onionoo historical bandwidth"`, `"AROI validation"`,
+`"Exit DNS Health"` (`workers.py` lines 792–927). On HTTP 304 and on the generic
+exception fallback it calls `cache_loader(api_name)`, and `CacheManager.save_cache/load_cache`
+build filenames as `f"{cache_key}.json"`. The cache is written under the config
+`api_name` (`onionoo_details.json`), so the decorator looks for `onionoo details.json`,
+which never exists. The same wrong key is passed to `_mark_ready`/`_mark_stale`, so worker
+state entries are also keyed inconsistently with the coordinator's registry.
+
+**Fix.** Pass the machine key and display name separately, e.g.
+`@handle_http_errors(cache_key="onionoo_details", display_name="onionoo details", ...)`,
+and use `cache_key` for `cache_loader`/`mark_ready`/`mark_stale`, `display_name` for log
+messages only.
+
+**Test.** Unit test: mock a 304 `HTTPError` from `_fetch_with_cache_fallback`, pre-seed
+`onionoo_details.json` cache, assert cached data is returned and worker status is keyed
+`onionoo_details`. The full-run diff should show **zero** content diffs beyond the noise
+floor (this path only triggers on 304/error).
+
+**Files.** `allium/lib/error_handlers.py`, `allium/lib/workers.py`,
+`tests/unit/workers/`.
+
+---
+
+## Phase 3 — Contact page downtime alerts double/triple-count dual-role relays (HTML diff expected)
+
+**Bug.** `operator_analysis.py` (~lines 1451–1463): an offline relay with both `Guard`
+and `Exit` flags increments `guard`, `exit`, **and** `middle` buckets. `contact.html`
+(line ~328) sums the three buckets into `total_offline`, so one offline Guard+Exit relay
+counts as 3. Per-role offline bandwidth percentages can also exceed 100%.
+
+**Fix.** Count each relay once for the total (unique fingerprints); keep per-role detail
+lists if desired but make the headline count exclusive (use the same primary-role rule
+used elsewhere: Exit > Guard > Middle), or compute `total_offline` in Python from the
+number of offline relays instead of summing buckets in the template.
+
+**Expected diff.** Contact pages of operators that currently have offline dual-role
+relays; verify a sampled contact page shows the corrected count.
+
+**Files.** `allium/lib/operator_analysis.py`, `allium/templates/contact.html`.
+
+---
+
+## Phase 4 — Reliability leaderboard drops 0% uptime relays from the average (HTML diff expected)
+
+**Bug.** `aroileaders.py` line ~250: `if uptime_pct > 0.0:` excludes relays with exactly
+0% uptime from the operator average. Nine relays at 99% plus one at 0% scores ~99%
+instead of ~89.1%, inflating "Reliability Masters"/"Legacy Titans" rankings.
+
+**Fix.** Include explicit 0.0 values when the relay has uptime data for the period;
+only skip relays with **missing** data. Distinguish "no data" (`None` /
+missing key) from "0% uptime" when reading `uptime_percentages`.
+
+**Expected diff.** Reliability leaderboard sections of `index.html` /
+`misc/aroi-leaderboards.html`, and contact pages showing reliability scores.
+
+**Files.** `allium/lib/aroileaders.py` (and the analogous logic in
+`operator_analysis.calculate_operator_reliability` if it shares the pattern),
+`tests/unit/aroi/`.
+
+---
+
+## Phase 5 — Inconsistent v3 migration percentage denominators (HTML diff expected)
+
+**Bug.** `aroi_validation.py` (~line 1806) computes `v3_relay_percentage` as
+`v3 / (v2 + v3)` (AROI-declaring relays only) while `aroileaders.py` (~line 965) uses
+`v3 / total_relays`. The same operator shows different percentages on contact pages vs
+leaderboards; `v3_tier` already uses `total_relays`, so contact validation is internally
+inconsistent too.
+
+**Fix.** Standardize on `total_relays` (matches the documented tier classification), and
+update template copy if needed.
+
+**Files.** `allium/lib/aroi_validation.py`, templates `contact-relay-list.html`,
+`macros.html`. Verify with the diff on contact pages and leaderboard v3 columns.
+
+---
+
+## Phase 6 — Timezone and determinism bugs (small HTML diffs possible)
+
+1. **Veteran score uses naive local time.** `aroileaders.py` (~lines 795–812) uses
+   `datetime.now()` and `strptime` on onionoo timestamps; every other consumer uses
+   UTC-aware helpers (`time_utils.parse_onionoo_timestamp`). On a non-UTC host, veteran
+   days drift by up to a day. Fix: `datetime.now(timezone.utc)` +
+   `parse_onionoo_timestamp()`.
+2. **Leaderboard ties are nondeterministic.** `_top_n` sorts by a single metric; ties
+   break by dict insertion order. Fix: secondary sort key `(-metric, operator_key)`.
+   This also reduces spurious diffs in the comparison workflow itself.
+3. **`total_steps` comment is stale.** `allium.py` line 296 says "59 total steps" but the
+   computed value is 61 (4+22+35) and the run logs `[61/61]` (verified). Fix the comment
+   (or derive counts from the registries). No HTML impact.
+
+**Files.** `allium/lib/aroileaders.py`, `allium/allium.py`.
+
+---
+
+## Phase 7 — Template correctness (HTML diff expected, cosmetic)
+
+1. **Broken nav highlighting.** `flag.html` and `first_seen.html` call
+   `navigation('misc', ...)` but the macro has no `'misc'` branch — nothing highlights.
+   `relay-info.html` uses `navigation('all', ...)`, wrongly highlighting "All Relays"
+   on relay pages. Fix: pass a valid section or none.
+2. **Country breadcrumb shows ISO code.** `page_context.get_detail_context()` puts the
+   raw sorted key (e.g. `US`) into `country_name`; `country.html` derives the full name
+   separately. Fix: resolve the display name in `get_detail_context`.
+3. **Sort variants with no visible column.** `site_generator.py` generates
+   `by-unique-contact-count` / `by-unique-family-count` pages for all five misc types,
+   but `misc-contacts.html` and `misc-families.html` have no such columns — the pages
+   exist with no visual indication of the sort. Fix: either add the columns or stop
+   generating those variants for those two types (note: removing variants deletes
+   4 output files — the comparison report will show them under "Only in baseline",
+   which is the expected signal).
+4. **`platform.html` description doesn't escape `value`** while the title does
+   (autoescape actually covers this — verify, then align the template for consistency).
+
+**Files.** `allium/templates/macros.html`, `flag.html`, `first_seen.html`,
+`relay-info.html`, `platform.html`, `allium/lib/page_context.py`,
+`allium/lib/site_generator.py`.
+
+---
+
+## Phase 8 — Data/display correctness in diagnostics (HTML diff expected, small)
+
+1. **`burst-limit` formatted as a rate.** Onionoo `burst-limit` is bytes (bucket size),
+   not bytes/sec, but `relay_diagnostics.py` (~line 606) and `relay-info.html`
+   (~line 980) render it with `/s` units. Fix: format burst as a data volume.
+2. **Guard bandwidth message ignores `--bits`.** `relay_diagnostics.py` line ~276
+   hardcodes `f"{observed_bandwidth / 1_000_000:.1f} MB/s"`. Fix: use the shared
+   formatter with `use_bits`.
+3. **IPv6 directory authority parsing.** `page_writer.py` (~lines 649–655) splits
+   `or_addresses[0]` on `:`, which breaks `[2001:db8::1]:9001`. Fix: reuse
+   `ip_utils.safe_parse_ip_address` bracket-aware parsing. Affects
+   `misc/authorities.html` latency probes for IPv6 authorities.
+4. **Stable-flag eligibility defaults to eligible.** `consensus/collector_fetcher.py`
+   (~line 1102): when an authority publishes no `stable-mtbf` threshold, every relay is
+   marked Stable-eligible. Fix: fall back to the documented dir-spec OR-condition
+   (`flag_thresholds.check_stable_eligibility`) instead of `True`.
+
+---
+
+## Phase 9 — Latent bugs (no HTML diff expected; fix + unit test only)
+
+1. **Rare-country loop iterates category names.** `country_utils.py` lines 574–592
+   iterate `GEOPOLITICAL_CLASSIFICATIONS.keys()` (`'conflict_zones'`, `'authoritarian'`, …)
+   instead of country codes, adding those strings to the rare-country set. Currently
+   masked because both consumers filter to 2-letter codes; still wrong. Fix: iterate the
+   union of the classification **sets**, or delete the block (zero-relay countries score
+   from geopolitical factors only). Confirm the diff is clean.
+2. **`first_seen_date` re-escapes instead of unescaping.** `html_escape_utils.py`
+   line 297: comment says "Unescape" but code does `.replace('&', '&amp;')`. Field is
+   unused in templates — remove it (also covered by Phase 1 rework).
+3. **Non-atomic state/cache writes.** `workers._save_state` and
+   `file_io_utils.write_json_file` write JSON in place; a crash mid-write corrupts
+   state/cache. Fix: write to temp file + `os.replace`.
+4. **`_is_retryable_error` retries all `OSError`s** (`workers.py` ~line 511), including
+   `ENOSPC`/`EACCES`. Fix: restrict to network-related errno values.
+5. **Fragile exception handler in `fetch_collector_consensus_data`** (`workers.py`
+   ~lines 999–1065): initialize `cached_data`/`timeout_seconds` before the `try`.
+
+---
+
+## Verification matrix
+
+| Phase | Expected compare_outputs result | Extra checks |
+|-------|--------------------------------|--------------|
+| 1 | Many diffs, all entity-decoding only | grep for `&amp;amp;`/`&amp;lt;` count → 0; XSS spot-check |
+| 2 | Noise floor only | new unit test for 304 fallback |
+| 3 | Contact pages with offline dual-role relays | sample page inspection |
+| 4 | Leaderboard + contact reliability sections | recompute one operator by hand |
+| 5 | Contact + leaderboard v3 columns | one operator cross-checked on both surfaces |
+| 6 | Ties may reorder once, then stable | re-run twice; second diff must be noise-floor only |
+| 7 | Nav/breadcrumb markup diffs; 4 files removed if variants dropped | — |
+| 8 | Relay pages with burst-limit / authorities page | — |
+| 9 | Noise floor only | unit tests per fix |
+
+After each phase: `pytest` must pass, then commit that phase separately so each diff
+review maps to one class of change.

--- a/docs/development/plans/bug-fix-plan.md
+++ b/docs/development/plans/bug-fix-plan.md
@@ -144,24 +144,44 @@ missing key) from "0% uptime" when reading `uptime_percentages`.
 **Bug.** `aroi_validation.py` (~line 1806) computes `v3_relay_percentage` as
 `v3 / (v2 + v3)` (AROI-declaring relays only) while `aroileaders.py` (~line 965) uses
 `v3 / total_relays`. The same operator shows different percentages on contact pages vs
-leaderboards; `v3_tier` already uses `total_relays`, so contact validation is internally
-inconsistent too.
+leaderboards. It is self-contradictory within a single sentence on the contact page
+(`contact-relay-list.html` line ~482): "**50%** of this operator's relays already
+declare ciissversion:3 (**1 of 50**)" — the percentage uses `v2+v3` while the
+parenthetical uses `total_relays`. `v3_tier` and `is_v3_adopter` already use
+`total_relays` everywhere.
 
-**Fix.** Standardize on `total_relays` (matches the documented tier classification), and
-update template copy if needed.
+**Options considered.**
 
-**Files.** `allium/lib/aroi_validation.py`, templates `contact-relay-list.html`,
-`macros.html`. Verify with the diff on contact pages and leaderboard v3 columns.
+- **A — standardize on `total_relays`** (chosen): matches `classify_v3_tier` (documented
+  single source of truth), `is_v3_adopter`, and the existing "(N of M)" template copy.
+- B — standardize on `v2 + v3` ("migration progress among AROI-declaring relays"):
+  would require rewording contact copy and changing leaderboard columns.
+- C — keep both semantics under two distinct field names: most precise but adds surface.
+
+**DECISION: Option A.** Compute `v3_relay_percentage = v3_relay_count / total_relays`
+in `aroi_validation.get_contact_validation_status` (delete the `v2+v3` variant); the
+leaderboard formula is already correct. Accept that the "🔁 X% v3" mixed-migration pill
+now measures share of all relays, consistent with the tier badge next to it.
+
+**Files.** `allium/lib/aroi_validation.py` (formula), templates
+`contact-relay-list.html`, `macros.html` (verify copy still reads correctly).
+Verify with the diff on contact pages and leaderboard v3 columns; cross-check one
+mixed-migration operator by hand.
 
 ---
 
 ## Phase 6 — Timezone and determinism bugs (small HTML diffs possible)
 
 1. **Veteran score uses naive local time.** `aroileaders.py` (~lines 795–812) uses
-   `datetime.now()` and `strptime` on onionoo timestamps; every other consumer uses
-   UTC-aware helpers (`time_utils.parse_onionoo_timestamp`). On a non-UTC host, veteran
-   days drift by up to a day. Fix: `datetime.now(timezone.utc)` +
-   `parse_onionoo_timestamp()`.
+   `datetime.now()` (naive, host-local) and `strptime` on onionoo's UTC timestamps;
+   every other consumer uses UTC-aware helpers (`time_utils.parse_onionoo_timestamp`).
+   On a non-UTC host, `veteran_days` drifts by up to ±1 day (more around DST), making
+   output non-reproducible across machines.
+   Options: (A, chosen) `datetime.now(timezone.utc)` + `parse_onionoo_timestamp()` —
+   consistent with the rest of the codebase; (B) `datetime.utcnow()` — minimal but
+   deprecated in Python 3.12; (C) leave as-is and rely on UTC hosts — silently
+   re-breaks on any non-UTC machine.
+   **DECISION: Option A.** On a UTC host the diff must be noise-floor only.
 2. **Leaderboard ties are nondeterministic.** `_top_n` sorts by a single metric; ties
    break by dict insertion order. Fix: secondary sort key `(-metric, operator_key)`.
    This also reduces spurious diffs in the comparison workflow itself.
@@ -200,16 +220,31 @@ update template copy if needed.
 
 ## Phase 8 — Data/display correctness in diagnostics (HTML diff expected, small)
 
-1. **`burst-limit` formatted as a rate.** Onionoo `burst-limit` is bytes (bucket size),
-   not bytes/sec, but `relay_diagnostics.py` (~line 606) and `relay-info.html`
-   (~line 980) render it with `/s` units. Fix: format burst as a data volume.
+1. **`burst-limit` formatted as a rate.** Per proposal 328 / dir-spec, onionoo's
+   `overload_ratelimits.rate-limit`/`burst-limit` are the raw torrc `BandwidthRate`
+   (bytes **per second**) and `BandwidthBurst` (token-bucket size in **bytes** — a
+   quantity, not a rate). `relay_diagnostics.py` (~line 606) and `relay-info.html`
+   (~line 980) render burst with `/s` units, so a 1 GB bucket shows as "1.07 GB/s".
+   Options: (A, chosen) format burst as a data volume, no `/s` — spec-correct, and the
+   diagnostics page should teach the correct semantics; (B) keep rate-style display to
+   match operators' torrc mental model — status quo; (C) raw bytes — unambiguous but
+   inconsistent with site formatting.
+   **DECISION: Option A.** Small diff confined to relay pages with overload data plus
+   the "Rate Limit Configuration" issue text.
 2. **Guard bandwidth message ignores `--bits`.** `relay_diagnostics.py` line ~276
    hardcodes `f"{observed_bandwidth / 1_000_000:.1f} MB/s"`. Fix: use the shared
    formatter with `use_bits`.
 3. **IPv6 directory authority parsing.** `page_writer.py` (~lines 649–655) splits
-   `or_addresses[0]` on `:`, which breaks `[2001:db8::1]:9001`. Fix: reuse
-   `ip_utils.safe_parse_ip_address` bracket-aware parsing. Affects
-   `misc/authorities.html` latency probes for IPv6 authorities.
+   `or_addresses[0]` on `:`, which breaks `[2001:db8::1]:9001` (yields `[2001`), and
+   `dir_address.split(':')[-1]` has the same flaw. **Latent today:** onionoo lists each
+   authority's IPv4 address first and `dir_address` is IPv4, so current output is
+   correct; it breaks only if an authority ever publishes IPv6-first, at which point
+   the latency probe silently targets a garbage endpoint and reports the authority down.
+   Options: (A, chosen) bracket-aware parsing via `ip_utils.safe_parse_ip_address`,
+   preferring the first IPv4 entry for the probe (the monitor's TCP check is only
+   exercised over IPv4); (B) IPv4-filter only; (C) leave as-is.
+   **DECISION: Option A** (which subsumes B's explicit IPv4 preference). Zero expected
+   output change today — the diff must be noise-floor only.
 4. **Stable-flag eligibility defaults to eligible.** `consensus/collector_fetcher.py`
    (~line 1102): when an authority publishes no `stable-mtbf` threshold, every relay is
    marked Stable-eligible. Fix: fall back to the documented dir-spec OR-condition
@@ -249,7 +284,7 @@ update template copy if needed.
 | 5 | Contact + leaderboard v3 columns | one operator cross-checked on both surfaces |
 | 6 | Ties may reorder once, then stable | re-run twice; second diff must be noise-floor only |
 | 7 | Nav/breadcrumb markup diffs; 4 files removed if variants dropped | — |
-| 8 | Relay pages with burst-limit / authorities page | — |
+| 8 | Relay pages with burst-limit/overload data; authorities page expected unchanged (IPv6 fix is latent) | — |
 | 9 | Noise floor only | unit tests per fix |
 
 After each phase: `pytest` must pass, then commit that phase separately so each diff

--- a/docs/development/plans/loc-reduction-plan.md
+++ b/docs/development/plans/loc-reduction-plan.md
@@ -1,0 +1,169 @@
+# Plan 2: Lines-of-Code Reduction Plan
+
+Scope: delete verified dead code and merge verbatim duplication with **zero behavior
+change**. Structural refactors are in the simplification plan; behavior changes in the
+bug fix plan. Current size: ~23.3k lines of production Python (`allium/` + 
+`compare_outputs.py`), ~8.2k lines of templates, ~22.2k lines of tests.
+
+Target: **~900–1,300 production Python lines** plus **~500–700 template lines**
+removed, in strictly mechanical, individually-verified steps.
+
+## Workflow (applies to every batch)
+
+```bash
+# 1. Baseline BEFORE (full APIs)
+python3 allium/allium.py --out allium/www_baseline --apis all --progress
+
+# 2. Delete one batch
+
+# 3. Regenerate AFTER
+python3 allium/allium.py --out allium/www_after --apis all --progress
+
+# 4. Compare all ~28k output files
+python3 compare_outputs.py --quiet
+
+# 5. Tests + lint
+pytest
+flake8 . --select=E9,F63,F7,F82 --show-source
+```
+
+Verified: full run ≈ 3.5 min / ~7 GB RSS; back-to-back runs have a noise floor of ~25
+content-diff files (relay uptime ticking, root timestamps). **Every batch in this plan
+must diff at the noise floor.** Dead-code deletion that changes output was not dead —
+revert and investigate.
+
+Additional gate for every deletion: `rg -n "<symbol>" allium/ tests/` must show only the
+definition (or definition + tests, in which case delete/update the tests in the same
+commit).
+
+---
+
+## Batch 1 — Dead functions and classes (zero callers, verified by grep)
+
+| Symbol | File | ~Lines |
+|--------|------|--------|
+| `handle_worker_errors` decorator (never applied) | `error_handlers.py` | 35 |
+| `TemplateEscapingHelpers` class + `create_template_helpers` | `html_escape_utils.py` | 70 |
+| `escape_relay_field`, unused `HTMLEscaper.escape_with_*` methods | `html_escape_utils.py` | 20 |
+| Dead `first_seen_date` write (mislabeled "unescape") | `html_escape_utils.py` | 1 |
+| `StatisticalUtils.calculate_z_score`, `classify_by_z_score`, `calculate_confidence_intervals` | `statistical_utils.py` | 90 |
+| Module-level wrappers `calculate_percentile`, `calculate_statistical_outliers` | `statistical_utils.py` | 7 |
+| `calculate_network_cv_statistics` (never wired; no caller passes its output) | `bandwidth_utils.py` | 21 |
+| `normalize_contact_info` | `aroileaders.py` | 13 |
+| `assign_rarity_tier` (superseded by `assign_as_rarity_tier`), `is_eu_geographic`, `get_geographic_regions_for_analysis`, `count_frontier_countries_weighted_with_existing_data` | `country_utils.py` | 50 |
+| `format_percentage`, `format_percentage_or_na` (thin aliases of `format_percentage_from_fraction`) | `string_utils.py` | 28 |
+| Legacy `log_step_progress`, `log_progress_with_step_increment`, `ProgressLogger.create_child_logger`, `update_from_other_logger` | `progress_logger.py` | 50 |
+| `create_template_context_builder`, `create_standard_contexts`, unused `StandardTemplateContexts.get_detail_page_context(page_data)` variant | `page_context.py` | 48 |
+| `Relays._write_timestamp`, `Relays.create_output_dir` | `relays.py` | 16 |
+| `Coordinator.get_collector_data` (tests-only), `self.workers = {}` | `coordinator.py` | 7 |
+| `normalize_uptime_value` (inlined at its only production call site) | `uptime_utils.py` | 12 |
+
+Subtotal ≈ **470 lines**. Where a symbol is exercised only by tests, delete the test in
+the same commit (it tests nothing the product uses).
+
+---
+
+## Batch 2 — Unreachable branches
+
+| Item | File | ~Lines |
+|------|------|--------|
+| Contact-specific logic in the generic sequential `write_pages_by_key` loop — unreachable because `if k == "contact": return` routes contacts to dedicated renderers first | `page_writer.py` | 130 |
+| Contact vanity-URL block in `write_pages_parallel` — contacts never reach this function | `page_writer.py` | 15 |
+| `network_position_display` assigned but never passed to the template | `page_writer.py` | 1 |
+
+Subtotal ≈ **145 lines**. This is the highest-value single deletion; verify with a full
+diff **and** confirm contact pages and vanity URLs are still generated (spot-check
+`allium/www_after/contact/<hash>/index.html` count matches baseline).
+
+---
+
+## Batch 3 — Dead pipeline plumbing
+
+| Item | File | ~Lines |
+|------|------|--------|
+| `fetch_consensus_health` (not in `API_WORKER_REGISTRY`; production never calls it) | `workers.py` | 72 |
+| `fetch_collector_data` legacy wrapper | `workers.py` | 6 |
+| `get_consensus_health_data` + `consensus_health_data` attach + reader stub | `coordinator.py`, `relays.py` | 40 |
+| `_state_manager` global (workers use `_save_state`/`_load_state` directly) | `workers.py` | 1 |
+| `BulkFileOperations`, `TestFileHelper`, `create_unified_file_manager`, `safe_file_operation`, `safe_json_operation` | `file_io_utils.py` | 150 |
+
+Subtotal ≈ **270 lines**. Integration tests that call `fetch_consensus_health` directly
+must be deleted or repointed in the same commit.
+
+---
+
+## Batch 4 — Unused imports and constants
+
+`flake8 --select=F401` plus the review found: `sys`, `Path`,
+`ThreadPoolExecutor`/`FuturesTimeoutError` (`workers.py`); `BandwidthFormatter`,
+`get_divisor_for_unit`, module-level `determine_unit` import (`page_writer.py`);
+`os` (`progress.py`, `page_context.py`); `ABS_PATH` (`allium.py`); `hashlib`, `html`,
+`count_frontier_countries_weighted_with_existing_data` (`aroileaders.py`); `math`
+(`intelligence_engine.py`); `json` (`aroi_validation.py`);
+`find_relay_uptime_data`, `calculate_relay_uptime_average` imports (`network_health.py`);
+duplicate in-function imports in `operator_analysis.calculate_operator_reliability`;
+`handle_calculation_errors`, `get_worker_status` imports (`coordinator.py`).
+
+Run `flake8 . --select=F401,F811,F841` to catch the full set mechanically.
+
+Subtotal ≈ **25–35 lines**. No diff expected at all (imports don't render).
+
+---
+
+## Batch 5 — Verbatim duplication merges (still zero behavior change)
+
+These merge copy-paste duplicates where both copies are demonstrably identical in
+behavior; anything with semantic differences stays for the simplification/bug plans.
+
+| Duplication | Files | ~Lines saved |
+|-------------|-------|--------------|
+| Daily bandwidth aggregation loop (`_calculate_growth_trend` vs `extract_operator_daily_bandwidth_totals`) | `bandwidth_utils.py` | 70 |
+| `_format_breakdown_details` builds two identical lists then truncates one | `aroileaders.py` | 4 |
+| Per-fetcher `log_wrapper` closure repeated 5× | `workers.py` | 25 |
+| `_format_leaderboard_entries` 19-category switchboard → table-driven config | `aroileaders.py` | 150–200 |
+| Flag uptime/bandwidth display processor pairs (same skeleton, different field names) | `flag_analysis.py`, `operator_analysis.py` | 160–200 |
+| Statistical outlier wrapper duplicated in `uptime_utils` and `statistical_utils` | both | 10 |
+
+Subtotal ≈ **420–510 lines**. The last two rows are the riskiest deletions in this plan:
+do each as its own commit, and treat *any* content diff above the noise floor as a
+failure (the merged implementation must reproduce byte-identical HTML, including CSS
+class names — note `flag_analysis` emits `al-status-*` while `operator_analysis` emits
+different class names in places; parameterize, don't normalize).
+
+---
+
+## Batch 6 — Template LOC (optional, shared with simplification plan Phase 8)
+
+| Item | ~Lines saved |
+|------|--------------|
+| `misc-*.html` shared header/sort-matrix/row macros | 400–450 |
+| `relay-list.html` / `contact-relay-list.html` shared row macros | 100–150 |
+| Inline country summary → `detail_summary` macro | 25 |
+
+Subtotal ≈ **500–650 template lines**. Byte-identical output required (whitespace
+included — Jinja `trim_blocks`/`lstrip_blocks` are on, but macro extraction can still
+shift whitespace; the comparison tool will catch it).
+
+---
+
+## Non-goals
+
+- `experiments/` and `docs/` cleanup — not production code; handle separately if wanted.
+- Deleting `compare_outputs.py` helpers — it is the verification tool for this plan.
+- Test-suite slimming beyond tests of deleted code (~22k test lines have their own
+  value; only remove tests whose subject is deleted).
+- Anything requiring judgment about intended behavior — that belongs to the bug plan.
+
+## Execution order and accounting
+
+1. Batch 4 (imports) — trivial, instant, zero diff.
+2. Batch 1 (dead symbols) — grep-gated, one commit per module.
+3. Batch 2 (unreachable branches) — one commit, careful diff + page-count check.
+4. Batch 3 (dead plumbing) — one commit, update tests.
+5. Batch 5 (duplication merges) — one commit per row, strict byte-identical gate.
+6. Batch 6 (templates) — one commit per template family.
+
+Running total if all batches land: **~1,330–1,530 Python lines** (~6% of production
+Python) **+ ~500–650 template lines** (~7% of templates), all with noise-floor diffs.
+Each commit message should state the batch, the symbols removed, and the compare result
+(`Content diffs: N (noise floor)`).

--- a/docs/development/plans/loc-reduction-plan.md
+++ b/docs/development/plans/loc-reduction-plan.md
@@ -5,8 +5,9 @@ change**. Structural refactors are in the simplification plan; behavior changes 
 bug fix plan. Current size: ~23.3k lines of production Python (`allium/` + 
 `compare_outputs.py`), ~8.2k lines of templates, ~22.2k lines of tests.
 
-Target: **~900–1,300 production Python lines** plus **~500–700 template lines**
-removed, in strictly mechanical, individually-verified steps.
+Target: **~900–1,200 production Python lines** plus **~500–700 template lines**
+removed, in strictly mechanical, individually-verified steps. (The consensus-health
+pipeline is explicitly out of scope — see Batch 3.)
 
 ## Workflow (applies to every batch)
 
@@ -81,14 +82,17 @@ diff **and** confirm contact pages and vanity URLs are still generated (spot-che
 
 | Item | File | ~Lines |
 |------|------|--------|
-| `fetch_consensus_health` (not in `API_WORKER_REGISTRY`; production never calls it) | `workers.py` | 72 |
 | `fetch_collector_data` legacy wrapper | `workers.py` | 6 |
-| `get_consensus_health_data` + `consensus_health_data` attach + reader stub | `coordinator.py`, `relays.py` | 40 |
 | `_state_manager` global (workers use `_save_state`/`_load_state` directly) | `workers.py` | 1 |
 | `BulkFileOperations`, `TestFileHelper`, `create_unified_file_manager`, `safe_file_operation`, `safe_json_operation` | `file_io_utils.py` | 150 |
 
-Subtotal ≈ **270 lines**. Integration tests that call `fetch_consensus_health` directly
-must be deleted or repointed in the same commit.
+Subtotal ≈ **160 lines**.
+
+**Keep (intentionally excluded):** the consensus-health path stays as-is —
+`fetch_consensus_health` (`workers.py`), `Coordinator.get_consensus_health_data`, the
+`consensus_health_data` attach in `create_relay_set_with_coordinator`, and the reader
+stub in `relays.py`. It is not wired into `API_WORKER_REGISTRY` today, but it is a
+planned feature path, not cruft — do not delete it in this plan.
 
 ---
 
@@ -163,7 +167,7 @@ shift whitespace; the comparison tool will catch it).
 5. Batch 5 (duplication merges) — one commit per row, strict byte-identical gate.
 6. Batch 6 (templates) — one commit per template family.
 
-Running total if all batches land: **~1,330–1,530 Python lines** (~6% of production
+Running total if all batches land: **~1,220–1,420 Python lines** (~5–6% of production
 Python) **+ ~500–650 template lines** (~7% of templates), all with noise-floor diffs.
 Each commit message should state the batch, the symbols removed, and the compare result
 (`Content diffs: N (noise floor)`).

--- a/docs/development/plans/loc-reduction-plan.md
+++ b/docs/development/plans/loc-reduction-plan.md
@@ -82,17 +82,19 @@ diff **and** confirm contact pages and vanity URLs are still generated (spot-che
 
 | Item | File | ~Lines |
 |------|------|--------|
-| `fetch_collector_data` legacy wrapper | `workers.py` | 6 |
 | `_state_manager` global (workers use `_save_state`/`_load_state` directly) | `workers.py` | 1 |
 | `BulkFileOperations`, `TestFileHelper`, `create_unified_file_manager`, `safe_file_operation`, `safe_json_operation` | `file_io_utils.py` | 150 |
 
-Subtotal ≈ **160 lines**.
+Subtotal ≈ **150 lines**.
 
-**Keep (intentionally excluded):** the consensus-health path stays as-is —
-`fetch_consensus_health` (`workers.py`), `Coordinator.get_consensus_health_data`, the
-`consensus_health_data` attach in `create_relay_set_with_coordinator`, and the reader
-stub in `relays.py`. It is not wired into `API_WORKER_REGISTRY` today, but it is a
-planned feature path, not cruft — do not delete it in this plan.
+**Keep (intentionally excluded):**
+
+- The consensus-health path stays as-is — `fetch_consensus_health` (`workers.py`),
+  `Coordinator.get_consensus_health_data`, the `consensus_health_data` attach in
+  `create_relay_set_with_coordinator`, and the reader stub in `relays.py`. It is not
+  wired into `API_WORKER_REGISTRY` today, but it is a planned feature path, not cruft —
+  do not delete it in this plan.
+- `fetch_collector_data` (`workers.py`) stays as well — keep the legacy wrapper.
 
 ---
 
@@ -167,7 +169,7 @@ shift whitespace; the comparison tool will catch it).
 5. Batch 5 (duplication merges) — one commit per row, strict byte-identical gate.
 6. Batch 6 (templates) — one commit per template family.
 
-Running total if all batches land: **~1,220–1,420 Python lines** (~5–6% of production
+Running total if all batches land: **~1,210–1,410 Python lines** (~5–6% of production
 Python) **+ ~500–650 template lines** (~7% of templates), all with noise-floor diffs.
 Each commit message should state the batch, the symbols removed, and the compare result
 (`Content diffs: N (noise floor)`).

--- a/docs/development/plans/simplification-plan.md
+++ b/docs/development/plans/simplification-plan.md
@@ -1,0 +1,261 @@
+# Plan 1: Simplification Plan
+
+Scope: reduce architectural complexity — fewer layers, fewer parallel ways of doing the
+same thing — while producing byte-identical output (modulo the known noise floor).
+This plan is about structure; raw line deletion is covered by the LOC reduction plan,
+and behavior changes by the bug fix plan.
+
+## Workflow (applies to every phase)
+
+```bash
+# 1. Baseline BEFORE the change (full APIs)
+python3 allium/allium.py --out allium/www_baseline --apis all --progress
+
+# 2. Apply one phase of refactoring
+
+# 3. Regenerate AFTER the change
+python3 allium/allium.py --out allium/www_after --apis all --progress
+
+# 4. Compare all ~28k files
+python3 compare_outputs.py --quiet
+
+# 5. Tests + lint
+pytest
+flake8 . --select=E9,F63,F7,F82 --show-source
+```
+
+Verified environment facts: a full run takes ~3.5 min / ~7 GB RSS; two back-to-back
+runs with warm caches diff at a noise floor of ~25 content files (uptime ticking on
+relay pages, timestamps on root pages). **Every phase in this plan must diff at the
+noise floor** — simplification must not change output. Any diff above the floor means
+the refactor altered behavior and must be fixed before the phase is committed.
+
+Phases are ordered so that each one reduces the surface area the next one touches.
+
+---
+
+## Phase 1 — Single escaping strategy (do the bug-fix first)
+
+Templates render with `autoescape=True` while Python pre-escapes a dozen `*_escaped`
+fields, which currently double-escapes output (see bug fix plan, Phase 1). Resolve that
+first; the simplification below assumes autoescape is the single mechanism.
+
+Then collapse `html_escape_utils.py` (411 lines, 5 classes) into a small module:
+
+- Production only uses `create_bulk_escaper()` (from `relays.py`) and two constants.
+  `HTMLEscapeConstants`, `HTMLEscaper`, `RelayFieldEscaper`, `TemplateEscapingHelpers`,
+  `escape_relay_field`, `create_template_helpers` are unused indirection.
+- Replace with module-level functions: one `escape_relay_fields(relay)` plus
+  `safe_html_escape(value, fallback)`.
+
+**Risk:** low. **Diff:** noise floor only (after the escaping bug fix has landed).
+
+---
+
+## Phase 2 — One error-handling/cache-fallback layer for API workers
+
+Today there are two overlapping layers:
+
+- `workers._fetch_with_cache_fallback` handles timeout/parse/validation errors with
+  cache fallback, keyed by `config.api_name`.
+- `error_handlers.handle_http_errors` decorator wraps the same functions to handle
+  304/HTTP/network errors with its own cache fallback — keyed (incorrectly) by display
+  name, plus a fragile positional-args inspection to find the progress logger.
+
+Simplification:
+
+1. Move the 304 and HTTP-error handling **into** `_fetch_with_cache_fallback`, where
+   `config.api_name`, `cached_data`, and `log_progress` already exist. The decorator
+   and its `cache_loader`/`mark_ready`/`mark_stale` parameters disappear.
+2. Delete `handle_worker_errors` (never applied anywhere; `coordinator._run_worker`
+   already has equivalent inline handling) and the now-unused imports in
+   `coordinator.py`.
+3. The per-fetcher `log_wrapper` closures in `workers.py` (repeated 5×) collapse into
+   `_fetch_with_cache_fallback`'s existing `log_progress`.
+
+**Risk:** medium — error paths are hard to exercise; add unit tests for 304-with-cache,
+304-without-cache, HTTPError-5xx, URLError before refactoring. **Diff:** noise floor
+(happy path unchanged).
+
+---
+
+## Phase 3 — One API registry
+
+`coordinator.py` defines `API_WORKER_REGISTRY`, while `workers.py` separately defines
+per-API `APIConfig` objects, display names, and orphan fetchers that are not in the
+registry (`fetch_consensus_health`, legacy `fetch_collector_data`). The consensus-health
+path is wired through `coordinator.get_consensus_health_data()` → always `None` →
+stored on `relay_set` → never read.
+
+Simplification:
+
+1. Make `APIConfig` the single source of truth: add `worker_fn`, `enabled_flag`, and
+   `progress_name` fields; derive `API_WORKER_REGISTRY` from the config list.
+2. Delete the dead consensus-health plumbing (`fetch_consensus_health`,
+   `get_consensus_health_data`, the `consensus_health_data` attach in
+   `coordinator.create_relay_set_with_coordinator`, and the reader stub in `relays.py`).
+3. Delete `Coordinator.get_collector_data` (tests-only) and the unused
+   `self.workers = {}`.
+
+**Risk:** medium — coordinator tests reference some of these; update tests rather than
+keeping dead production code. **Diff:** noise floor.
+
+---
+
+## Phase 4 — Collapse the progress-logging stack
+
+Three generations of progress APIs coexist: `ProgressLogger.log/log_without_increment`,
+legacy module functions (`log_step_progress`, `log_progress_with_step_increment` — zero
+callers), coordinator-internal `_log_progress` / `_log_progress_with_step_increment` /
+`_log_progress_without_increment`, plus `relays.py` manually incrementing
+`self.progress_step` that the coordinator then overwrites.
+
+Simplification:
+
+1. Keep only `ProgressLogger.log()` / `log_without_increment()`; delete legacy module
+   functions and `create_child_logger` / `update_from_other_logger` (zero callers).
+2. Thread one `ProgressLogger` instance through coordinator → relays → page_writer;
+   remove the manual `progress_step` bookkeeping and the `[step/total]` counters being
+   passed as separate ints.
+3. Derive `total_steps` in `allium.py` from the enabled API count and page-generation
+   step list instead of hard-coded `4 + 22 + 35` with stale comments (run logs `[61/61]`
+   while the comment says 59).
+
+**Risk:** low — progress output is cosmetic, but keep the log format identical to make
+CI log diffs stable. **Diff:** none (progress goes to stdout, not HTML).
+
+---
+
+## Phase 5 — Remove the `Relays` god-object facade
+
+`relays.py` has ~40 one-line delegate methods (lines ~895–1393) that forward to
+`categorization`, `page_writer`, `uptime_utils`, etc. Callers mix direct module calls
+and `relay_set._method()` calls arbitrarily, so every new module function grows a
+facade twin.
+
+Simplification:
+
+1. Inventory delegates; for each, migrate call sites to the underlying module function
+   (passing `relay_set` explicitly) and delete the wrapper. Do it in 3–4 batches
+   (categorization, uptime/bandwidth, page-writer, misc) with a full diff after each.
+2. Keep genuinely stateful methods (`_preprocess_template_data`, cache fields) on the
+   class.
+3. Delete `Relays._write_timestamp` and `Relays.create_output_dir` (zero callers).
+
+**Risk:** medium — many call sites, including the multiprocessing worker init path in
+`page_writer.py` which pickles `relay_set`; verify parallel contact-page rendering still
+works (run with default worker count and confirm in progress output). **Diff:** noise
+floor.
+
+---
+
+## Phase 6 — Unify the sequential/parallel page-writing paths
+
+`page_writer.write_pages_by_key` routes contact pages to dedicated renderers and returns
+early (`if k == "contact": return`), yet the generic sequential loop below still carries
+~130 lines of contact-only logic that can never execute, and `write_pages_parallel`
+carries an unreachable contact vanity-URL block.
+
+Simplification:
+
+1. Delete the unreachable contact branches from the generic paths.
+2. Extract the shared "build template args for one page" logic used by sequential and
+   parallel paths into one function (the `_get_family_support_counts` /
+   `_get_exit_dns_health_summary` helpers already started this) so the two paths cannot
+   drift.
+3. Move `get_directory_authorities_data`'s live `AuthorityMonitor` TCP probing out of
+   page rendering into a coordinator worker, so page generation is pure rendering.
+   (Do this last; it changes when probes run, not what is rendered.)
+
+**Risk:** step 1–2 low; step 3 medium (timing of probes changes; authorities page
+content may legitimately differ — review that diff explicitly). **Diff:** steps 1–2
+noise floor; step 3 authorities page only.
+
+---
+
+## Phase 7 — Consolidate overlapping stats/formatting utilities
+
+Three module families compute the same things:
+
+- **Statistics:** `statistical_utils.py`, plus wrappers in `uptime_utils.py` and CV
+  logic in `bandwidth_utils.py`. Keep `StatisticalUtils` as the only implementation;
+  everything else calls it.
+- **Bandwidth formatting:** `BandwidthFormatter` class (stateless except `use_bits`),
+  `relay_diagnostics._format_rate`, `consensus_evaluation._format_bandwidth_display`.
+  Make the formatter module-level functions parameterized by `use_bits`; delete the
+  duplicate private formatters.
+- **Overload/stability:** `stability_utils.compute_relay_stability` and
+  `relay_diagnostics._check_overload_issues` duplicate overload detection with slightly
+  different semantics (the 72h window is applied inconsistently — see bug plan
+  Phase 8). One `evaluate_overload(relay, now)` used by both.
+- **Time-ago formatting:** `api_diagnostics._format_age/_format_time_ago/_format_timestamp`
+  duplicate `time_utils`. Reuse `time_utils` with thin wrappers only where the display
+  string genuinely differs.
+- **URL-token regexes:** three near-identical regexes in `aroileaders.py`,
+  `aroi_validation.py`, `categorization.py`; move one shared pattern into
+  `string_utils.py`.
+
+**Risk:** medium — formatting differences show up immediately in the diff, which is
+exactly the point; review any diff character-by-character before accepting. **Diff:**
+must be noise floor; if a diff appears, the two implementations disagreed and the plan
+is to preserve the behavior the templates currently show (byte-identical), then decide
+separately (bug plan) if that behavior was wrong.
+
+---
+
+## Phase 8 — Template deduplication
+
+1. **`misc-*.html` family (5 files, ~750 lines, ~60% duplicated):** extract
+   `misc_listing_macros.html` with macros for the stats header, the sort-header link
+   matrix (parameterized by `contacts-`/`families-`/... prefix), and the shared row
+   cells.
+2. **`relay-list.html` vs `contact-relay-list.html` (~200 overlapping lines):** extract
+   shared row-cell macros (status circle, nickname/family links, AS, country, platform,
+   flags, first-seen); keep contact-specific columns local. Note the intentional
+   differences first (first-seen shows date vs time-ago; measured shows text vs icons)
+   so the macro parameterizes them rather than silently normalizing.
+3. **Thin detail wrappers** (`as.html`, `flag.html`, `platform.html`,
+   `first_seen.html` — 10 lines each): acceptable to keep, but move the inline country
+   summary in `country.html` into the existing `detail_summary` macro (add an optional
+   parameter for the RouteFluxMap link).
+4. Unify the operator-link markup duplicated between `macros.html` and
+   `aroi_macros.html` into one macro.
+
+**Risk:** medium-high — templates are the output; the comparison tool is the safety
+net. Do one template family per commit and demand a noise-floor diff each time.
+**Diff:** must be noise floor (byte-identical HTML is the acceptance criterion).
+
+---
+
+## Phase 9 — `page_context.py` and `file_io_utils.py` de-layering
+
+1. `page_context.py`: production uses three convenience functions; delete
+   `create_template_context_builder`, `create_standard_contexts`, and the unused
+   `StandardTemplateContexts.get_detail_page_context(page_data)` variant; flatten
+   `TemplateContextBuilder` into the functions.
+2. `file_io_utils.py`: keep `CacheManager`, `TimestampManager`, `StateManager`; delete
+   `BulkFileOperations`, `TestFileHelper`, `create_unified_file_manager`,
+   `safe_file_operation`, `safe_json_operation` (zero production imports).
+3. `page_writer.get_detail_page_context(relay_set, ...)`: drop the ignored `relay_set`
+   parameter.
+
+**Risk:** low. **Diff:** noise floor.
+
+---
+
+## Ordering and acceptance
+
+| Phase | Prereq | Acceptance |
+|-------|--------|------------|
+| 1 escaping | bug-plan Phase 1 merged | noise-floor diff, pytest green |
+| 2 error layer | new error-path unit tests written first | noise-floor diff |
+| 3 API registry | Phase 2 | noise-floor diff |
+| 4 progress | — | no HTML diff; progress format unchanged |
+| 5 Relays facade | — | noise-floor diff per batch; parallel rendering verified |
+| 6 page writer | Phase 5 | steps 1–2 noise floor; step 3 authorities page reviewed |
+| 7 utils merge | — | noise-floor diff per module family |
+| 8 templates | Phase 1 | noise-floor diff per template family |
+| 9 de-layering | — | noise-floor diff |
+
+Each phase is one or more commits, each commit individually verified with the full
+baseline/after/compare cycle. Never batch two phases into one diff review.

--- a/docs/development/plans/simplification-plan.md
+++ b/docs/development/plans/simplification-plan.md
@@ -91,9 +91,12 @@ Simplification:
 
 1. Make `APIConfig` the single source of truth: add `worker_fn`, `enabled_flag`, and
    `progress_name` fields; derive `API_WORKER_REGISTRY` from the config list.
-2. Delete the dead consensus-health plumbing (`fetch_consensus_health`,
+2. Keep the consensus-health path (`fetch_consensus_health`,
    `get_consensus_health_data`, the `consensus_health_data` attach in
-   `coordinator.create_relay_set_with_coordinator`, and the reader stub in `relays.py`).
+   `coordinator.create_relay_set_with_coordinator`, and the reader stub in `relays.py`)
+   — it is a planned feature path, not cruft. When migrating to the unified registry,
+   give it an `APIConfig` entry with a disabled/optional flag so it fits the single
+   registry instead of remaining an orphan.
 3. Delete `Coordinator.get_collector_data` (tests-only) and the unused
    `self.workers = {}`.
 

--- a/docs/development/plans/simplification-plan.md
+++ b/docs/development/plans/simplification-plan.md
@@ -38,15 +38,18 @@ Phases are ordered so that each one reduces the surface area the next one touche
 
 Templates render with `autoescape=True` while Python pre-escapes a dozen `*_escaped`
 fields, which currently double-escapes output (see bug fix plan, Phase 1). Resolve that
-first; the simplification below assumes autoescape is the single mechanism.
+first. Decision recorded there: escaping logic **stays in Python** (Jinja2 is slower;
+templates should render precomputed values) — the pre-escaped fields are wrapped in
+`markupsafe.Markup` so autoescape does not re-escape them, and autoescape remains on as
+the safety net for raw fields.
 
 Then collapse `html_escape_utils.py` (411 lines, 5 classes) into a small module:
 
 - Production only uses `create_bulk_escaper()` (from `relays.py`) and two constants.
   `HTMLEscapeConstants`, `HTMLEscaper`, `RelayFieldEscaper`, `TemplateEscapingHelpers`,
   `escape_relay_field`, `create_template_helpers` are unused indirection.
-- Replace with module-level functions: one `escape_relay_fields(relay)` plus
-  `safe_html_escape(value, fallback)`.
+- Replace with module-level functions: one `escape_relay_fields(relay)` (returning
+  `Markup`-wrapped escaped fields) plus `safe_html_escape(value, fallback)`.
 
 **Risk:** low. **Diff:** noise floor only (after the escaping bug fix has landed).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Thorough review of the codebase (all `allium/lib/` modules, `allium/allium.py`, templates, and tests), delivered as three separate execution plans under `docs/development/plans/`:

- `simplification-plan.md` — 9 phases reducing architectural complexity (single escaping strategy, one error-handling layer, one API registry, progress-stack collapse, `Relays` facade removal, page-writer unification, utils consolidation, template dedup, de-layering), each gated on a byte-identical output diff.
- `loc-reduction-plan.md` — 6 batches of mechanical deletion (~1,200–1,400 production Python lines + ~500–650 template lines), every symbol grep-verified as dead or verbatim-duplicated before removal.
- `bug-fix-plan.md` — 9 phases fixing verified and suspected bugs, ordered by risk and expected HTML impact.

**Explicitly out of scope:** the consensus-health pipeline (`fetch_consensus_health`, `get_consensus_health_data`, the `consensus_health_data` attach, and the reader stub in `relays.py`) and the `fetch_collector_data` wrapper are kept. The simplification plan folds consensus-health into the unified API registry as a disabled/optional entry instead of deleting it.

**Recorded decisions** (options weighed in the bug-fix plan):
- Escaping (Phase 1): keep escaping logic in Python for render performance; wrap pre-escaped strings in `markupsafe.Markup` so `autoescape` stops double-escaping them while remaining the safety net for raw fields. No `|safe` in templates.
- Downtime alerts (Phase 3): exclusive role buckets using the codebase-standard Exit > Guard > Middle priority; `total_offline` computed in Python, template arithmetic removed (Jinja2 is slower — templates render precomputed values).
- v3 migration percentage (Phase 5): Option C — two explicitly-named fields: `v3_pct_of_total` (leaderboards, tier, adopter flag, contact sentence) and `v3_migration_progress_pct` (mixed-migration pill); the ambiguous `v3_relay_percentage` is deleted so every consumer picks semantics explicitly.
- Leaderboard ties (Phase 6): break by metric, then relay count (more relays wins), then operator key purely for byte-stable determinism.
- Progress steps (Phase 6): derive `total_steps` dynamically from the API worker registry and `site_generator` page definitions instead of hard-coded literals.
- Veteran scoring: `datetime.now(timezone.utc)` + `parse_onionoo_timestamp()` for host-timezone-independent output.
- IPv6 authority parsing: bracket-aware parsing via `ip_utils.safe_parse_ip_address`, preferring the IPv4 entry for latency probes (latent bug — zero expected output change).
- `burst-limit`: format as a data volume (bytes), not a rate — per proposal 328/dir-spec, `BandwidthBurst` is a token-bucket size, not bytes/sec.
- Rare-country loop (Phase 9): iterate the union of the `GEOPOLITICAL_CLASSIFICATIONS` sets so zero-relay countries are scored as intended; diff on rare-country surfaces reviewed rather than assumed noise-floor.

Every plan mandates the output comparison workflow: generate a full-API baseline (`python3 allium/allium.py --out allium/www_baseline --apis all --progress`) before changes, regenerate after, and diff with `compare_outputs.py`.

## Key verified findings baked into the plans

- **Double-escaped HTML entities in production output** — `autoescape=True` plus Python pre-escaped `*_escaped` fields double-escapes; verified in generated output (`misc/all.html`: 1,275 occurrences; `index.html`: 71; `top500.html`: 61 — e.g. `&amp;lt;admin AT my-mail dot rocks&amp;gt;` renders as literal `&lt;...&gt;` text).
- **HTTP 304/error cache fallback can never find the cache** — `handle_http_errors` receives display names (`"onionoo details"`) but cache files are keyed `onionoo_details.json`.
- **Contact-page downtime alerts triple-count Guard+Exit relays**; **reliability leaderboard drops 0%-uptime relays from averages**; **inconsistent v3 migration denominators** between contact pages and leaderboards; ~130 unreachable contact-branch lines in `page_writer.py`; and more.

## Workflow verification (in this environment)

- ✅ Full `--apis all` baseline run completes (~3.5 min, ~7 GB RSS, 61/61 steps)
- ✅ Second full run + `python3 compare_outputs.py --quiet` — 28,339 common files; measured back-to-back noise floor of ~25 content-diff files (relay uptime ticking, root timestamps), now documented as the acceptance gate in all three plans
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93516e9e-b265-48ea-86ba-5554e346e387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93516e9e-b265-48ea-86ba-5554e346e387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

