### PR TITLE
Fix stale directory-authority reachability count (8/9 → 8/8) + retain removed authorities on DA page

### DIFF
--- a/allium/lib/consensus/collector_fetcher.py
+++ b/allium/lib/consensus/collector_fetcher.py
@@ -243,9 +243,10 @@ class AuthorityRegistry:
         Prefers the dynamic list discovered from CollecTor votes (via
         update_voting_authorities); falls back to the hardcoded 9 voting authorities
         when no vote data is available. NOTE: Serge has Authority flag but doesn't vote.
+        Returns a copy so callers can't mutate the registry's internal state.
         """
         if self._voting_authority_names:
-            return self._voting_authority_names
+            return list(self._voting_authority_names)
         return _FALLBACK_VOTING_AUTHORITY_NAMES
     
     def get_voting_authority_count(self) -> int:

--- a/allium/lib/consensus/collector_fetcher.py
+++ b/allium/lib/consensus/collector_fetcher.py
@@ -116,8 +116,9 @@ def get_known_offline_authorities() -> List[dict]:
 
     Display-only, used to keep recently-removed authorities visible (as offline) on
     the dedicated Directory Authorities page after they age out of live data sources.
+    Returns copies so callers can't mutate the module-level entries.
     """
-    return KNOWN_OFFLINE_AUTHORITIES
+    return [dict(entry) for entry in KNOWN_OFFLINE_AUTHORITIES]
 
 
 # ============================================================================

--- a/allium/lib/consensus/collector_fetcher.py
+++ b/allium/lib/consensus/collector_fetcher.py
@@ -248,7 +248,7 @@ class AuthorityRegistry:
         """
         if self._voting_authority_names:
             return list(self._voting_authority_names)
-        return _FALLBACK_VOTING_AUTHORITY_NAMES
+        return list(_FALLBACK_VOTING_AUTHORITY_NAMES)
     
     def get_voting_authority_count(self) -> int:
         """Get number of voting authorities (dynamic from CollecTor, else fallback 9)."""

--- a/allium/lib/consensus/collector_fetcher.py
+++ b/allium/lib/consensus/collector_fetcher.py
@@ -210,7 +210,9 @@ class AuthorityRegistry:
         diagnostics - consistent with the authorities that actually voted.
 
         Returns:
-            The number of voting authorities currently recorded.
+            The effective number of voting authorities in use after the update
+            (the dynamic list if set, otherwise the hardcoded fallback) - so an
+            ignored empty update never reads as "zero voters".
         """
         names = sorted({n for n in (vote_authority_names or []) if n})
         if names:
@@ -219,7 +221,7 @@ class AuthorityRegistry:
                 f"AuthorityRegistry: {len(names)} voting authorities discovered "
                 f"from CollecTor: {names}"
             )
-        return len(self._voting_authority_names or [])
+        return self.get_voting_authority_count()
 
     def clear_voting_authorities(self) -> None:
         """Reset the dynamic voting list back to the hardcoded fallback.
@@ -228,6 +230,11 @@ class AuthorityRegistry:
         registry is a shared singleton.
         """
         self._voting_authority_names = None
+
+    def has_dynamic_voting_authorities(self) -> bool:
+        """True when the voting list was discovered from CollecTor vote data
+        (via update_voting_authorities) rather than the hardcoded fallback."""
+        return self._voting_authority_names is not None
 
     def get_voting_authority_names(self) -> List[str]:
         """

--- a/allium/lib/consensus/collector_fetcher.py
+++ b/allium/lib/consensus/collector_fetcher.py
@@ -100,7 +100,9 @@ KNOWN_OFFLINE_AUTHORITIES = [
     {
         'nickname': 'gabelmoo',
         'fingerprint': 'F2044413DAC2E02E3D6BCF4735A19BCA1DE97281',
-        'country': 'de',
+        # Uppercase to match _preprocess_template_data (relay["country"] = country.upper())
+        # and the country-page URL convention (country/DE/), so the offline row links correctly.
+        'country': 'DE',
         'country_name': 'Germany',
         'offline_since': '2026-06-30',  # last vote 2026-06-29 23:00 UTC (CollecTor archive)
         'note': ('Went offline on 2026-06-30 (last vote 2026-06-29) and was '

--- a/allium/lib/consensus/collector_fetcher.py
+++ b/allium/lib/consensus/collector_fetcher.py
@@ -78,6 +78,47 @@ AUTHORITY_COUNTRIES = {
 
 
 # ============================================================================
+# KNOWN OFFLINE / REMOVED AUTHORITIES - small hardcoded bridge list
+# ============================================================================
+# Directory-authority membership changing is rare but critical. When an authority
+# is removed from the consensus it eventually ages out of ALL live data sources
+# (Onionoo drops a relay ~1 week after its last consensus; CollecTor 'recent/' only
+# retains ~3-4 days), so it would silently disappear from every page. To preserve
+# historical context, we keep a SMALL hardcoded list of recently-removed authorities
+# and surface them (as offline) on the dedicated Directory Authorities page ONLY.
+#
+# This list is display-only: entries here are NEVER fed into the voting registry,
+# never counted as voters, and never affect reachability/consensus math. Each entry
+# is shown only if the authority is NOT already present dynamically from Onionoo, so
+# if it ever returns the live data supersedes the hardcoded row automatically.
+#
+# Keep this list SMALL: add an entry only when an authority is actually removed, and
+# prune it once the authority is permanently gone (no longer needs context) or has
+# returned. The 'fingerprint' is the Onionoo RELAY fingerprint (used for dedupe
+# against live Onionoo data) - NOT the V3 signing key used in vote filenames.
+KNOWN_OFFLINE_AUTHORITIES = [
+    {
+        'nickname': 'gabelmoo',
+        'fingerprint': 'F2044413DAC2E02E3D6BCF4735A19BCA1DE97281',
+        'country': 'de',
+        'country_name': 'Germany',
+        'offline_since': '2026-06-30',  # last vote 2026-06-29 23:00 UTC (CollecTor archive)
+        'note': ('Went offline on 2026-06-30 (last vote 2026-06-29) and was '
+                 'subsequently removed from the directory authority list.'),
+    },
+]
+
+
+def get_known_offline_authorities() -> List[dict]:
+    """Return the (small) hardcoded list of known removed/offline authorities.
+
+    Display-only, used to keep recently-removed authorities visible (as offline) on
+    the dedicated Directory Authorities page after they age out of live data sources.
+    """
+    return KNOWN_OFFLINE_AUTHORITIES
+
+
+# ============================================================================
 # DYNAMIC AUTHORITY REGISTRY - Prefers Onionoo data, falls back to hardcoded
 # ============================================================================
 class AuthorityRegistry:
@@ -96,6 +137,12 @@ class AuthorityRegistry:
         self._discovered_authorities = []  # From Onionoo
         self._authority_names = None  # Cached sorted names
         self._using_fallback = True
+        # Dynamic voting-authority list, derived from the authorities that actually
+        # produced a vote in the most recent consensus round (CollecTor). None means
+        # "not yet discovered" -> fall back to the hardcoded voting list. This makes
+        # the voting set track reality when authorities are added/removed (e.g. an
+        # authority going offline like gabelmoo) instead of a stale hardcoded 9.
+        self._voting_authority_names = None
     
     def update_from_onionoo(self, relays: list) -> int:
         """
@@ -147,17 +194,55 @@ class AuthorityRegistry:
         """Check if using fallback data (Onionoo not available)."""
         return self._using_fallback
     
+    def update_voting_authorities(self, vote_authority_names) -> int:
+        """
+        Set the actively-voting authority list from CollecTor vote data.
+
+        Args:
+            vote_authority_names: iterable of authority names that produced a vote
+                this consensus round (e.g. flag_thresholds.keys() or votes.keys()).
+
+        Empty/falsy input is ignored so a failed or empty fetch never wipes the list
+        (the previous value, or the hardcoded fallback, is kept). This keeps the
+        voting set - used for reachability denominators, per-authority tables, and
+        diagnostics - consistent with the authorities that actually voted.
+
+        Returns:
+            The number of voting authorities currently recorded.
+        """
+        names = sorted({n for n in (vote_authority_names or []) if n})
+        if names:
+            self._voting_authority_names = names
+            logger.info(
+                f"AuthorityRegistry: {len(names)} voting authorities discovered "
+                f"from CollecTor: {names}"
+            )
+        return len(self._voting_authority_names or [])
+
+    def clear_voting_authorities(self) -> None:
+        """Reset the dynamic voting list back to the hardcoded fallback.
+
+        Primarily for test isolation and fresh generation runs, since the module
+        registry is a shared singleton.
+        """
+        self._voting_authority_names = None
+
     def get_voting_authority_names(self) -> List[str]:
         """
-        Get sorted list of VOTING authority names (9 authorities).
-        NOTE: Serge has Authority flag but doesn't vote.
+        Get sorted list of VOTING authority names.
+
+        Prefers the dynamic list discovered from CollecTor votes (via
+        update_voting_authorities); falls back to the hardcoded 9 voting authorities
+        when no vote data is available. NOTE: Serge has Authority flag but doesn't vote.
         """
-        # If we have Onionoo data, filter out non-voting authorities
-        # For now, we use the signing key mapping as source of truth for voters
+        if self._voting_authority_names:
+            return self._voting_authority_names
         return _FALLBACK_VOTING_AUTHORITY_NAMES
     
     def get_voting_authority_count(self) -> int:
-        """Get number of voting authorities (9)."""
+        """Get number of voting authorities (dynamic from CollecTor, else fallback 9)."""
+        if self._voting_authority_names:
+            return len(self._voting_authority_names)
         return _FALLBACK_VOTING_AUTHORITY_COUNT
     
     def get_signing_key_to_name(self) -> Dict[str, str]:
@@ -201,6 +286,15 @@ def get_voting_authority_names() -> List[str]:
 def get_voting_authority_count() -> int:
     """Get voting authority count (9 - excludes non-voting authorities like Serge)."""
     return _authority_registry.get_voting_authority_count()
+
+
+def update_voting_authorities(vote_authority_names) -> int:
+    """Update the global registry's voting-authority list from CollecTor vote data.
+
+    See AuthorityRegistry.update_voting_authorities. Empty input is ignored (keeps
+    the previous/fallback list). Returns the current voting authority count.
+    """
+    return _authority_registry.update_voting_authorities(vote_authority_names)
 
 
 # Signing key mapping - always hardcoded (different from relay fingerprints)

--- a/allium/lib/page_writer.py
+++ b/allium/lib/page_writer.py
@@ -8,6 +8,7 @@ Extracted from relays.py for better modularity.
 """
 
 import functools
+import logging
 import multiprocessing as mp
 import os
 import time
@@ -38,6 +39,8 @@ from .intelligence_engine import IntelligenceEngine
 from .time_utils import format_time_ago, format_timestamp, format_timestamp_ago
 
 ABS_PATH = os.path.dirname(os.path.abspath(__file__))
+
+logger = logging.getLogger(__name__)
 
 
 def _sanitize_path_component(value: str) -> str:
@@ -764,7 +767,7 @@ def get_directory_authorities_data(relay_set):
         from .consensus.collector_fetcher import get_known_offline_authorities
         known_offline = get_known_offline_authorities()
     except Exception as e:
-        print(f"Warning: Failed to load known offline authorities ({e}), skipping offline-retention rows")
+        logger.warning(f"Failed to load known offline authorities ({e}), skipping offline-retention rows")
         known_offline = []
     for entry in known_offline:
         entry_fp = (entry.get('fingerprint') or '').upper()

--- a/allium/lib/page_writer.py
+++ b/allium/lib/page_writer.py
@@ -827,8 +827,18 @@ def get_directory_authorities_data(relay_set):
     
     # Use voting authority count from collector (actual voters) rather than Onionoo authority flag count
     # This is more accurate since some authorities (like Serge) may have Authority flag but don't vote.
-    # Fallback uses the DYNAMIC (pre-merge) count so hardcoded offline rows don't inflate it.
-    voting_authority_count = len(collector_flag_thresholds) if collector_flag_thresholds else dynamic_authority_count
+    # When flag_thresholds is absent but votes were seen, the voting registry (updated from the vote
+    # keys in enrich_with_api_data) still holds the real voter count, so prefer it over the Onionoo
+    # Authority-flag count. Only with no vote data at all fall back to the DYNAMIC (pre-merge) Onionoo
+    # count, so hardcoded offline rows never inflate the denominator.
+    if collector_flag_thresholds:
+        voting_authority_count = len(collector_flag_thresholds)
+    else:
+        from .consensus.collector_fetcher import get_authority_registry
+        registry = get_authority_registry()
+        voting_authority_count = (registry.get_voting_authority_count()
+                                  if registry.has_dynamic_voting_authorities()
+                                  else dynamic_authority_count)
     
     # Extract consensus method info from collector data (for Happy Family migration tracking)
     consensus_method_info = None

--- a/allium/lib/page_writer.py
+++ b/allium/lib/page_writer.py
@@ -804,7 +804,7 @@ def get_directory_authorities_data(relay_set):
     # header sub-bullet, so it auto-updates for ANY future DA going offline.
     offline_names = sorted(a.get('nickname', '') for a in authorities if not a.get('running', False))
     offline_count = len(offline_names)
-    
+
     # Build consensus status
     voted_count = sum(1 for a in authorities if a.get('collector_data', {}).get('voted', False))
     consensus_status = {

--- a/allium/lib/page_writer.py
+++ b/allium/lib/page_writer.py
@@ -802,9 +802,8 @@ def get_directory_authorities_data(relay_set):
     # Offline summary is DYNAMIC: any authority currently not running - includes live
     # (stage 1/2) offline authorities AND hardcoded (stage 3) entries. Drives the
     # header sub-bullet, so it auto-updates for ANY future DA going offline.
-    offline_authorities = [a for a in authorities if not a.get('running', False)]
-    offline_count = len(offline_authorities)
-    offline_names = sorted(a.get('nickname', '') for a in offline_authorities)
+    offline_names = sorted(a.get('nickname', '') for a in authorities if not a.get('running', False))
+    offline_count = len(offline_names)
     
     # Build consensus status
     voted_count = sum(1 for a in authorities if a.get('collector_data', {}).get('voted', False))

--- a/allium/lib/page_writer.py
+++ b/allium/lib/page_writer.py
@@ -744,6 +744,68 @@ def get_directory_authorities_data(relay_set):
             authority['uptime_zscore'] = None
             authority['uptime_outlier_status'] = 'insufficient_data'
     
+    # ------------------------------------------------------------------
+    # Retain recently-removed authorities (as offline) for historical context.
+    # A directory authority removed from the consensus eventually ages out of ALL
+    # live data sources (Onionoo drops it ~1 week after its last consensus; CollecTor
+    # 'recent/' keeps only ~3-4 days), so it would silently vanish from this page. We
+    # merge in a SMALL hardcoded list of known-offline authorities, but ONLY those not
+    # already present dynamically from Onionoo. If such an authority returns to
+    # Onionoo, the live row wins (dedupe) and the page refreshes it automatically.
+    #
+    # Display-only: these entries are never counted as voters and never affect the
+    # reachability/consensus denominators. Totals below use the DYNAMIC (pre-merge)
+    # authority count so the hardcoded rows can't inflate any counts.
+    # ------------------------------------------------------------------
+    dynamic_authority_count = len(authorities)
+    dynamic_fingerprints = {a.get('fingerprint', '').upper() for a in authorities}
+    dynamic_nicknames = {a.get('nickname', '').lower() for a in authorities}
+    try:
+        from .consensus.collector_fetcher import get_known_offline_authorities
+        known_offline = get_known_offline_authorities()
+    except Exception:
+        known_offline = []
+    for entry in known_offline:
+        entry_fp = (entry.get('fingerprint') or '').upper()
+        entry_nick = (entry.get('nickname') or '').lower()
+        # Skip if already present dynamically (authority returned / never fully left)
+        if (entry_fp and entry_fp in dynamic_fingerprints) or \
+           (entry_nick and entry_nick in dynamic_nicknames):
+            continue
+        # Build a complete authority-shaped dict so the template renders safely.
+        # Intentionally NO 'collector_data'/'latency_*' keys -> those columns render as
+        # a muted "-" rather than an alarming red 0 / X.
+        authorities.append({
+            'nickname': entry.get('nickname', ''),
+            'fingerprint': entry.get('fingerprint', ''),
+            'running': False,
+            'country': entry.get('country'),
+            'country_name': entry.get('country_name'),
+            'as': None,
+            'as_name': None,
+            'uptime_percentages': {},
+            'uptime_zscore': None,
+            'uptime_outlier_status': 'insufficient_data',
+            'version': None,
+            'recommended_version': None,
+            'first_seen': None,
+            'first_seen_relative': None,
+            'first_seen_timestamp': None,
+            'last_restarted': None,
+            'is_known_offline': True,
+            'offline_since': entry.get('offline_since'),
+            'offline_note': entry.get('note', 'Removed from the directory authority list.'),
+        })
+    # Re-sort so any appended offline rows slot into alphabetical position
+    authorities = sorted(authorities, key=lambda x: x.get('nickname', '').lower())
+
+    # Offline summary is DYNAMIC: any authority currently not running - includes live
+    # (stage 1/2) offline authorities AND hardcoded (stage 3) entries. Drives the
+    # header sub-bullet, so it auto-updates for ANY future DA going offline.
+    offline_authorities = [a for a in authorities if not a.get('running', False)]
+    offline_count = len(offline_authorities)
+    offline_names = sorted(a.get('nickname', '') for a in offline_authorities)
+    
     # Build consensus status
     voted_count = sum(1 for a in authorities if a.get('collector_data', {}).get('voted', False))
     consensus_status = {
@@ -765,8 +827,9 @@ def get_directory_authorities_data(relay_set):
         collector_flag_thresholds = collector_data.get('flag_thresholds', {})
     
     # Use voting authority count from collector (actual voters) rather than Onionoo authority flag count
-    # This is more accurate since some authorities (like Serge) may have Authority flag but don't vote
-    voting_authority_count = len(collector_flag_thresholds) if collector_flag_thresholds else len(authorities)
+    # This is more accurate since some authorities (like Serge) may have Authority flag but don't vote.
+    # Fallback uses the DYNAMIC (pre-merge) count so hardcoded offline rows don't inflate it.
+    voting_authority_count = len(collector_flag_thresholds) if collector_flag_thresholds else dynamic_authority_count
     
     # Extract consensus method info from collector data (for Happy Family migration tracking)
     consensus_method_info = None
@@ -777,10 +840,12 @@ def get_directory_authorities_data(relay_set):
         'authorities_data': authorities,
         'authorities_summary': {
             'total_authorities': voting_authority_count,
-            'total_with_authority_flag': len(authorities),  # Keep for reference
+            'total_with_authority_flag': dynamic_authority_count,  # Live Onionoo count (excludes hardcoded offline rows)
             'above_average_uptime': above_average_uptime,
             'below_average_uptime': below_average_uptime,
-            'problem_uptime': problem_uptime
+            'problem_uptime': problem_uptime,
+            'offline_count': offline_count,  # Dynamic: any authority not running (live + hardcoded)
+            'offline_names': offline_names,
         },
         'authority_network_stats': authority_network_stats,
         'uptime_metadata': (getattr(relay_set, 'uptime_data', {}) or {}).get('relays_published', 'Unknown'),

--- a/allium/lib/page_writer.py
+++ b/allium/lib/page_writer.py
@@ -763,7 +763,8 @@ def get_directory_authorities_data(relay_set):
     try:
         from .consensus.collector_fetcher import get_known_offline_authorities
         known_offline = get_known_offline_authorities()
-    except Exception:
+    except Exception as e:
+        print(f"Warning: Failed to load known offline authorities ({e}), skipping offline-retention rows")
         known_offline = []
     for entry in known_offline:
         entry_fp = (entry.get('fingerprint') or '').upper()

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -148,16 +148,14 @@ class Relays:
         # (e.g. gabelmoo going offline) so reachability, per-authority tables, and
         # diagnostics use the correct denominator instead of a stale hardcoded 9.
         # Done EARLY (before uptime/bandwidth/network-health/collector steps below) so
-        # every downstream consumer sees the corrected voting count. Empty vote data
-        # is ignored by update_voting_authorities(), keeping the fallback.
+        # every downstream consumer sees the corrected voting count. update_voting_authorities()
+        # extracts names from the dict's keys and ignores empty input (keeps the fallback).
         if collector_consensus_data:
-            _flag_thresholds = collector_consensus_data.get('flag_thresholds') or {}
-            _vote_names = list(_flag_thresholds.keys()) or list(
-                (collector_consensus_data.get('votes') or {}).keys()
+            from .consensus.collector_fetcher import update_voting_authorities
+            update_voting_authorities(
+                collector_consensus_data.get('flag_thresholds')
+                or collector_consensus_data.get('votes')
             )
-            if _vote_names:
-                from .consensus.collector_fetcher import update_voting_authorities
-                update_voting_authorities(_vote_names)
 
         # Steps 8-10: Uptime processing → regenerate leaderboards + health
         if uptime_data:

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -150,9 +150,14 @@ class Relays:
         # Done EARLY (before uptime/bandwidth/network-health/collector steps below) so
         # every downstream consumer sees the corrected voting count. update_voting_authorities()
         # extracts names from the dict's keys and ignores empty input (keeps the fallback).
+        # The registry is a module singleton, so reset it at this generation boundary
+        # first: a collector-less (or failed-fetch) run in the same process must use
+        # the fallback, never a stale dynamic list from a previous generation.
+        from .consensus.collector_fetcher import get_authority_registry
+        registry = get_authority_registry()
+        registry.clear_voting_authorities()
         if collector_consensus_data:
-            from .consensus.collector_fetcher import update_voting_authorities
-            update_voting_authorities(
+            registry.update_voting_authorities(
                 collector_consensus_data.get('flag_thresholds')
                 or collector_consensus_data.get('votes')
             )

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -143,6 +143,22 @@ class Relays:
         # Legacy attribute for backward compatibility
         self.collector_data = None
 
+        # Make the voting-authority set dynamic based on the authorities that actually
+        # voted this consensus round. This handles authorities being removed/added
+        # (e.g. gabelmoo going offline) so reachability, per-authority tables, and
+        # diagnostics use the correct denominator instead of a stale hardcoded 9.
+        # Done EARLY (before uptime/bandwidth/network-health/collector steps below) so
+        # every downstream consumer sees the corrected voting count. Empty vote data
+        # is ignored by update_voting_authorities(), keeping the fallback.
+        if collector_consensus_data:
+            _flag_thresholds = collector_consensus_data.get('flag_thresholds') or {}
+            _vote_names = list(_flag_thresholds.keys()) or list(
+                (collector_consensus_data.get('votes') or {}).keys()
+            )
+            if _vote_names:
+                from .consensus.collector_fetcher import update_voting_authorities
+                update_voting_authorities(_vote_names)
+
         # Steps 8-10: Uptime processing → regenerate leaderboards + health
         if uptime_data:
             self._reprocess_uptime_data()

--- a/allium/templates/misc-authorities.html
+++ b/allium/templates/misc-authorities.html
@@ -152,11 +152,16 @@
             <tr>
                 {% set is_problematic = not authority.running or (authority.uptime_zscore and authority.uptime_zscore <= -2.0) -%}
                 <td>
-                    {% if authority.is_known_offline %}{# Removed authority aged out of live data: no relay page exists, so plain text (no 404 link) #}<span style="color: #dc3545; font-weight: bold;">{{ authority.nickname }}</span> <span class="al-status-muted" style="font-size: 0.85em;" title="{{ authority.offline_note }}">(removed — shown for context)</span>{% else %}<a href="{{ page_ctx.path_prefix }}relay/{{ authority.fingerprint }}/" 
+                    {% if authority.is_known_offline %}
+                    {# Removed authority aged out of live data: no relay page exists, so plain text (no 404 link) #}
+                    <span style="color: #dc3545; font-weight: bold;">{{ authority.nickname }}</span> <span class="al-status-muted" style="font-size: 0.85em;" title="{{ authority.offline_note }}">(removed — shown for context)</span>
+                    {% else %}
+                    <a href="{{ page_ctx.path_prefix }}relay/{{ authority.fingerprint }}/" 
                        {% if is_problematic %}style="color: #dc3545; font-weight: bold; text-decoration: underline;"
                        {% else %}class="al-link-plain"{% endif %}>
                         {{ authority.nickname }}
-                    </a>{% endif %}
+                    </a>
+                    {% endif %}
                 </td>
                 <td>
                     {% if authority.running -%}

--- a/allium/templates/misc-authorities.html
+++ b/allium/templates/misc-authorities.html
@@ -15,7 +15,13 @@
     </p>
 
     <ul style="margin-bottom: 15px;">
-        <li><strong>Directory Authorities:</strong> {{ relays.authorities_summary.total_authorities }} authorities discovered (dynamic from Onionoo)</li>
+        <li><strong>Directory Authorities:</strong> {{ relays.authorities_summary.total_authorities }} authorities discovered (dynamic from Onionoo)
+            {% if relays.authorities_summary.offline_count %}
+            <ul style="margin-top: 4px;">
+                <li><span class="al-status-danger">🔴 {{ relays.authorities_summary.offline_count }} offline</span>: {{ relays.authorities_summary.offline_names | join(', ') }} <span style="font-size: 0.85em; color: #666;">(shown for historical context)</span></li>
+            </ul>
+            {% endif %}
+        </li>
         
         {# Consensus status from CollecTor #}
         {% if relays.consensus_status %}
@@ -146,11 +152,17 @@
             <tr>
                 {% set is_problematic = not authority.running or (authority.uptime_zscore and authority.uptime_zscore <= -2.0) -%}
                 <td>
-                    <a href="{{ page_ctx.path_prefix }}relay/{{ authority.fingerprint }}/" 
-                       {% if is_problematic %}style="color: #dc3545; font-weight: bold; text-decoration: underline;"
-                       {% else %}class="al-link-plain"{% endif %}>
-                        {{ authority.nickname }}
-                    </a>
+                    {% if authority.is_known_offline -%}
+                        {# Removed authority aged out of live data: no relay page exists, so plain text (no 404 link) #}
+                        <span style="color: #dc3545; font-weight: bold;">{{ authority.nickname }}</span>
+                        <span class="al-status-muted" style="font-size: 0.85em;" title="{{ authority.offline_note }}">(removed — shown for context)</span>
+                    {% else -%}
+                        <a href="{{ page_ctx.path_prefix }}relay/{{ authority.fingerprint }}/" 
+                           {% if is_problematic %}style="color: #dc3545; font-weight: bold; text-decoration: underline;"
+                           {% else %}class="al-link-plain"{% endif %}>
+                            {{ authority.nickname }}
+                        </a>
+                    {%- endif %}
                 </td>
                 <td>
                     {% if authority.running -%}
@@ -316,6 +328,7 @@
         <h4>Legend:</h4>
         <ul style="margin: 0; padding-left: 20px;">
             <li><strong>Online:</strong> 🟢 = Online, 🔴 = Offline</li>
+            <li><strong>🔴 "removed — shown for context":</strong> A directory authority that was removed from the consensus and has aged out of live data sources (Onionoo/CollecTor). Retained here as a hardcoded placeholder for historical context after such a critical change; all other data on this page is dynamic. If the authority returns, its live data automatically supersedes this placeholder.</li>
             <li><strong>Voted:</strong> Shows number of relays in authority's vote. <span class="al-status-success-bold">Green (&gt;1)</span> = Vote received with relays, <span class="al-status-danger-bold">Red (0)</span> = No vote or empty. Hover for details and check timestamp.</li>
             <li><strong>BW Auth:</strong> <span class="al-status-success-bold">Yes</span> = Runs bandwidth scanner (sbws), <span class="al-status-muted">No</span> = Does not run scanner</li>
             <li><strong>Latency (ms):</strong> TCP connection time to authority's directory port. <span class="al-status-warning">Orange = &gt;200ms</span>, <span class="al-status-danger-bold">Red = &gt;500ms</span>, <span class="al-status-danger-bold">Timeout</span> = &gt;2s, <span class="al-status-danger-bold">✗</span> = Connection failed. Hover for exact time and check timestamp.</li>

--- a/allium/templates/misc-authorities.html
+++ b/allium/templates/misc-authorities.html
@@ -152,17 +152,11 @@
             <tr>
                 {% set is_problematic = not authority.running or (authority.uptime_zscore and authority.uptime_zscore <= -2.0) -%}
                 <td>
-                    {% if authority.is_known_offline -%}
-                        {# Removed authority aged out of live data: no relay page exists, so plain text (no 404 link) #}
-                        <span style="color: #dc3545; font-weight: bold;">{{ authority.nickname }}</span>
-                        <span class="al-status-muted" style="font-size: 0.85em;" title="{{ authority.offline_note }}">(removed — shown for context)</span>
-                    {% else -%}
-                        <a href="{{ page_ctx.path_prefix }}relay/{{ authority.fingerprint }}/" 
-                           {% if is_problematic %}style="color: #dc3545; font-weight: bold; text-decoration: underline;"
-                           {% else %}class="al-link-plain"{% endif %}>
-                            {{ authority.nickname }}
-                        </a>
-                    {%- endif %}
+                    {% if authority.is_known_offline %}{# Removed authority aged out of live data: no relay page exists, so plain text (no 404 link) #}<span style="color: #dc3545; font-weight: bold;">{{ authority.nickname }}</span> <span class="al-status-muted" style="font-size: 0.85em;" title="{{ authority.offline_note }}">(removed — shown for context)</span>{% else %}<a href="{{ page_ctx.path_prefix }}relay/{{ authority.fingerprint }}/" 
+                       {% if is_problematic %}style="color: #dc3545; font-weight: bold; text-decoration: underline;"
+                       {% else %}class="al-link-plain"{% endif %}>
+                        {{ authority.nickname }}
+                    </a>{% endif %}
                 </td>
                 <td>
                     {% if authority.running -%}

--- a/allium/templates/misc-authorities.html
+++ b/allium/templates/misc-authorities.html
@@ -154,7 +154,7 @@
                 <td>
                     {% if authority.is_known_offline %}
                     {# Removed authority aged out of live data: no relay page exists, so plain text (no 404 link) #}
-                    <span style="color: #dc3545; font-weight: bold;">{{ authority.nickname }}</span> <span class="al-status-muted" style="font-size: 0.85em;" title="{{ authority.offline_note }}">(removed — shown for context)</span>
+                    <span style="color: #dc3545; font-weight: bold;">{{ authority.nickname }}</span> <span class="al-status-muted" style="font-size: 0.85em;" title="{{ authority.offline_note }}">(Onionoo removed due to offline longer than 1 week — shown for context)</span>
                     {% else %}
                     <a href="{{ page_ctx.path_prefix }}relay/{{ authority.fingerprint }}/" 
                        {% if is_problematic %}style="color: #dc3545; font-weight: bold; text-decoration: underline;"
@@ -327,7 +327,7 @@
         <h4>Legend:</h4>
         <ul style="margin: 0; padding-left: 20px;">
             <li><strong>Online:</strong> 🟢 = Online, 🔴 = Offline</li>
-            <li><strong>🔴 "removed — shown for context":</strong> A directory authority that was removed from the consensus and has aged out of live data sources (Onionoo/CollecTor). Retained here as a hardcoded placeholder for historical context after such a critical change; all other data on this page is dynamic. If the authority returns, its live data automatically supersedes this placeholder.</li>
+            <li><strong>🔴 "Onionoo removed due to offline longer than 1 week — shown for context":</strong> A directory authority that stopped voting and was then dropped by Onionoo, which only lists relays seen in a network status within the past week (~7 days, per the <a href="https://metrics.torproject.org/onionoo.html" target="_blank" rel="noopener">Onionoo protocol</a>). Retained here as a hardcoded placeholder for historical context after such a critical change; all other data on this page is dynamic. If the authority returns, its live data automatically supersedes this placeholder.</li>
             <li><strong>Voted:</strong> Shows number of relays in authority's vote. <span class="al-status-success-bold">Green (&gt;1)</span> = Vote received with relays, <span class="al-status-danger-bold">Red (0)</span> = No vote or empty. Hover for details and check timestamp.</li>
             <li><strong>BW Auth:</strong> <span class="al-status-success-bold">Yes</span> = Runs bandwidth scanner (sbws), <span class="al-status-muted">No</span> = Does not run scanner</li>
             <li><strong>Latency (ms):</strong> TCP connection time to authority's directory port. <span class="al-status-warning">Orange = &gt;200ms</span>, <span class="al-status-danger-bold">Red = &gt;500ms</span>, <span class="al-status-danger-bold">Timeout</span> = &gt;2s, <span class="al-status-danger-bold">✗</span> = Connection failed. Hover for exact time and check timestamp.</li>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,10 +116,98 @@ def make_relays(temp_dir):
     """
     from allium.lib.relays import Relays
 
-    def _make(relay_data, onionoo_url=TEST_DETAILS_URL):
+    def _make(relay_data, onionoo_url=TEST_DETAILS_URL) -> Relays:
         return Relays(temp_dir, onionoo_url, relay_data)
 
     return _make
+
+
+@pytest.fixture
+def mock_uptime_response():
+    """Onionoo uptime document for three mock directory authorities
+    (moria1: good, tor26: excellent, dannenberg: poor uptime)."""
+    return {
+        "version": "10.0",
+        "build_revision": "unknown",
+        "relays_published": "2025-01-01 00:00:00",
+        "relays": [
+            {
+                "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
+                "uptime": {
+                    "1_month": {
+                        "factor": 0.01,
+                        "count": 720,
+                        "values": [99.2, 98.8, 99.1, 99.0, 98.9]  # Good uptime
+                    },
+                    "6_months": {
+                        "factor": 0.01,
+                        "count": 4320,
+                        "values": [98.5, 98.8, 99.0, 98.7, 98.6]
+                    },
+                    "1_year": {
+                        "factor": 0.01,
+                        "count": 8760,
+                        "values": [97.5, 97.8, 98.0, 97.9, 97.6]
+                    },
+                    "5_years": {
+                        "factor": 0.01,
+                        "count": 43800,
+                        "values": [96.8, 97.0, 97.2, 96.9, 96.7]
+                    }
+                }
+            },
+            {
+                "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
+                "uptime": {
+                    "1_month": {
+                        "factor": 0.01,
+                        "count": 720,
+                        "values": [99.8, 99.6, 99.7, 99.5, 99.9]  # Excellent uptime
+                    },
+                    "6_months": {
+                        "factor": 0.01,
+                        "count": 4320,
+                        "values": [99.6, 99.4, 99.5, 99.3, 99.7]
+                    },
+                    "1_year": {
+                        "factor": 0.01,
+                        "count": 8760,
+                        "values": [99.1, 99.0, 99.2, 98.9, 99.3]
+                    },
+                    "5_years": {
+                        "factor": 0.01,
+                        "count": 43800,
+                        "values": [98.7, 98.5, 98.9, 98.6, 98.8]
+                    }
+                }
+            },
+            {
+                "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
+                "uptime": {
+                    "1_month": {
+                        "factor": 0.01,
+                        "count": 720,
+                        "values": [89.2, 88.5, 90.1, 87.8, 89.9]  # Poor uptime
+                    },
+                    "6_months": {
+                        "factor": 0.01,
+                        "count": 4320,
+                        "values": [85.7, 86.2, 85.0, 86.8, 85.3]
+                    },
+                    "1_year": {
+                        "factor": 0.01,
+                        "count": 8760,
+                        "values": [82.1, 83.0, 81.5, 82.8, 81.9]
+                    },
+                    "5_years": {
+                        "factor": 0.01,
+                        "count": 43800,
+                        "values": [78.5, 79.2, 78.0, 79.8, 78.1]
+                    }
+                }
+            }
+        ]
+    }
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,11 @@ TEST_AROI_URL = "https://test.aroi.url/validate"
 TEST_EXIT_DNS_HEALTH_URL = "https://test.exitdnshealth.url/latest.json"
 TEST_BANDWIDTH_CACHE_HOURS = 1
 
+# The 8 currently-voting directory authorities (gabelmoo removed) - alphabetical.
+# Shared by the dynamic voting-authority tests (collector fetcher, diagnostics).
+ACTIVE_VOTING_AUTHORITIES_8 = ['bastet', 'dannenberg', 'dizum', 'faravahar',
+                               'longclaw', 'maatuska', 'moria1', 'tor26']
+
 
 # ============================================================================
 # PYTEST FIXTURES - Common test data and utilities
@@ -82,6 +87,39 @@ def temp_dir():
     """Fixture that provides a temporary directory that's cleaned up after the test."""
     with tempfile.TemporaryDirectory() as tmpdir:
         yield tmpdir
+
+
+@pytest.fixture
+def voting_registry_8_voters():
+    """Set the shared authority registry to the 8 active voters (gabelmoo removed).
+
+    Updates the module singleton via the global update_voting_authorities()
+    wrapper before the test and restores the hardcoded fallback afterwards, so
+    dynamic-voting tests never leak state into other tests.
+    """
+    from allium.lib.consensus.collector_fetcher import (
+        get_authority_registry,
+        update_voting_authorities,
+    )
+    registry = get_authority_registry()
+    update_voting_authorities(ACTIVE_VOTING_AUTHORITIES_8)
+    yield registry
+    registry.clear_voting_authorities()
+
+
+@pytest.fixture
+def make_relays(temp_dir):
+    """Factory that builds a Relays instance writing into a per-test temp directory.
+
+    Shared setup for the directory-authority integration tests (and any other
+    test that needs a real Relays object without hitting the network).
+    """
+    from allium.lib.relays import Relays
+
+    def _make(relay_data, onionoo_url=TEST_DETAILS_URL):
+        return Relays(temp_dir, onionoo_url, relay_data)
+
+    return _make
 
 
 @pytest.fixture

--- a/tests/integration/test_authorities.py
+++ b/tests/integration/test_authorities.py
@@ -222,7 +222,7 @@ class TestDirectoryAuthorities(unittest.TestCase):
                                if not a.get('is_known_offline')]
         self.assertEqual(len(dynamic_authorities), 1)
         self.assertEqual(dynamic_authorities[0]['nickname'], 'moria1')
-        
+
         # Verify summary (authority-flag count excludes offline placeholders)
         self.assertEqual(authorities_info['authorities_summary']['total_authorities'], 1)
 

--- a/tests/integration/test_authorities.py
+++ b/tests/integration/test_authorities.py
@@ -215,11 +215,15 @@ class TestDirectoryAuthorities(unittest.TestCase):
         self.assertIn('authorities_data', authorities_info)
         self.assertIn('authorities_summary', authorities_info)
         
-        # Verify only authorities are returned (not regular relays)
-        self.assertEqual(len(authorities_info['authorities_data']), 1)
-        self.assertEqual(authorities_info['authorities_data'][0]['nickname'], 'moria1')
+        # Verify only authorities are returned (not regular relays).
+        # Exclude hardcoded known-offline placeholders (e.g. gabelmoo) that are merged
+        # in for historical context; they are not part of the dynamic Onionoo set.
+        dynamic_authorities = [a for a in authorities_info['authorities_data']
+                               if not a.get('is_known_offline')]
+        self.assertEqual(len(dynamic_authorities), 1)
+        self.assertEqual(dynamic_authorities[0]['nickname'], 'moria1')
         
-        # Verify summary
+        # Verify summary (authority-flag count excludes offline placeholders)
         self.assertEqual(authorities_info['authorities_summary']['total_authorities'], 1)
 
     @patch('urllib.request.urlopen')
@@ -300,11 +304,13 @@ class TestDirectoryAuthorities(unittest.TestCase):
         authorities_info = relays._get_directory_authorities_data()
         authorities = authorities_info['authorities_data']
         
-        # Verify we got expected number of authorities (only relays with Authority flag)
-        self.assertEqual(len(authorities), 3)
+        # Verify we got expected number of authorities (only relays with Authority flag).
+        # Exclude hardcoded known-offline placeholders (e.g. gabelmoo) merged in for context.
+        dynamic_authorities = [a for a in authorities if not a.get('is_known_offline')]
+        self.assertEqual(len(dynamic_authorities), 3)
         
         # Verify authorities are found (order may vary)
-        nicknames = [auth['nickname'] for auth in authorities]
+        nicknames = [auth['nickname'] for auth in dynamic_authorities]
         self.assertIn('dannenberg', nicknames)
         self.assertIn('moria1', nicknames)
         self.assertIn('tor26', nicknames)
@@ -360,7 +366,10 @@ class TestDirectoryAuthorities(unittest.TestCase):
         # Verify authority data and summary were stored as attributes
         self.assertTrue(hasattr(relays, 'authorities_data'))
         self.assertTrue(hasattr(relays, 'authorities_summary'))
-        self.assertEqual(len(relays.authorities_data), 1)
+        # Exclude hardcoded known-offline placeholders (e.g. gabelmoo) merged in for context.
+        dynamic_authorities = [a for a in relays.authorities_data
+                               if not a.get('is_known_offline')]
+        self.assertEqual(len(dynamic_authorities), 1)
         self.assertEqual(relays.authorities_summary['total_authorities'], 1)
         
         # Verify output file was created
@@ -377,9 +386,12 @@ class TestDirectoryAuthorities(unittest.TestCase):
         empty_relay_data = {"relays": []}
         relays = Relays(self.test_dir, self.test_onionoo_url, empty_relay_data)
         
-        # Should still work but authorities will have empty uptime data
+        # Should still work but authorities will have empty uptime data.
+        # Exclude hardcoded known-offline placeholders (e.g. gabelmoo) merged in for context.
         authorities_info = relays._get_directory_authorities_data()
-        self.assertEqual(len(authorities_info['authorities_data']), 0)  # No authorities since no relays with Authority flag
+        dynamic_authorities = [a for a in authorities_info['authorities_data']
+                               if not a.get('is_known_offline')]
+        self.assertEqual(len(dynamic_authorities), 0)  # No authorities since no relays with Authority flag
 
     @patch('urllib.request.urlopen')
     def test_uptime_edge_cases(self, mock_urlopen):
@@ -409,8 +421,10 @@ class TestDirectoryAuthorities(unittest.TestCase):
         authorities_info = relays._get_directory_authorities_data()
         authorities = authorities_info['authorities_data']
         
-        # Should handle missing uptime gracefully
-        self.assertEqual(len(authorities), 1)
+        # Should handle missing uptime gracefully.
+        # Exclude hardcoded known-offline placeholders (e.g. gabelmoo) merged in for context.
+        dynamic_authorities = [a for a in authorities if not a.get('is_known_offline')]
+        self.assertEqual(len(dynamic_authorities), 1)
         # Note: The actual implementation may not set these fields if uptime data is missing
         # The test focuses on proper handling without errors
 
@@ -543,8 +557,11 @@ class TestDirectoryAuthorities(unittest.TestCase):
         
         relays = Relays(self.test_dir, self.test_onionoo_url, main_response_no_authorities)
         
+        # Exclude hardcoded known-offline placeholders (e.g. gabelmoo) merged in for context.
         authorities_info = relays._get_directory_authorities_data()
-        self.assertEqual(len(authorities_info['authorities_data']), 0)
+        dynamic_authorities = [a for a in authorities_info['authorities_data']
+                               if not a.get('is_known_offline')]
+        self.assertEqual(len(dynamic_authorities), 0)
 
 
     def test_template_validation(self):
@@ -647,6 +664,106 @@ class TestAuthorityIntegration(unittest.TestCase):
             self.fail(f"Authorities integration failed: {e}")
 
 
+class TestKnownOfflineAuthorityMerge(unittest.TestCase):
+    """Tests for retaining removed/offline authorities on the DA page (Task 5).
+
+    A directory authority removed from the consensus eventually ages out of all live
+    data sources, so it would vanish from the page. A small hardcoded list keeps such
+    authorities visible (as offline) - but only when NOT present dynamically, and
+    without ever affecting the voting/reachability counts.
+    """
+
+    GABELMOO_FP = 'F2044413DAC2E02E3D6BCF4735A19BCA1DE97281'
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.test_onionoo_url = "https://test.onionoo.url/details"
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def _authorities_by_nick(self, authorities_info):
+        return {a['nickname']: a for a in authorities_info['authorities_data']}
+
+    def test_offline_authority_merged_when_absent(self):
+        """gabelmoo absent from Onionoo -> appears as an offline, context-only row."""
+        mock_relay_data = {
+            "relays": [
+                {
+                    "nickname": "moria1",
+                    "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
+                    "running": True,
+                    "flags": ["Authority", "Running", "V2Dir", "Valid"],
+                    "country": "US", "country_name": "United States",
+                    "first_seen": "2015-03-11 20:00:00",
+                    "platform": "Tor 0.4.8.12 on Linux",
+                    "observed_bandwidth": 1000000, "consensus_weight": 5000,
+                },
+            ]
+        }
+        relays = Relays(self.test_dir, self.test_onionoo_url, mock_relay_data)
+        info = relays._get_directory_authorities_data()
+        by_nick = self._authorities_by_nick(info)
+
+        # gabelmoo is merged in as offline / context-only
+        self.assertIn('gabelmoo', by_nick)
+        self.assertFalse(by_nick['gabelmoo']['running'])
+        self.assertTrue(by_nick['gabelmoo'].get('is_known_offline'))
+        # No broken relay link source: it carries an offline_note for the badge tooltip
+        self.assertTrue(by_nick['gabelmoo'].get('offline_note'))
+
+        # The live authority is untouched (not flagged offline)
+        self.assertTrue(by_nick['moria1']['running'])
+        self.assertFalse(by_nick['moria1'].get('is_known_offline', False))
+
+        # Counts: dynamic authority-flag count EXCLUDES the hardcoded offline row
+        self.assertEqual(info['authorities_summary']['total_with_authority_flag'], 1)
+        # Offline summary (dynamic) reflects gabelmoo
+        self.assertGreaterEqual(info['authorities_summary']['offline_count'], 1)
+        self.assertIn('gabelmoo', info['authorities_summary']['offline_names'])
+        # Alphabetical ordering preserved after merge
+        nicks = [a['nickname'] for a in info['authorities_data']]
+        self.assertEqual(nicks, sorted(nicks, key=str.lower))
+
+    def test_offline_authority_not_duplicated_when_present(self):
+        """gabelmoo present in Onionoo -> live row wins, no hardcoded duplicate."""
+        mock_relay_data = {
+            "relays": [
+                {
+                    "nickname": "moria1",
+                    "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
+                    "running": True,
+                    "flags": ["Authority", "Running", "V2Dir", "Valid"],
+                    "country": "US", "country_name": "United States",
+                    "first_seen": "2015-03-11 20:00:00",
+                    "platform": "Tor 0.4.8.12 on Linux",
+                    "observed_bandwidth": 1000000, "consensus_weight": 5000,
+                },
+                {
+                    "nickname": "gabelmoo",
+                    "fingerprint": self.GABELMOO_FP,
+                    "running": True,
+                    "flags": ["Authority", "Running", "V2Dir", "Valid"],
+                    "country": "DE", "country_name": "Germany",
+                    "first_seen": "2010-03-22 11:00:00",
+                    "platform": "Tor 0.4.9.9 on Linux",
+                    "observed_bandwidth": 9810000, "consensus_weight": 20,
+                },
+            ]
+        }
+        relays = Relays(self.test_dir, self.test_onionoo_url, mock_relay_data)
+        info = relays._get_directory_authorities_data()
+
+        gabelmoo_rows = [a for a in info['authorities_data'] if a['nickname'] == 'gabelmoo']
+        self.assertEqual(len(gabelmoo_rows), 1)  # no duplicate
+        # The live row wins: running True, not flagged as the hardcoded offline entry
+        self.assertTrue(gabelmoo_rows[0]['running'])
+        self.assertFalse(gabelmoo_rows[0].get('is_known_offline', False))
+        # Both authorities online -> offline summary empty, and gabelmoo counted live
+        self.assertEqual(info['authorities_summary']['offline_count'], 0)
+        self.assertEqual(info['authorities_summary']['total_with_authority_flag'], 2)
+
+
 if __name__ == '__main__':
     # Create test suite
     loader = unittest.TestLoader()
@@ -655,6 +772,7 @@ if __name__ == '__main__':
     # Add test cases
     suite.addTests(loader.loadTestsFromTestCase(TestDirectoryAuthorities))
     suite.addTests(loader.loadTestsFromTestCase(TestAuthorityIntegration))
+    suite.addTests(loader.loadTestsFromTestCase(TestKnownOfflineAuthorityMerge))
     
     # Run tests
     runner = unittest.TextTestRunner(verbosity=2)

--- a/tests/integration/test_authorities.py
+++ b/tests/integration/test_authorities.py
@@ -3,8 +3,9 @@
 """
 Test suite for directory authorities functionality.
 
-Pytest-style tests: shared relay construction and temp-directory handling live
-in the make_relays / temp_dir fixtures defined in tests/conftest.py.
+Pytest-style tests: shared relay construction, temp-directory handling, and
+mock uptime data live in the make_relays / temp_dir / mock_uptime_response
+fixtures defined in tests/conftest.py.
 """
 
 import json
@@ -15,97 +16,6 @@ import pytest
 
 
 GABELMOO_FP = 'F2044413DAC2E02E3D6BCF4735A19BCA1DE97281'
-
-
-# ============================================================================
-# Shared mock data
-# ============================================================================
-
-@pytest.fixture
-def mock_uptime_response():
-    """Onionoo uptime document for the three mock authorities."""
-    return {
-        "version": "10.0",
-        "build_revision": "unknown",
-        "relays_published": "2025-01-01 00:00:00",
-        "relays": [
-            {
-                "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
-                "uptime": {
-                    "1_month": {
-                        "factor": 0.01,
-                        "count": 720,
-                        "values": [99.2, 98.8, 99.1, 99.0, 98.9]  # Good uptime
-                    },
-                    "6_months": {
-                        "factor": 0.01,
-                        "count": 4320,
-                        "values": [98.5, 98.8, 99.0, 98.7, 98.6]
-                    },
-                    "1_year": {
-                        "factor": 0.01,
-                        "count": 8760,
-                        "values": [97.5, 97.8, 98.0, 97.9, 97.6]
-                    },
-                    "5_years": {
-                        "factor": 0.01,
-                        "count": 43800,
-                        "values": [96.8, 97.0, 97.2, 96.9, 96.7]
-                    }
-                }
-            },
-            {
-                "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
-                "uptime": {
-                    "1_month": {
-                        "factor": 0.01,
-                        "count": 720,
-                        "values": [99.8, 99.6, 99.7, 99.5, 99.9]  # Excellent uptime
-                    },
-                    "6_months": {
-                        "factor": 0.01,
-                        "count": 4320,
-                        "values": [99.6, 99.4, 99.5, 99.3, 99.7]
-                    },
-                    "1_year": {
-                        "factor": 0.01,
-                        "count": 8760,
-                        "values": [99.1, 99.0, 99.2, 98.9, 99.3]
-                    },
-                    "5_years": {
-                        "factor": 0.01,
-                        "count": 43800,
-                        "values": [98.7, 98.5, 98.9, 98.6, 98.8]
-                    }
-                }
-            },
-            {
-                "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
-                "uptime": {
-                    "1_month": {
-                        "factor": 0.01,
-                        "count": 720,
-                        "values": [89.2, 88.5, 90.1, 87.8, 89.9]  # Poor uptime
-                    },
-                    "6_months": {
-                        "factor": 0.01,
-                        "count": 4320,
-                        "values": [85.7, 86.2, 85.0, 86.8, 85.3]
-                    },
-                    "1_year": {
-                        "factor": 0.01,
-                        "count": 8760,
-                        "values": [82.1, 83.0, 81.5, 82.8, 81.9]
-                    },
-                    "5_years": {
-                        "factor": 0.01,
-                        "count": 43800,
-                        "values": [78.5, 79.2, 78.0, 79.8, 78.1]
-                    }
-                }
-            }
-        ]
-    }
 
 
 def _dynamic_authorities(authorities):

--- a/tests/integration/test_authorities.py
+++ b/tests/integration/test_authorities.py
@@ -540,6 +540,10 @@ def test_offline_authority_merged_when_absent(make_relays):
 
     # Counts: dynamic authority-flag count EXCLUDES the hardcoded offline row
     assert info['authorities_summary']['total_with_authority_flag'] == 1
+    # The voting denominator (the 8/9 -> 8/8 regression this fixes) also
+    # excludes the offline row: no collector data here, so it falls back to
+    # the dynamic Onionoo authority count
+    assert info['authorities_summary']['total_authorities'] == 1
     # Offline summary (dynamic) reflects gabelmoo
     assert info['authorities_summary']['offline_count'] >= 1
     assert 'gabelmoo' in info['authorities_summary']['offline_names']

--- a/tests/integration/test_authorities.py
+++ b/tests/integration/test_authorities.py
@@ -1,782 +1,677 @@
 #!/usr/bin/env python3
 
 """
-Test suite for directory authorities functionality
+Test suite for directory authorities functionality.
+
+Pytest-style tests: shared relay construction and temp-directory handling live
+in the make_relays / temp_dir fixtures defined in tests/conftest.py.
 """
 
 import json
 import os
-import shutil
-import tempfile
-import unittest
-from unittest.mock import Mock, patch, mock_open
+from unittest.mock import Mock, patch
 
-from allium.lib.relays import Relays
+import pytest
 
 
-class TestDirectoryAuthorities(unittest.TestCase):
-    """Test directory authorities functionality"""
+GABELMOO_FP = 'F2044413DAC2E02E3D6BCF4735A19BCA1DE97281'
 
-    def setUp(self):
-        """Set up test fixtures"""
-        self.test_dir = tempfile.mkdtemp()
-        self.test_onionoo_url = "https://test.onionoo.url/details"
-        
-        # Mock authority data
-        self.mock_authorities_response = {
-            "version": "10.0",
-            "build_revision": "unknown",
-            "relays_published": "2025-01-01 00:00:00",
-            "relays_skipped": 0,
-            "relays_truncated": 0,
-            "relays": [
-                {
-                    "nickname": "moria1",
-                    "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",  
-                    "running": True,
-                    "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
-                    "country": "US",
-                    "country_name": "United States",
-                    "as": "AS3",
-                    "as_name": "MIT",
-                    "contact": "tor-ops@mit.edu",
-                    "version": "0.4.8.12",
-                    "platform": "Tor 0.4.8.12 on Linux",
-                    "first_seen": "2015-03-11 20:00:00",
-                    "last_restarted": "2025-05-29 08:18:56",
-                    "last_seen": "2025-01-01 00:00:00"
-                },
-                {
-                    "nickname": "tor26", 
-                    "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
-                    "running": True,
-                    "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
-                    "country": "AT",
-                    "country_name": "Austria", 
-                    "as": "AS5404",
-                    "as_name": "conova communications GmbH",
-                    "contact": "tor-ops@conova.com",
-                    "version": "0.4.8.12",
-                    "platform": "Tor 0.4.8.12 on Linux",
-                    "first_seen": "2015-07-30 10:15:00",
-                    "last_restarted": "2025-05-31 13:28:19",
-                    "last_seen": "2025-01-01 00:00:00"
-                },
-                {
-                    "nickname": "dannenberg",
-                    "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
-                    "running": True,
-                    "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
-                    "country": "DE",
-                    "country_name": "Germany",
-                    "as": "AS39788", 
-                    "as_name": "Chaos Computer Club e.V.",
-                    "contact": "tor-ops@ccc.de",
-                    "version": "0.4.7.16",  # Outdated version
-                    "platform": "Tor 0.4.7.16 on Linux",
-                    "first_seen": "2018-03-22 18:00:00",
-                    "last_restarted": "2025-04-12 09:15:42", 
-                    "last_seen": "2025-01-01 00:00:00"
-                }
-            ]
-        }
-        
-        # Mock uptime data
-        self.mock_uptime_response = {
-            "version": "10.0",
-            "build_revision": "unknown",
-            "relays_published": "2025-01-01 00:00:00",
-            "relays": [
-                {
-                    "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
-                    "uptime": {
-                        "1_month": {
-                            "factor": 0.01,
-                            "count": 720,
-                            "values": [99.2, 98.8, 99.1, 99.0, 98.9]  # Good uptime
-                        },
-                        "6_months": {
-                            "factor": 0.01,
-                            "count": 4320,
-                            "values": [98.5, 98.8, 99.0, 98.7, 98.6]
-                        },
-                        "1_year": {
-                            "factor": 0.01,
-                            "count": 8760,
-                            "values": [97.5, 97.8, 98.0, 97.9, 97.6]
-                        },
-                        "5_years": {
-                            "factor": 0.01,
-                            "count": 43800,
-                            "values": [96.8, 97.0, 97.2, 96.9, 96.7]
-                        }
-                    }
-                },
-                {
-                    "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D", 
-                    "uptime": {
-                        "1_month": {
-                            "factor": 0.01,
-                            "count": 720,
-                            "values": [99.8, 99.6, 99.7, 99.5, 99.9]  # Excellent uptime
-                        },
-                        "6_months": {
-                            "factor": 0.01,
-                            "count": 4320,
-                            "values": [99.6, 99.4, 99.5, 99.3, 99.7]
-                        },
-                        "1_year": {
-                            "factor": 0.01,
-                            "count": 8760,
-                            "values": [99.1, 99.0, 99.2, 98.9, 99.3]
-                        },
-                        "5_years": {
-                            "factor": 0.01,
-                            "count": 43800,
-                            "values": [98.7, 98.5, 98.9, 98.6, 98.8]
-                        }
-                    }
-                },
-                {
-                    "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
-                    "uptime": {
-                        "1_month": {
-                            "factor": 0.01,
-                            "count": 720,
-                            "values": [89.2, 88.5, 90.1, 87.8, 89.9]  # Poor uptime
-                        },
-                        "6_months": {
-                            "factor": 0.01,
-                            "count": 4320,
-                            "values": [85.7, 86.2, 85.0, 86.8, 85.3]
-                        },
-                        "1_year": {
-                            "factor": 0.01,
-                            "count": 8760,
-                            "values": [82.1, 83.0, 81.5, 82.8, 81.9]
-                        },
-                        "5_years": {
-                            "factor": 0.01,
-                            "count": 43800,
-                            "values": [78.5, 79.2, 78.0, 79.8, 78.1]
-                        }
-                    }
-                }
-            ]
-        }
 
-    def tearDown(self):
-        """Clean up test fixtures"""
-        shutil.rmtree(self.test_dir)
+# ============================================================================
+# Shared mock data
+# ============================================================================
 
-    def test_get_directory_authorities_data(self):
-        """Test directory authorities data processing"""
-        # Create Relays instance with mock authority data
-        mock_relay_data = {
-            "relays": [
-                {
-                    "nickname": "moria1",
-                    "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",  
-                    "running": True,
-                    "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
-                    "country": "US",
-                    "country_name": "United States",
-                    "version": "0.4.8.12",
-                    "platform": "Tor 0.4.8.12 on Linux",
-                    "first_seen": "2015-03-11 20:00:00",
-                    "observed_bandwidth": 1000000,
-                    "consensus_weight": 5000,
-                    "uptime_percentages": {
-                        "1_month": 99.2,
-                        "6_months": 98.5,
-                        "1_year": 97.5,
-                        "5_years": 96.8
-                    }
-                },
-                {
-                    "nickname": "regular_relay",
-                    "fingerprint": "ABCD1234567890ABCD1234567890ABCD12345678",
-                    "running": True,
-                    "flags": ["Running", "Valid"],  # No Authority flag
-                    "observed_bandwidth": 1000000,
-                    "consensus_weight": 3000,
-                    "first_seen": "2024-01-01 12:00:00",
-                    "platform": "Tor 0.4.8.12 on Linux"
-                }
-            ]
-        }
-        
-        relays = Relays(self.test_dir, self.test_onionoo_url, mock_relay_data)
-        
-        # Test authorities data extraction
-        authorities_info = relays._get_directory_authorities_data()
-        
-        # Verify structure
-        self.assertIn('authorities_data', authorities_info)
-        self.assertIn('authorities_summary', authorities_info)
-        
-        # Verify only authorities are returned (not regular relays).
-        # Exclude hardcoded known-offline placeholders (e.g. gabelmoo) that are merged
-        # in for historical context; they are not part of the dynamic Onionoo set.
-        dynamic_authorities = [a for a in authorities_info['authorities_data']
-                               if not a.get('is_known_offline')]
-        self.assertEqual(len(dynamic_authorities), 1)
-        self.assertEqual(dynamic_authorities[0]['nickname'], 'moria1')
-
-        # Verify summary (authority-flag count excludes offline placeholders)
-        self.assertEqual(authorities_info['authorities_summary']['total_authorities'], 1)
-
-    @patch('urllib.request.urlopen')
-    def test_process_directory_authorities(self, mock_urlopen):
-        """Test processing of directory authority data"""
-        # Mock the main details response for Relays __init__ with authority data included
-        main_response_with_authorities = {
-            "relays": [
-                {
-                    "nickname": "moria1",
-                    "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",  
-                    "running": True,
-                    "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
-                    "country": "US",
-                    "country_name": "United States",
-                    "as": "AS3",
-                    "as_name": "MIT",
-                    "contact": "tor-ops@mit.edu",
-                    "version": "0.4.8.12",
-                    "platform": "Tor 0.4.8.12 on Linux",
-                    "first_seen": "2015-03-11 20:00:00",
-                    "last_restarted": "2025-05-29 08:18:56",
-                    "last_seen": "2025-01-01 00:00:00",
-                    "observed_bandwidth": 1000000
-                },
-                {
-                    "nickname": "tor26", 
-                    "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
-                    "running": True,
-                    "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
-                    "country": "AT",
-                    "country_name": "Austria", 
-                    "as": "AS5404",
-                    "as_name": "conova communications GmbH",
-                    "contact": "tor-ops@conova.com",
-                    "version": "0.4.8.12",
-                    "platform": "Tor 0.4.8.12 on Linux",
-                    "first_seen": "2015-07-30 10:15:00",
-                    "last_restarted": "2025-05-31 13:28:19",
-                    "last_seen": "2025-01-01 00:00:00",
-                    "observed_bandwidth": 1000000
-                },
-                {
-                    "nickname": "dannenberg",
-                    "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
-                    "running": True,
-                    "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
-                    "country": "DE",
-                    "country_name": "Germany",
-                    "as": "AS39788", 
-                    "as_name": "Chaos Computer Club e.V.",
-                    "contact": "tor-ops@ccc.de",
-                    "version": "0.4.7.16",  # Outdated version
-                    "platform": "Tor 0.4.7.16 on Linux",
-                    "first_seen": "2018-03-22 18:00:00",
-                    "last_restarted": "2025-04-12 09:15:42", 
-                    "last_seen": "2025-01-01 00:00:00",
-                    "observed_bandwidth": 1000000
-                },
-                {
-                    "nickname": "regular_relay",
-                    "fingerprint": "ABCD1234567890ABCD1234567890ABCD12345678",
-                    "running": True,
-                    "flags": ["Running", "Valid"],  # No Authority flag
-                    "observed_bandwidth": 1000000,
-                    "first_seen": "2024-01-01 00:00:00"
-                }
-            ]
-        }
-        
-        # Mock sequential API calls: first details, then uptime
-        details_response = Mock(read=Mock(return_value=json.dumps(main_response_with_authorities).encode('utf-8')))
-        uptime_response = Mock(read=Mock(return_value=json.dumps(self.mock_uptime_response).encode('utf-8')))
-        mock_urlopen.side_effect = [details_response, uptime_response]
-        
-        relays = Relays(self.test_dir, self.test_onionoo_url, main_response_with_authorities)
-        
-        authorities_info = relays._get_directory_authorities_data()
-        authorities = authorities_info['authorities_data']
-        
-        # Verify we got expected number of authorities (only relays with Authority flag).
-        # Exclude hardcoded known-offline placeholders (e.g. gabelmoo) merged in for context.
-        dynamic_authorities = [a for a in authorities if not a.get('is_known_offline')]
-        self.assertEqual(len(dynamic_authorities), 3)
-        
-        # Verify authorities are found (order may vary)
-        nicknames = [auth['nickname'] for auth in dynamic_authorities]
-        self.assertIn('dannenberg', nicknames)
-        self.assertIn('moria1', nicknames)
-        self.assertIn('tor26', nicknames)
-        
-        # Version compliance is now commented out, so we don't test for it
-        # Verify z-score attributes are present (may be None if no uptime data)
-        for auth in authorities:
-            self.assertIn('uptime_zscore', auth)
-            self.assertIn('uptime_outlier_status', auth)
-            # With the mock data, there's no consolidated uptime results, so these should be None
-            self.assertIsNone(auth['uptime_zscore'])
-            self.assertEqual(auth['uptime_outlier_status'], 'insufficient_data')
-
-    @patch('urllib.request.urlopen')
-    def test_write_directory_authorities(self, mock_urlopen):
-        """Test generation of directory authorities HTML page"""
-        # Mock the main details response with authority data included
-        main_response_with_authorities = {
-            "relays": [
-                {
-                    "nickname": "moria1",
-                    "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",  
-                    "running": True,
-                    "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
-                    "country": "US",
-                    "country_name": "United States",
-                    "as": "AS3",
-                    "as_name": "MIT",
-                    "contact": "tor-ops@mit.edu",
-                    "version": "0.4.8.12",
-                    "platform": "Tor 0.4.8.12 on Linux",
-                    "first_seen": "2015-03-11 20:00:00",
-                    "last_restarted": "2025-05-29 08:18:56",
-                    "last_seen": "2025-01-01 00:00:00",
-                    "observed_bandwidth": 1000000
-                }
-            ]
-        }
-        
-        # Mock sequential API calls: first details, then uptime
-        details_response = Mock(read=Mock(return_value=json.dumps(main_response_with_authorities).encode('utf-8')))
-        uptime_response = Mock(read=Mock(return_value=json.dumps(self.mock_uptime_response).encode('utf-8')))
-        mock_urlopen.side_effect = [details_response, uptime_response]
-        
-        relays = Relays(self.test_dir, self.test_onionoo_url, main_response_with_authorities)
-        
-        # Call write_misc directly since write_directory_authorities no longer exists
-        relays.write_misc(
-            template="misc-authorities.html",
-            path="misc/authorities.html"
-        )
-        
-        # Verify authority data and summary were stored as attributes
-        self.assertTrue(hasattr(relays, 'authorities_data'))
-        self.assertTrue(hasattr(relays, 'authorities_summary'))
-        # Exclude hardcoded known-offline placeholders (e.g. gabelmoo) merged in for context.
-        dynamic_authorities = [a for a in relays.authorities_data
-                               if not a.get('is_known_offline')]
-        self.assertEqual(len(dynamic_authorities), 1)
-        self.assertEqual(relays.authorities_summary['total_authorities'], 1)
-        
-        # Verify output file was created
-        output_file = os.path.join(self.test_dir, "misc", "authorities.html")
-        self.assertTrue(os.path.exists(output_file))
-
-    @patch('urllib.request.urlopen')
-    def test_network_error_handling(self, mock_urlopen):
-        """Test handling of network errors when fetching authority data"""
-        # Mock successful details response but failed uptime response
-        details_response = Mock(read=Mock(return_value=json.dumps({"relays": []}).encode('utf-8')))
-        mock_urlopen.side_effect = [details_response, Exception("Network error")]
-        
-        empty_relay_data = {"relays": []}
-        relays = Relays(self.test_dir, self.test_onionoo_url, empty_relay_data)
-        
-        # Should still work but authorities will have empty uptime data.
-        # Exclude hardcoded known-offline placeholders (e.g. gabelmoo) merged in for context.
-        authorities_info = relays._get_directory_authorities_data()
-        dynamic_authorities = [a for a in authorities_info['authorities_data']
-                               if not a.get('is_known_offline')]
-        self.assertEqual(len(dynamic_authorities), 0)  # No authorities since no relays with Authority flag
-
-    @patch('urllib.request.urlopen')
-    def test_uptime_edge_cases(self, mock_urlopen):
-        """Test edge cases in uptime processing"""
-        # Mock response with authority but missing uptime data
-        main_response_with_authority = {
-            "relays": [{
-                "nickname": "test_auth",
-                "fingerprint": "ABCD1234567890ABCD1234567890ABCD12345678",
-                "running": True,
-                "flags": ["Authority", "Running"],  # Include Authority flag
-                "version": "0.4.8.12",
-                "observed_bandwidth": 1000000,
-                "first_seen": "2024-01-01 00:00:00"
-            }]
-        }
-        
-        uptime_no_data = {"relays": []}
-        
-        # Mock sequential API calls: details with authority data, uptime with no data
-        details_response = Mock(read=Mock(return_value=json.dumps(main_response_with_authority).encode('utf-8')))
-        uptime_response = Mock(read=Mock(return_value=json.dumps(uptime_no_data).encode('utf-8')))
-        mock_urlopen.side_effect = [details_response, uptime_response]
-        
-        relays = Relays(self.test_dir, self.test_onionoo_url, main_response_with_authority)
-        
-        authorities_info = relays._get_directory_authorities_data()
-        authorities = authorities_info['authorities_data']
-        
-        # Should handle missing uptime gracefully.
-        # Exclude hardcoded known-offline placeholders (e.g. gabelmoo) merged in for context.
-        dynamic_authorities = [a for a in authorities if not a.get('is_known_offline')]
-        self.assertEqual(len(dynamic_authorities), 1)
-        # Note: The actual implementation may not set these fields if uptime data is missing
-        # The test focuses on proper handling without errors
-
-    def test_zscore_calculation(self):
-        """Test Z-score calculation for authority uptime analysis"""
-        # Create mock data with authorities having different uptimes
-        mock_authorities_data = {
-            "relays": [
-                {
-                    "nickname": "good_auth",
-                    "fingerprint": "GOOD1234567890ABCD1234567890ABCD12345678",
-                    "running": True,
-                    "flags": ["Authority", "Running"],
-                    "uptime_percentages": {"1_month": 99.5},  # High uptime
-                    "observed_bandwidth": 1000000,
-                    "first_seen": "2024-01-01 00:00:00",
-                    "platform": "Tor 0.4.8.12 on Linux",
-                    "consensus_weight": 3000
-                },
-                {
-                    "nickname": "avg_auth", 
-                    "fingerprint": "AVG1234567890ABCD1234567890ABCD12345678",
-                    "running": True,
-                    "flags": ["Authority", "Running"],
-                    "uptime_percentages": {"1_month": 98.0},  # Average uptime
-                    "observed_bandwidth": 1000000,
-                    "first_seen": "2024-01-01 00:00:00",
-                    "platform": "Tor 0.4.8.12 on Linux",
-                    "consensus_weight": 3000
-                },
-                {
-                    "nickname": "poor_auth",
-                    "fingerprint": "POOR1234567890ABCD1234567890ABCD12345678", 
-                    "running": True,
-                    "flags": ["Authority", "Running"],
-                    "uptime_percentages": {"1_month": 95.0},  # Poor uptime
-                    "observed_bandwidth": 1000000,
-                    "first_seen": "2024-01-01 00:00:00",
-                    "platform": "Tor 0.4.8.12 on Linux",
-                    "consensus_weight": 3000
-                }
-            ]
-        }
-        
-        relays = Relays(self.test_dir, self.test_onionoo_url, mock_authorities_data)
-        
-        # Mock consolidated uptime results to enable Z-score calculation
-        relays._consolidated_uptime_results = {
-            "network_flag_statistics": {
-                "Authority": {
+@pytest.fixture
+def mock_uptime_response():
+    """Onionoo uptime document for the three mock authorities."""
+    return {
+        "version": "10.0",
+        "build_revision": "unknown",
+        "relays_published": "2025-01-01 00:00:00",
+        "relays": [
+            {
+                "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
+                "uptime": {
                     "1_month": {
-                        "mean": 97.5,
-                        "std_dev": 1.5,
-                        "two_sigma_low": 94.5,
-                        "two_sigma_high": 100.5
+                        "factor": 0.01,
+                        "count": 720,
+                        "values": [99.2, 98.8, 99.1, 99.0, 98.9]  # Good uptime
+                    },
+                    "6_months": {
+                        "factor": 0.01,
+                        "count": 4320,
+                        "values": [98.5, 98.8, 99.0, 98.7, 98.6]
+                    },
+                    "1_year": {
+                        "factor": 0.01,
+                        "count": 8760,
+                        "values": [97.5, 97.8, 98.0, 97.9, 97.6]
+                    },
+                    "5_years": {
+                        "factor": 0.01,
+                        "count": 43800,
+                        "values": [96.8, 97.0, 97.2, 96.9, 96.7]
+                    }
+                }
+            },
+            {
+                "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
+                "uptime": {
+                    "1_month": {
+                        "factor": 0.01,
+                        "count": 720,
+                        "values": [99.8, 99.6, 99.7, 99.5, 99.9]  # Excellent uptime
+                    },
+                    "6_months": {
+                        "factor": 0.01,
+                        "count": 4320,
+                        "values": [99.6, 99.4, 99.5, 99.3, 99.7]
+                    },
+                    "1_year": {
+                        "factor": 0.01,
+                        "count": 8760,
+                        "values": [99.1, 99.0, 99.2, 98.9, 99.3]
+                    },
+                    "5_years": {
+                        "factor": 0.01,
+                        "count": 43800,
+                        "values": [98.7, 98.5, 98.9, 98.6, 98.8]
+                    }
+                }
+            },
+            {
+                "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
+                "uptime": {
+                    "1_month": {
+                        "factor": 0.01,
+                        "count": 720,
+                        "values": [89.2, 88.5, 90.1, 87.8, 89.9]  # Poor uptime
+                    },
+                    "6_months": {
+                        "factor": 0.01,
+                        "count": 4320,
+                        "values": [85.7, 86.2, 85.0, 86.8, 85.3]
+                    },
+                    "1_year": {
+                        "factor": 0.01,
+                        "count": 8760,
+                        "values": [82.1, 83.0, 81.5, 82.8, 81.9]
+                    },
+                    "5_years": {
+                        "factor": 0.01,
+                        "count": 43800,
+                        "values": [78.5, 79.2, 78.0, 79.8, 78.1]
                     }
                 }
             }
-        }
-        
-        authorities_info = relays._get_directory_authorities_data()
-        authorities = authorities_info['authorities_data']
-        
-        # Test Z-score calculation and classification
-        good_auth = next(auth for auth in authorities if auth['nickname'] == 'good_auth')
-        avg_auth = next(auth for auth in authorities if auth['nickname'] == 'avg_auth')
-        poor_auth = next(auth for auth in authorities if auth['nickname'] == 'poor_auth')
-        
-        # Z-scores should be calculated
-        self.assertIsNotNone(good_auth['uptime_zscore'])
-        self.assertIsNotNone(avg_auth['uptime_zscore'])
-        self.assertIsNotNone(poor_auth['uptime_zscore'])
-        
-        # Good authority should have positive Z-score
-        self.assertGreater(good_auth['uptime_zscore'], 0)
-        
-        # Poor authority should have negative Z-score
-        self.assertLess(poor_auth['uptime_zscore'], 0)
+        ]
+    }
 
-    def test_version_compliance_check(self):
-        """Test version compliance logic - DISABLED: Version compliance commented out until consensus-health data available"""
-        # This test is commented out since version compliance is disabled
-        # until we have real consensus-health API data
-        pass
-        
-        # # This test doesn't need network mocking since it tests logic
-        # with patch('urllib.request.urlopen') as mock_main:
-        #     mock_main.return_value.read.return_value = json.dumps({"relays": []}).encode('utf-8')
-        #     relays = Relays(self.test_dir, self.test_onionoo_url)
-        # 
-        # # Test version compliance
-        # test_cases = [
-        #     ("0.4.8.12", "0.4.8.12", True),   # Exact match
-        #     ("0.4.8.11", "0.4.8.12", False),  # Outdated
-        #     ("0.4.9.0", "0.4.8.12", False),   # Different version
-        #     ("", "0.4.8.12", False),          # Empty version
-        #     (None, "0.4.8.12", False),        # None version
-        # ]
-        # 
-        # for current, recommended, expected in test_cases:
-        #     # Simulate authority data
-        #     auth = {"version": current}
-        #     auth["recommended_version"] = recommended
-        #     auth["version_compliant"] = auth.get('version', '') == recommended
-        #     
-        #     self.assertEqual(auth["version_compliant"], expected,
-        #                    f"Version compliance check failed for {current} vs {recommended}")
 
-    @patch('urllib.request.urlopen')
-    def test_no_authorities_found(self, mock_urlopen):
-        """Test handling when no directory authorities are found in relay data"""
-        # Mock response with no authorities (no relays with Authority flag)
-        main_response_no_authorities = {
-            "relays": [
-                {
-                    "nickname": "regular_relay",
-                    "fingerprint": "ABCD1234567890ABCD1234567890ABCD12345678",
-                    "running": True,
-                    "flags": ["Running", "Valid"],  # No Authority flag
-                    "observed_bandwidth": 1000000,
-                    "first_seen": "2024-01-01 00:00:00"
+def _dynamic_authorities(authorities):
+    """Exclude hardcoded known-offline placeholders (e.g. gabelmoo) that are
+    merged in for historical context; they are not part of the dynamic Onionoo set."""
+    return [a for a in authorities if not a.get('is_known_offline')]
+
+
+# ============================================================================
+# Directory authorities data processing
+# ============================================================================
+
+def test_get_directory_authorities_data(make_relays):
+    """Test directory authorities data processing"""
+    mock_relay_data = {
+        "relays": [
+            {
+                "nickname": "moria1",
+                "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
+                "running": True,
+                "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
+                "country": "US",
+                "country_name": "United States",
+                "version": "0.4.8.12",
+                "platform": "Tor 0.4.8.12 on Linux",
+                "first_seen": "2015-03-11 20:00:00",
+                "observed_bandwidth": 1000000,
+                "consensus_weight": 5000,
+                "uptime_percentages": {
+                    "1_month": 99.2,
+                    "6_months": 98.5,
+                    "1_year": 97.5,
+                    "5_years": 96.8
                 }
-            ]
-        }
-        
-        # Mock sequential API calls: details with no authorities, uptime (doesn't matter for this test)
-        details_response = Mock(read=Mock(return_value=json.dumps(main_response_no_authorities).encode('utf-8')))
-        uptime_response = Mock(read=Mock(return_value=json.dumps({"relays": []}).encode('utf-8')))
-        mock_urlopen.side_effect = [details_response, uptime_response]
-        
-        relays = Relays(self.test_dir, self.test_onionoo_url, main_response_no_authorities)
-        
-        # Exclude hardcoded known-offline placeholders (e.g. gabelmoo) merged in for context.
-        authorities_info = relays._get_directory_authorities_data()
-        dynamic_authorities = [a for a in authorities_info['authorities_data']
-                               if not a.get('is_known_offline')]
-        self.assertEqual(len(dynamic_authorities), 0)
-
-
-    def test_template_validation(self):
-        """Test that authorities template renders with minimal data"""
-        # Minimal authority data for template testing
-        minimal_authority_data = {
-            "relays": [{
-                "nickname": "test_auth",
+            },
+            {
+                "nickname": "regular_relay",
                 "fingerprint": "ABCD1234567890ABCD1234567890ABCD12345678",
                 "running": True,
+                "flags": ["Running", "Valid"],  # No Authority flag
+                "observed_bandwidth": 1000000,
+                "consensus_weight": 3000,
+                "first_seen": "2024-01-01 12:00:00",
+                "platform": "Tor 0.4.8.12 on Linux"
+            }
+        ]
+    }
+
+    relays = make_relays(mock_relay_data)
+
+    # Test authorities data extraction
+    authorities_info = relays._get_directory_authorities_data()
+
+    # Verify structure
+    assert 'authorities_data' in authorities_info
+    assert 'authorities_summary' in authorities_info
+
+    # Verify only authorities are returned (not regular relays)
+    dynamic_authorities = _dynamic_authorities(authorities_info['authorities_data'])
+    assert len(dynamic_authorities) == 1
+    assert dynamic_authorities[0]['nickname'] == 'moria1'
+
+    # Verify summary (authority-flag count excludes offline placeholders)
+    assert authorities_info['authorities_summary']['total_authorities'] == 1
+
+
+@patch('urllib.request.urlopen')
+def test_process_directory_authorities(mock_urlopen, make_relays, mock_uptime_response):
+    """Test processing of directory authority data"""
+    # Main details response for Relays with authority data included
+    main_response_with_authorities = {
+        "relays": [
+            {
+                "nickname": "moria1",
+                "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
+                "running": True,
+                "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
+                "country": "US",
+                "country_name": "United States",
+                "as": "AS3",
+                "as_name": "MIT",
+                "contact": "tor-ops@mit.edu",
+                "version": "0.4.8.12",
+                "platform": "Tor 0.4.8.12 on Linux",
+                "first_seen": "2015-03-11 20:00:00",
+                "last_restarted": "2025-05-29 08:18:56",
+                "last_seen": "2025-01-01 00:00:00",
+                "observed_bandwidth": 1000000
+            },
+            {
+                "nickname": "tor26",
+                "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
+                "running": True,
+                "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
+                "country": "AT",
+                "country_name": "Austria",
+                "as": "AS5404",
+                "as_name": "conova communications GmbH",
+                "contact": "tor-ops@conova.com",
+                "version": "0.4.8.12",
+                "platform": "Tor 0.4.8.12 on Linux",
+                "first_seen": "2015-07-30 10:15:00",
+                "last_restarted": "2025-05-31 13:28:19",
+                "last_seen": "2025-01-01 00:00:00",
+                "observed_bandwidth": 1000000
+            },
+            {
+                "nickname": "dannenberg",
+                "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
+                "running": True,
+                "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
+                "country": "DE",
+                "country_name": "Germany",
+                "as": "AS39788",
+                "as_name": "Chaos Computer Club e.V.",
+                "contact": "tor-ops@ccc.de",
+                "version": "0.4.7.16",  # Outdated version
+                "platform": "Tor 0.4.7.16 on Linux",
+                "first_seen": "2018-03-22 18:00:00",
+                "last_restarted": "2025-04-12 09:15:42",
+                "last_seen": "2025-01-01 00:00:00",
+                "observed_bandwidth": 1000000
+            },
+            {
+                "nickname": "regular_relay",
+                "fingerprint": "ABCD1234567890ABCD1234567890ABCD12345678",
+                "running": True,
+                "flags": ["Running", "Valid"],  # No Authority flag
+                "observed_bandwidth": 1000000,
+                "first_seen": "2024-01-01 00:00:00"
+            }
+        ]
+    }
+
+    # Mock sequential API calls: first details, then uptime
+    details_response = Mock(read=Mock(return_value=json.dumps(main_response_with_authorities).encode('utf-8')))
+    uptime_response = Mock(read=Mock(return_value=json.dumps(mock_uptime_response).encode('utf-8')))
+    mock_urlopen.side_effect = [details_response, uptime_response]
+
+    relays = make_relays(main_response_with_authorities)
+
+    authorities_info = relays._get_directory_authorities_data()
+    authorities = authorities_info['authorities_data']
+
+    # Verify we got expected number of authorities (only relays with Authority flag)
+    dynamic_authorities = _dynamic_authorities(authorities)
+    assert len(dynamic_authorities) == 3
+
+    # Verify authorities are found (order may vary)
+    nicknames = [auth['nickname'] for auth in dynamic_authorities]
+    assert 'dannenberg' in nicknames
+    assert 'moria1' in nicknames
+    assert 'tor26' in nicknames
+
+    # Version compliance is now commented out, so we don't test for it
+    # Verify z-score attributes are present (may be None if no uptime data)
+    for auth in authorities:
+        assert 'uptime_zscore' in auth
+        assert 'uptime_outlier_status' in auth
+        # With the mock data, there's no consolidated uptime results, so these should be None
+        assert auth['uptime_zscore'] is None
+        assert auth['uptime_outlier_status'] == 'insufficient_data'
+
+
+@patch('urllib.request.urlopen')
+def test_write_directory_authorities(mock_urlopen, make_relays, temp_dir, mock_uptime_response):
+    """Test generation of directory authorities HTML page"""
+    main_response_with_authorities = {
+        "relays": [
+            {
+                "nickname": "moria1",
+                "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
+                "running": True,
+                "flags": ["Authority", "Running", "Stable", "V2Dir", "Valid"],
+                "country": "US",
+                "country_name": "United States",
+                "as": "AS3",
+                "as_name": "MIT",
+                "contact": "tor-ops@mit.edu",
+                "version": "0.4.8.12",
+                "platform": "Tor 0.4.8.12 on Linux",
+                "first_seen": "2015-03-11 20:00:00",
+                "last_restarted": "2025-05-29 08:18:56",
+                "last_seen": "2025-01-01 00:00:00",
+                "observed_bandwidth": 1000000
+            }
+        ]
+    }
+
+    # Mock sequential API calls: first details, then uptime
+    details_response = Mock(read=Mock(return_value=json.dumps(main_response_with_authorities).encode('utf-8')))
+    uptime_response = Mock(read=Mock(return_value=json.dumps(mock_uptime_response).encode('utf-8')))
+    mock_urlopen.side_effect = [details_response, uptime_response]
+
+    relays = make_relays(main_response_with_authorities)
+
+    # Call write_misc directly since write_directory_authorities no longer exists
+    relays.write_misc(
+        template="misc-authorities.html",
+        path="misc/authorities.html"
+    )
+
+    # Verify authority data and summary were stored as attributes
+    assert hasattr(relays, 'authorities_data')
+    assert hasattr(relays, 'authorities_summary')
+    dynamic_authorities = _dynamic_authorities(relays.authorities_data)
+    assert len(dynamic_authorities) == 1
+    assert relays.authorities_summary['total_authorities'] == 1
+
+    # Verify output file was created
+    output_file = os.path.join(temp_dir, "misc", "authorities.html")
+    assert os.path.exists(output_file)
+
+
+@patch('urllib.request.urlopen')
+def test_network_error_handling(mock_urlopen, make_relays):
+    """Test handling of network errors when fetching authority data"""
+    # Mock successful details response but failed uptime response
+    details_response = Mock(read=Mock(return_value=json.dumps({"relays": []}).encode('utf-8')))
+    mock_urlopen.side_effect = [details_response, Exception("Network error")]
+
+    relays = make_relays({"relays": []})
+
+    # Should still work but authorities will have empty uptime data
+    authorities_info = relays._get_directory_authorities_data()
+    dynamic_authorities = _dynamic_authorities(authorities_info['authorities_data'])
+    assert len(dynamic_authorities) == 0  # No authorities since no relays with Authority flag
+
+
+@patch('urllib.request.urlopen')
+def test_uptime_edge_cases(mock_urlopen, make_relays):
+    """Test edge cases in uptime processing"""
+    # Response with authority but missing uptime data
+    main_response_with_authority = {
+        "relays": [{
+            "nickname": "test_auth",
+            "fingerprint": "ABCD1234567890ABCD1234567890ABCD12345678",
+            "running": True,
+            "flags": ["Authority", "Running"],  # Include Authority flag
+            "version": "0.4.8.12",
+            "observed_bandwidth": 1000000,
+            "first_seen": "2024-01-01 00:00:00"
+        }]
+    }
+
+    # Mock sequential API calls: details with authority data, uptime with no data
+    details_response = Mock(read=Mock(return_value=json.dumps(main_response_with_authority).encode('utf-8')))
+    uptime_response = Mock(read=Mock(return_value=json.dumps({"relays": []}).encode('utf-8')))
+    mock_urlopen.side_effect = [details_response, uptime_response]
+
+    relays = make_relays(main_response_with_authority)
+
+    authorities_info = relays._get_directory_authorities_data()
+
+    # Should handle missing uptime gracefully
+    dynamic_authorities = _dynamic_authorities(authorities_info['authorities_data'])
+    assert len(dynamic_authorities) == 1
+    # Note: The actual implementation may not set these fields if uptime data is missing
+    # The test focuses on proper handling without errors
+
+
+def test_zscore_calculation(make_relays):
+    """Test Z-score calculation for authority uptime analysis"""
+    # Create mock data with authorities having different uptimes
+    mock_authorities_data = {
+        "relays": [
+            {
+                "nickname": "good_auth",
+                "fingerprint": "GOOD1234567890ABCD1234567890ABCD12345678",
+                "running": True,
                 "flags": ["Authority", "Running"],
+                "uptime_percentages": {"1_month": 99.5},  # High uptime
+                "observed_bandwidth": 1000000,
                 "first_seen": "2024-01-01 00:00:00",
                 "platform": "Tor 0.4.8.12 on Linux",
-                "observed_bandwidth": 1000000,
                 "consensus_weight": 3000
-            }]
-        }
-        
-        relays = Relays(self.test_dir, self.test_onionoo_url, minimal_authority_data)
-        
-        # Test template compilation and rendering
-        try:
-            relays.write_misc(
-                template="misc-authorities.html",
-                path="misc/authorities.html"
-            )
-            
-            # Verify output file was created and has content
-            output_file = os.path.join(self.test_dir, "misc", "authorities.html")
-            self.assertTrue(os.path.exists(output_file))
-            
-            with open(output_file, 'r') as f:
-                content = f.read()
-                
-            # Basic content validation
-            self.assertIn("test_auth", content)
-            self.assertIn("Directory Authorities", content)
-            self.assertIn("authorities discovered", content)
-            
-        except Exception as e:
-            self.fail(f"Template rendering failed: {e}")
+            },
+            {
+                "nickname": "avg_auth",
+                "fingerprint": "AVG1234567890ABCD1234567890ABCD12345678",
+                "running": True,
+                "flags": ["Authority", "Running"],
+                "uptime_percentages": {"1_month": 98.0},  # Average uptime
+                "observed_bandwidth": 1000000,
+                "first_seen": "2024-01-01 00:00:00",
+                "platform": "Tor 0.4.8.12 on Linux",
+                "consensus_weight": 3000
+            },
+            {
+                "nickname": "poor_auth",
+                "fingerprint": "POOR1234567890ABCD1234567890ABCD12345678",
+                "running": True,
+                "flags": ["Authority", "Running"],
+                "uptime_percentages": {"1_month": 95.0},  # Poor uptime
+                "observed_bandwidth": 1000000,
+                "first_seen": "2024-01-01 00:00:00",
+                "platform": "Tor 0.4.8.12 on Linux",
+                "consensus_weight": 3000
+            }
+        ]
+    }
 
+    relays = make_relays(mock_authorities_data)
 
-class TestAuthorityIntegration(unittest.TestCase):
-    """Integration tests for directory authorities in full Allium workflow"""
-    
-    def setUp(self):
-        """Set up integration test fixtures"""
-        self.test_dir = tempfile.mkdtemp()
-        
-        # Mock a minimal but complete onionoo response 
-        self.mock_main_response = {
-            "version": "10.0",
-            "relays_published": "2025-01-01 00:00:00",
-            "relays": [
-                {
-                    "nickname": "TestRelay",
-                    "fingerprint": "ABCD1234567890ABCD1234567890ABCD12345678",
-                    "running": True,
-                    "observed_bandwidth": 1000000,
-                    "flags": ["Running", "Valid"],
-                    "first_seen": "2024-01-01 00:00:00",
-                    "platform": "Tor 0.4.8.12 on Linux",
-                    "consensus_weight": 3000
+    # Mock consolidated uptime results to enable Z-score calculation
+    relays._consolidated_uptime_results = {
+        "network_flag_statistics": {
+            "Authority": {
+                "1_month": {
+                    "mean": 97.5,
+                    "std_dev": 1.5,
+                    "two_sigma_low": 94.5,
+                    "two_sigma_high": 100.5
                 }
-            ]
+            }
         }
+    }
 
-    def tearDown(self):
-        """Clean up integration test fixtures"""
-        shutil.rmtree(self.test_dir)
+    authorities_info = relays._get_directory_authorities_data()
+    authorities = authorities_info['authorities_data']
 
-    @patch('urllib.request.urlopen')
-    def test_allium_integration(self, mock_urlopen):
-        """Test that authorities page integrates properly with Allium workflow"""
-        # Mock sequential API calls: details and uptime
-        details_response = Mock(read=Mock(return_value=json.dumps(self.mock_main_response).encode('utf-8')))
-        uptime_response = Mock(read=Mock(return_value=json.dumps({"relays": []}).encode('utf-8')))
-        mock_urlopen.side_effect = [details_response, uptime_response]
-        
-        # Create Relays instance (this would normally be done in allium.py)
-        relays = Relays(self.test_dir, "https://test.onionoo.url/details", self.mock_main_response)
-        
-        # Verify Relays was created successfully 
-        self.assertIsNotNone(relays.json)
-        self.assertEqual(len(relays.json['relays']), 1)
-        
-        # Test that write_misc method can handle misc-authorities.html template
-        self.assertTrue(hasattr(relays, 'write_misc'))
-        self.assertTrue(callable(getattr(relays, 'write_misc')))
-        
-        # Test authorities processing integration
-        try:
-            relays.write_misc(
-                template="misc-authorities.html", 
-                path="misc/authorities.html"
-            )
-            # If no exception, integration is working
-        except Exception as e:
-            self.fail(f"Authorities integration failed: {e}")
+    # Test Z-score calculation and classification
+    good_auth = next(auth for auth in authorities if auth['nickname'] == 'good_auth')
+    avg_auth = next(auth for auth in authorities if auth['nickname'] == 'avg_auth')
+    poor_auth = next(auth for auth in authorities if auth['nickname'] == 'poor_auth')
+
+    # Z-scores should be calculated
+    assert good_auth['uptime_zscore'] is not None
+    assert avg_auth['uptime_zscore'] is not None
+    assert poor_auth['uptime_zscore'] is not None
+
+    # Good authority should have positive Z-score
+    assert good_auth['uptime_zscore'] > 0
+
+    # Poor authority should have negative Z-score
+    assert poor_auth['uptime_zscore'] < 0
 
 
-class TestKnownOfflineAuthorityMerge(unittest.TestCase):
-    """Tests for retaining removed/offline authorities on the DA page (Task 5).
-
-    A directory authority removed from the consensus eventually ages out of all live
-    data sources, so it would vanish from the page. A small hardcoded list keeps such
-    authorities visible (as offline) - but only when NOT present dynamically, and
-    without ever affecting the voting/reachability counts.
-    """
-
-    GABELMOO_FP = 'F2044413DAC2E02E3D6BCF4735A19BCA1DE97281'
-
-    def setUp(self):
-        self.test_dir = tempfile.mkdtemp()
-        self.test_onionoo_url = "https://test.onionoo.url/details"
-
-    def tearDown(self):
-        shutil.rmtree(self.test_dir)
-
-    def _authorities_by_nick(self, authorities_info):
-        return {a['nickname']: a for a in authorities_info['authorities_data']}
-
-    def test_offline_authority_merged_when_absent(self):
-        """gabelmoo absent from Onionoo -> appears as an offline, context-only row."""
-        mock_relay_data = {
-            "relays": [
-                {
-                    "nickname": "moria1",
-                    "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
-                    "running": True,
-                    "flags": ["Authority", "Running", "V2Dir", "Valid"],
-                    "country": "US", "country_name": "United States",
-                    "first_seen": "2015-03-11 20:00:00",
-                    "platform": "Tor 0.4.8.12 on Linux",
-                    "observed_bandwidth": 1000000, "consensus_weight": 5000,
-                },
-            ]
-        }
-        relays = Relays(self.test_dir, self.test_onionoo_url, mock_relay_data)
-        info = relays._get_directory_authorities_data()
-        by_nick = self._authorities_by_nick(info)
-
-        # gabelmoo is merged in as offline / context-only
-        self.assertIn('gabelmoo', by_nick)
-        self.assertFalse(by_nick['gabelmoo']['running'])
-        self.assertTrue(by_nick['gabelmoo'].get('is_known_offline'))
-        # No broken relay link source: it carries an offline_note for the badge tooltip
-        self.assertTrue(by_nick['gabelmoo'].get('offline_note'))
-
-        # The live authority is untouched (not flagged offline)
-        self.assertTrue(by_nick['moria1']['running'])
-        self.assertFalse(by_nick['moria1'].get('is_known_offline', False))
-
-        # Counts: dynamic authority-flag count EXCLUDES the hardcoded offline row
-        self.assertEqual(info['authorities_summary']['total_with_authority_flag'], 1)
-        # Offline summary (dynamic) reflects gabelmoo
-        self.assertGreaterEqual(info['authorities_summary']['offline_count'], 1)
-        self.assertIn('gabelmoo', info['authorities_summary']['offline_names'])
-        # Alphabetical ordering preserved after merge
-        nicks = [a['nickname'] for a in info['authorities_data']]
-        self.assertEqual(nicks, sorted(nicks, key=str.lower))
-
-    def test_offline_authority_not_duplicated_when_present(self):
-        """gabelmoo present in Onionoo -> live row wins, no hardcoded duplicate."""
-        mock_relay_data = {
-            "relays": [
-                {
-                    "nickname": "moria1",
-                    "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
-                    "running": True,
-                    "flags": ["Authority", "Running", "V2Dir", "Valid"],
-                    "country": "US", "country_name": "United States",
-                    "first_seen": "2015-03-11 20:00:00",
-                    "platform": "Tor 0.4.8.12 on Linux",
-                    "observed_bandwidth": 1000000, "consensus_weight": 5000,
-                },
-                {
-                    "nickname": "gabelmoo",
-                    "fingerprint": self.GABELMOO_FP,
-                    "running": True,
-                    "flags": ["Authority", "Running", "V2Dir", "Valid"],
-                    "country": "DE", "country_name": "Germany",
-                    "first_seen": "2010-03-22 11:00:00",
-                    "platform": "Tor 0.4.9.9 on Linux",
-                    "observed_bandwidth": 9810000, "consensus_weight": 20,
-                },
-            ]
-        }
-        relays = Relays(self.test_dir, self.test_onionoo_url, mock_relay_data)
-        info = relays._get_directory_authorities_data()
-
-        gabelmoo_rows = [a for a in info['authorities_data'] if a['nickname'] == 'gabelmoo']
-        self.assertEqual(len(gabelmoo_rows), 1)  # no duplicate
-        # The live row wins: running True, not flagged as the hardcoded offline entry
-        self.assertTrue(gabelmoo_rows[0]['running'])
-        self.assertFalse(gabelmoo_rows[0].get('is_known_offline', False))
-        # Both authorities online -> offline summary empty, and gabelmoo counted live
-        self.assertEqual(info['authorities_summary']['offline_count'], 0)
-        self.assertEqual(info['authorities_summary']['total_with_authority_flag'], 2)
+@pytest.mark.skip(reason="Version compliance disabled until consensus-health API data is available")
+def test_version_compliance_check():
+    """Test version compliance logic - DISABLED: Version compliance commented out
+    until consensus-health data available."""
+    # # This test doesn't need network mocking since it tests logic
+    # with patch('urllib.request.urlopen') as mock_main:
+    #     mock_main.return_value.read.return_value = json.dumps({"relays": []}).encode('utf-8')
+    #     relays = Relays(self.test_dir, self.test_onionoo_url)
+    #
+    # # Test version compliance
+    # test_cases = [
+    #     ("0.4.8.12", "0.4.8.12", True),   # Exact match
+    #     ("0.4.8.11", "0.4.8.12", False),  # Outdated
+    #     ("0.4.9.0", "0.4.8.12", False),   # Different version
+    #     ("", "0.4.8.12", False),          # Empty version
+    #     (None, "0.4.8.12", False),        # None version
+    # ]
+    #
+    # for current, recommended, expected in test_cases:
+    #     # Simulate authority data
+    #     auth = {"version": current}
+    #     auth["recommended_version"] = recommended
+    #     auth["version_compliant"] = auth.get('version', '') == recommended
+    #
+    #     assert auth["version_compliant"] == expected, \
+    #         f"Version compliance check failed for {current} vs {recommended}"
 
 
-if __name__ == '__main__':
-    # Create test suite
-    loader = unittest.TestLoader()
-    suite = unittest.TestSuite()
-    
-    # Add test cases
-    suite.addTests(loader.loadTestsFromTestCase(TestDirectoryAuthorities))
-    suite.addTests(loader.loadTestsFromTestCase(TestAuthorityIntegration))
-    suite.addTests(loader.loadTestsFromTestCase(TestKnownOfflineAuthorityMerge))
-    
-    # Run tests
-    runner = unittest.TextTestRunner(verbosity=2)
-    result = runner.run(suite)
-    
-    # Exit with appropriate code
-    sys.exit(0 if result.wasSuccessful() else 1) 
+@patch('urllib.request.urlopen')
+def test_no_authorities_found(mock_urlopen, make_relays):
+    """Test handling when no directory authorities are found in relay data"""
+    # Response with no authorities (no relays with Authority flag)
+    main_response_no_authorities = {
+        "relays": [
+            {
+                "nickname": "regular_relay",
+                "fingerprint": "ABCD1234567890ABCD1234567890ABCD12345678",
+                "running": True,
+                "flags": ["Running", "Valid"],  # No Authority flag
+                "observed_bandwidth": 1000000,
+                "first_seen": "2024-01-01 00:00:00"
+            }
+        ]
+    }
+
+    # Mock sequential API calls: details with no authorities, uptime (doesn't matter for this test)
+    details_response = Mock(read=Mock(return_value=json.dumps(main_response_no_authorities).encode('utf-8')))
+    uptime_response = Mock(read=Mock(return_value=json.dumps({"relays": []}).encode('utf-8')))
+    mock_urlopen.side_effect = [details_response, uptime_response]
+
+    relays = make_relays(main_response_no_authorities)
+
+    authorities_info = relays._get_directory_authorities_data()
+    dynamic_authorities = _dynamic_authorities(authorities_info['authorities_data'])
+    assert len(dynamic_authorities) == 0
+
+
+def test_template_validation(make_relays, temp_dir):
+    """Test that authorities template renders with minimal data"""
+    # Minimal authority data for template testing
+    minimal_authority_data = {
+        "relays": [{
+            "nickname": "test_auth",
+            "fingerprint": "ABCD1234567890ABCD1234567890ABCD12345678",
+            "running": True,
+            "flags": ["Authority", "Running"],
+            "first_seen": "2024-01-01 00:00:00",
+            "platform": "Tor 0.4.8.12 on Linux",
+            "observed_bandwidth": 1000000,
+            "consensus_weight": 3000
+        }]
+    }
+
+    relays = make_relays(minimal_authority_data)
+
+    # Test template compilation and rendering (any exception fails the test)
+    relays.write_misc(
+        template="misc-authorities.html",
+        path="misc/authorities.html"
+    )
+
+    # Verify output file was created and has content
+    output_file = os.path.join(temp_dir, "misc", "authorities.html")
+    assert os.path.exists(output_file)
+
+    with open(output_file, 'r') as f:
+        content = f.read()
+
+    # Basic content validation
+    assert "test_auth" in content
+    assert "Directory Authorities" in content
+    assert "authorities discovered" in content
+
+
+# ============================================================================
+# Integration with the full Allium workflow
+# ============================================================================
+
+@patch('urllib.request.urlopen')
+def test_allium_integration(mock_urlopen, make_relays):
+    """Test that authorities page integrates properly with Allium workflow"""
+    # Minimal but complete onionoo response
+    mock_main_response = {
+        "version": "10.0",
+        "relays_published": "2025-01-01 00:00:00",
+        "relays": [
+            {
+                "nickname": "TestRelay",
+                "fingerprint": "ABCD1234567890ABCD1234567890ABCD12345678",
+                "running": True,
+                "observed_bandwidth": 1000000,
+                "flags": ["Running", "Valid"],
+                "first_seen": "2024-01-01 00:00:00",
+                "platform": "Tor 0.4.8.12 on Linux",
+                "consensus_weight": 3000
+            }
+        ]
+    }
+
+    # Mock sequential API calls: details and uptime
+    details_response = Mock(read=Mock(return_value=json.dumps(mock_main_response).encode('utf-8')))
+    uptime_response = Mock(read=Mock(return_value=json.dumps({"relays": []}).encode('utf-8')))
+    mock_urlopen.side_effect = [details_response, uptime_response]
+
+    # Create Relays instance (this would normally be done in allium.py)
+    relays = make_relays(mock_main_response)
+
+    # Verify Relays was created successfully
+    assert relays.json is not None
+    assert len(relays.json['relays']) == 1
+
+    # Test that write_misc method can handle misc-authorities.html template
+    # (any exception fails the test)
+    assert callable(getattr(relays, 'write_misc', None))
+    relays.write_misc(
+        template="misc-authorities.html",
+        path="misc/authorities.html"
+    )
+
+
+# ============================================================================
+# Retaining removed/offline authorities on the DA page (Task 5)
+#
+# A directory authority removed from the consensus eventually ages out of all
+# live data sources, so it would vanish from the page. A small hardcoded list
+# keeps such authorities visible (as offline) - but only when NOT present
+# dynamically, and without ever affecting the voting/reachability counts.
+# ============================================================================
+
+def _authorities_by_nick(authorities_info):
+    return {a['nickname']: a for a in authorities_info['authorities_data']}
+
+
+def test_offline_authority_merged_when_absent(make_relays):
+    """gabelmoo absent from Onionoo -> appears as an offline, context-only row."""
+    mock_relay_data = {
+        "relays": [
+            {
+                "nickname": "moria1",
+                "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
+                "running": True,
+                "flags": ["Authority", "Running", "V2Dir", "Valid"],
+                "country": "US", "country_name": "United States",
+                "first_seen": "2015-03-11 20:00:00",
+                "platform": "Tor 0.4.8.12 on Linux",
+                "observed_bandwidth": 1000000, "consensus_weight": 5000,
+            },
+        ]
+    }
+    relays = make_relays(mock_relay_data)
+    info = relays._get_directory_authorities_data()
+    by_nick = _authorities_by_nick(info)
+
+    # gabelmoo is merged in as offline / context-only
+    assert 'gabelmoo' in by_nick
+    assert not by_nick['gabelmoo']['running']
+    assert by_nick['gabelmoo'].get('is_known_offline')
+    # No broken relay link source: it carries an offline_note for the badge tooltip
+    assert by_nick['gabelmoo'].get('offline_note')
+
+    # The live authority is untouched (not flagged offline)
+    assert by_nick['moria1']['running']
+    assert not by_nick['moria1'].get('is_known_offline', False)
+
+    # Counts: dynamic authority-flag count EXCLUDES the hardcoded offline row
+    assert info['authorities_summary']['total_with_authority_flag'] == 1
+    # Offline summary (dynamic) reflects gabelmoo
+    assert info['authorities_summary']['offline_count'] >= 1
+    assert 'gabelmoo' in info['authorities_summary']['offline_names']
+    # Alphabetical ordering preserved after merge
+    nicks = [a['nickname'] for a in info['authorities_data']]
+    assert nicks == sorted(nicks, key=str.lower)
+
+
+def test_offline_authority_not_duplicated_when_present(make_relays):
+    """gabelmoo present in Onionoo -> live row wins, no hardcoded duplicate."""
+    mock_relay_data = {
+        "relays": [
+            {
+                "nickname": "moria1",
+                "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
+                "running": True,
+                "flags": ["Authority", "Running", "V2Dir", "Valid"],
+                "country": "US", "country_name": "United States",
+                "first_seen": "2015-03-11 20:00:00",
+                "platform": "Tor 0.4.8.12 on Linux",
+                "observed_bandwidth": 1000000, "consensus_weight": 5000,
+            },
+            {
+                "nickname": "gabelmoo",
+                "fingerprint": GABELMOO_FP,
+                "running": True,
+                "flags": ["Authority", "Running", "V2Dir", "Valid"],
+                "country": "DE", "country_name": "Germany",
+                "first_seen": "2010-03-22 11:00:00",
+                "platform": "Tor 0.4.9.9 on Linux",
+                "observed_bandwidth": 9810000, "consensus_weight": 20,
+            },
+        ]
+    }
+    relays = make_relays(mock_relay_data)
+    info = relays._get_directory_authorities_data()
+
+    gabelmoo_rows = [a for a in info['authorities_data'] if a['nickname'] == 'gabelmoo']
+    assert len(gabelmoo_rows) == 1  # no duplicate
+    # The live row wins: running True, not flagged as the hardcoded offline entry
+    assert gabelmoo_rows[0]['running']
+    assert not gabelmoo_rows[0].get('is_known_offline', False)
+    # Both authorities online -> offline summary empty, and gabelmoo counted live
+    assert info['authorities_summary']['offline_count'] == 0
+    assert info['authorities_summary']['total_with_authority_flag'] == 2

--- a/tests/unit/consensus/test_collector_fetcher.py
+++ b/tests/unit/consensus/test_collector_fetcher.py
@@ -23,6 +23,11 @@ from allium.lib.consensus.collector_fetcher import (
     get_authority_names,
     get_authority_count,
     get_authority_registry,
+    get_voting_authority_names,
+    get_voting_authority_count,
+    update_voting_authorities,
+    get_known_offline_authorities,
+    KNOWN_OFFLINE_AUTHORITIES,
 )
 
 
@@ -1364,3 +1369,109 @@ class TestMiddleOnlyFlagTracking:
         details_by_auth = {d['authority']: d for d in eligibility['middleonly']['details']}
         assert details_by_auth['auth1']['assigned'] is True
         assert details_by_auth['auth2']['assigned'] is False
+
+
+# 8 currently-voting authorities (gabelmoo removed) - alphabetical
+_ACTIVE_VOTERS_8 = ['bastet', 'dannenberg', 'dizum', 'faravahar',
+                    'longclaw', 'maatuska', 'moria1', 'tor26']
+
+
+class TestDynamicVotingAuthorities:
+    """Tests for the dynamic voting-authority list (update_voting_authorities).
+
+    Verifies the fix for stale reachability denominators when a directory authority
+    is removed (e.g. gabelmoo going offline -> should become 8 voters, not 9).
+    """
+
+    def test_fresh_registry_uses_fallback_voting_list(self):
+        registry = AuthorityRegistry()
+        assert registry.get_voting_authority_count() == 9
+        assert 'gabelmoo' in registry.get_voting_authority_names()
+
+    def test_update_voting_authorities_sets_dynamic_list(self):
+        registry = AuthorityRegistry()
+        count = registry.update_voting_authorities(_ACTIVE_VOTERS_8)
+        assert count == 8
+        assert registry.get_voting_authority_count() == 8
+        assert registry.get_voting_authority_names() == sorted(_ACTIVE_VOTERS_8)
+        assert 'gabelmoo' not in registry.get_voting_authority_names()
+
+    def test_update_voting_authorities_dedups_and_sorts(self):
+        registry = AuthorityRegistry()
+        count = registry.update_voting_authorities(['moria1', 'bastet', 'moria1', ''])
+        assert count == 2
+        assert registry.get_voting_authority_names() == ['bastet', 'moria1']
+
+    def test_update_voting_authorities_empty_keeps_previous(self):
+        registry = AuthorityRegistry()
+        registry.update_voting_authorities(['moria1', 'bastet'])
+        # Empty / None input must not wipe the list
+        assert registry.update_voting_authorities([]) == 2
+        assert registry.update_voting_authorities(None) == 2
+        assert registry.get_voting_authority_names() == ['bastet', 'moria1']
+
+    def test_update_voting_authorities_empty_on_fresh_keeps_fallback(self):
+        registry = AuthorityRegistry()
+        registry.update_voting_authorities([])
+        assert registry.get_voting_authority_count() == 9  # fallback intact
+
+    def test_clear_voting_authorities_restores_fallback(self):
+        registry = AuthorityRegistry()
+        registry.update_voting_authorities(['moria1', 'bastet'])
+        assert registry.get_voting_authority_count() == 2
+        registry.clear_voting_authorities()
+        assert registry.get_voting_authority_count() == 9
+        assert 'gabelmoo' in registry.get_voting_authority_names()
+
+    def test_global_update_voting_authorities_wrapper(self):
+        registry = get_authority_registry()
+        try:
+            update_voting_authorities(_ACTIVE_VOTERS_8)
+            assert get_voting_authority_count() == 8
+            assert 'gabelmoo' not in get_voting_authority_names()
+        finally:
+            registry.clear_voting_authorities()  # reset shared singleton
+
+    def test_reachability_denominator_reflects_dynamic_voters(self):
+        """_format_reachability must use the dynamic voting set as the denominator.
+
+        With gabelmoo removed (8 voters) and a relay reachable by all 8, reachability
+        should be 8/8 - not the stale 8/9 that produced the false 'partial' warning.
+        """
+        registry = get_authority_registry()
+        try:
+            update_voting_authorities(_ACTIVE_VOTERS_8)
+
+            fetcher = CollectorFetcher()
+            relay = {'votes': {name: {'flags': ['Running', 'Valid']}
+                               for name in _ACTIVE_VOTERS_8}}
+            reachability = fetcher._format_reachability(relay)
+
+            assert reachability['total_authorities'] == 8
+            assert reachability['ipv4_reachable_count'] == 8
+            assert 'gabelmoo' not in reachability['ipv4_reachable_authorities']
+        finally:
+            registry.clear_voting_authorities()
+
+
+class TestKnownOfflineAuthorities:
+    """Tests for the small hardcoded known-offline authority bridge list."""
+
+    def test_gabelmoo_present_with_relay_fingerprint(self):
+        offline = get_known_offline_authorities()
+        assert offline is KNOWN_OFFLINE_AUTHORITIES
+        by_nick = {e['nickname']: e for e in offline}
+        assert 'gabelmoo' in by_nick
+        # Must be the Onionoo RELAY fingerprint (for dedupe), not the ED03BB signing key
+        assert by_nick['gabelmoo']['fingerprint'] == 'F2044413DAC2E02E3D6BCF4735A19BCA1DE97281'
+        assert by_nick['gabelmoo']['offline_since'] == '2026-06-30'
+
+    def test_offline_list_is_small(self):
+        # Deliberately tiny bridge list; guard against unbounded growth.
+        assert len(get_known_offline_authorities()) <= 3
+
+    def test_offline_entries_have_relay_fingerprints(self):
+        # Entries carry 40-char Onionoo relay fingerprints (used for dedupe), and a note.
+        for e in get_known_offline_authorities():
+            assert len(e['fingerprint']) == 40
+            assert e.get('note')

--- a/tests/unit/consensus/test_collector_fetcher.py
+++ b/tests/unit/consensus/test_collector_fetcher.py
@@ -1449,7 +1449,11 @@ class TestKnownOfflineAuthorities:
 
     def test_gabelmoo_present_with_relay_fingerprint(self):
         offline = get_known_offline_authorities()
-        assert offline is KNOWN_OFFLINE_AUTHORITIES
+        # Same content as the module list, but copies - callers can't mutate it
+        assert offline == KNOWN_OFFLINE_AUTHORITIES
+        assert offline is not KNOWN_OFFLINE_AUTHORITIES
+        assert all(entry is not original
+                   for entry, original in zip(offline, KNOWN_OFFLINE_AUTHORITIES))
         by_nick = {e['nickname']: e for e in offline}
         assert 'gabelmoo' in by_nick
         # Must be the Onionoo RELAY fingerprint (for dedupe), not the ED03BB signing key

--- a/tests/unit/consensus/test_collector_fetcher.py
+++ b/tests/unit/consensus/test_collector_fetcher.py
@@ -1475,3 +1475,12 @@ class TestKnownOfflineAuthorities:
         for e in get_known_offline_authorities():
             assert len(e['fingerprint']) == 40
             assert e.get('note')
+
+    def test_offline_entries_use_uppercase_country(self):
+        # Country must be uppercase to match _preprocess_template_data
+        # (relay["country"] = country.upper()) and the country/<CC>/ page URL convention,
+        # otherwise the offline row's country link 404s (e.g. /country/de/ vs /country/DE/).
+        for e in get_known_offline_authorities():
+            country = e.get('country')
+            if country:
+                assert country == country.upper(), f"{e['nickname']} country must be uppercase"

--- a/tests/unit/consensus/test_collector_fetcher.py
+++ b/tests/unit/consensus/test_collector_fetcher.py
@@ -29,6 +29,9 @@ from allium.lib.consensus.collector_fetcher import (
     get_known_offline_authorities,
     KNOWN_OFFLINE_AUTHORITIES,
 )
+# 8 currently-voting authorities (gabelmoo removed) - shared with the
+# voting_registry_8_voters fixture in tests/conftest.py
+from tests.conftest import ACTIVE_VOTING_AUTHORITIES_8 as _ACTIVE_VOTERS_8
 
 
 # ============================================================================
@@ -1371,11 +1374,6 @@ class TestMiddleOnlyFlagTracking:
         assert details_by_auth['auth2']['assigned'] is False
 
 
-# 8 currently-voting authorities (gabelmoo removed) - alphabetical
-_ACTIVE_VOTERS_8 = ['bastet', 'dannenberg', 'dizum', 'faravahar',
-                    'longclaw', 'maatuska', 'moria1', 'tor26']
-
-
 class TestDynamicVotingAuthorities:
     """Tests for the dynamic voting-authority list (update_voting_authorities).
 
@@ -1412,7 +1410,8 @@ class TestDynamicVotingAuthorities:
 
     def test_update_voting_authorities_empty_on_fresh_keeps_fallback(self):
         registry = AuthorityRegistry()
-        registry.update_voting_authorities([])
+        # An ignored empty update reports the effective (fallback) count, not 0
+        assert registry.update_voting_authorities([]) == 9
         assert registry.get_voting_authority_count() == 9  # fallback intact
 
     def test_clear_voting_authorities_restores_fallback(self):
@@ -1423,35 +1422,26 @@ class TestDynamicVotingAuthorities:
         assert registry.get_voting_authority_count() == 9
         assert 'gabelmoo' in registry.get_voting_authority_names()
 
-    def test_global_update_voting_authorities_wrapper(self):
-        registry = get_authority_registry()
-        try:
-            update_voting_authorities(_ACTIVE_VOTERS_8)
-            assert get_voting_authority_count() == 8
-            assert 'gabelmoo' not in get_voting_authority_names()
-        finally:
-            registry.clear_voting_authorities()  # reset shared singleton
+    def test_global_update_voting_authorities_wrapper(self, voting_registry_8_voters):
+        # The fixture updates the shared singleton via the global
+        # update_voting_authorities() wrapper; the global getters must reflect it.
+        assert get_voting_authority_count() == 8
+        assert 'gabelmoo' not in get_voting_authority_names()
 
-    def test_reachability_denominator_reflects_dynamic_voters(self):
+    def test_reachability_denominator_reflects_dynamic_voters(self, voting_registry_8_voters):
         """_format_reachability must use the dynamic voting set as the denominator.
 
         With gabelmoo removed (8 voters) and a relay reachable by all 8, reachability
         should be 8/8 - not the stale 8/9 that produced the false 'partial' warning.
         """
-        registry = get_authority_registry()
-        try:
-            update_voting_authorities(_ACTIVE_VOTERS_8)
+        fetcher = CollectorFetcher()
+        relay = {'votes': {name: {'flags': ['Running', 'Valid']}
+                           for name in _ACTIVE_VOTERS_8}}
+        reachability = fetcher._format_reachability(relay)
 
-            fetcher = CollectorFetcher()
-            relay = {'votes': {name: {'flags': ['Running', 'Valid']}
-                               for name in _ACTIVE_VOTERS_8}}
-            reachability = fetcher._format_reachability(relay)
-
-            assert reachability['total_authorities'] == 8
-            assert reachability['ipv4_reachable_count'] == 8
-            assert 'gabelmoo' not in reachability['ipv4_reachable_authorities']
-        finally:
-            registry.clear_voting_authorities()
+        assert reachability['total_authorities'] == 8
+        assert reachability['ipv4_reachable_count'] == 8
+        assert 'gabelmoo' not in reachability['ipv4_reachable_authorities']
 
 
 class TestKnownOfflineAuthorities:

--- a/tests/unit/consensus/test_relay_diagnostics.py
+++ b/tests/unit/consensus/test_relay_diagnostics.py
@@ -24,10 +24,7 @@ from allium.lib.relay_diagnostics import (
     _check_overload_issues,
     OVERLOAD_THRESHOLD_HOURS,
 )
-from allium.lib.consensus.collector_fetcher import (
-    get_authority_registry,
-    update_voting_authorities,
-)
+from tests.conftest import ACTIVE_VOTING_AUTHORITIES_8
 
 # Constants for testing
 SECONDS_PER_DAY = 86400
@@ -763,53 +760,44 @@ class TestReachabilityAfterAuthorityRemoval:
     the relay) must still be flagged, now against the dynamic denominator.
     """
 
-    ACTIVE_VOTERS = ['bastet', 'dannenberg', 'dizum', 'faravahar',
-                     'longclaw', 'maatuska', 'moria1', 'tor26']
+    # 8 active voters (gabelmoo removed) - the voting_registry_8_voters fixture
+    # from tests/conftest.py loads this same list into the shared registry
+    ACTIVE_VOTERS = ACTIVE_VOTING_AUTHORITIES_8
 
-    def test_no_partial_reachability_when_authority_removed(self):
-        registry = get_authority_registry()
-        try:
-            update_voting_authorities(self.ACTIVE_VOTERS)  # gabelmoo removed -> 8 voters
-            consensus_data = {
-                'in_consensus': True,
-                'authority_votes': [{'wfu': 0.99, 'tk': 30 * SECONDS_PER_DAY}],
-                'reachability': {
-                    'ipv4_reachable_count': 8,
-                    'ipv4_reachable_authorities': self.ACTIVE_VOTERS,
-                    'ipv6_reachable_count': 8,
-                    'ipv6_not_tested_authorities': [],
-                },
-                'flag_eligibility': {},
-            }
-            issues = generate_issues_from_consensus(consensus_data)
-            titles = [i['title'] for i in issues]
-            assert 'Partial IPv4 reachability' not in titles
-            assert 'IPv4 reachability issues' not in titles
-        finally:
-            registry.clear_voting_authorities()
+    def test_no_partial_reachability_when_authority_removed(self, voting_registry_8_voters):
+        consensus_data = {
+            'in_consensus': True,
+            'authority_votes': [{'wfu': 0.99, 'tk': 30 * SECONDS_PER_DAY}],
+            'reachability': {
+                'ipv4_reachable_count': 8,
+                'ipv4_reachable_authorities': self.ACTIVE_VOTERS,
+                'ipv6_reachable_count': 8,
+                'ipv6_not_tested_authorities': [],
+            },
+            'flag_eligibility': {},
+        }
+        issues = generate_issues_from_consensus(consensus_data)
+        titles = [i['title'] for i in issues]
+        assert 'Partial IPv4 reachability' not in titles
+        assert 'IPv4 reachability issues' not in titles
 
-    def test_partial_reachability_still_flagged_for_real_gap(self):
+    def test_partial_reachability_still_flagged_for_real_gap(self, voting_registry_8_voters):
         """A voter that genuinely can't reach the relay still warns, using 7/8."""
-        registry = get_authority_registry()
-        try:
-            update_voting_authorities(self.ACTIVE_VOTERS)  # 8 voters
-            reachable = self.ACTIVE_VOTERS[:-1]  # all but 'tor26' can reach (7/8)
-            consensus_data = {
-                'in_consensus': True,
-                'authority_votes': [{'wfu': 0.99, 'tk': 30 * SECONDS_PER_DAY}],
-                'reachability': {
-                    'ipv4_reachable_count': 7,
-                    'ipv4_reachable_authorities': reachable,
-                    'ipv6_reachable_count': 7,
-                    'ipv6_not_tested_authorities': [],
-                },
-                'flag_eligibility': {},
-            }
-            issues = generate_issues_from_consensus(consensus_data)
-            partial = [i for i in issues if i['title'] == 'Partial IPv4 reachability']
-            assert len(partial) == 1
-            assert '7/8' in partial[0]['description']
-            assert 'tor26' in partial[0]['suggestion']  # the one missing voter
-        finally:
-            registry.clear_voting_authorities()
+        reachable = self.ACTIVE_VOTERS[:-1]  # all but 'tor26' can reach (7/8)
+        consensus_data = {
+            'in_consensus': True,
+            'authority_votes': [{'wfu': 0.99, 'tk': 30 * SECONDS_PER_DAY}],
+            'reachability': {
+                'ipv4_reachable_count': 7,
+                'ipv4_reachable_authorities': reachable,
+                'ipv6_reachable_count': 7,
+                'ipv6_not_tested_authorities': [],
+            },
+            'flag_eligibility': {},
+        }
+        issues = generate_issues_from_consensus(consensus_data)
+        partial = [i for i in issues if i['title'] == 'Partial IPv4 reachability']
+        assert len(partial) == 1
+        assert '7/8' in partial[0]['description']
+        assert 'tor26' in partial[0]['suggestion']  # the one missing voter
 

--- a/tests/unit/consensus/test_relay_diagnostics.py
+++ b/tests/unit/consensus/test_relay_diagnostics.py
@@ -24,6 +24,10 @@ from allium.lib.relay_diagnostics import (
     _check_overload_issues,
     OVERLOAD_THRESHOLD_HOURS,
 )
+from allium.lib.consensus.collector_fetcher import (
+    get_authority_registry,
+    update_voting_authorities,
+)
 
 # Constants for testing
 SECONDS_PER_DAY = 86400
@@ -748,4 +752,64 @@ class TestBackwardCompatibility:
             assert 'description' in issue
             assert 'suggestion' in issue
             assert issue['severity'] in ('error', 'warning', 'info')
+
+
+class TestReachabilityAfterAuthorityRemoval:
+    """Regression tests for the stale reachability denominator bug.
+
+    When a directory authority is removed (e.g. gabelmoo went offline), a relay
+    reachable by all remaining voters must NOT be flagged 'Partial IPv4 reachability'
+    (previously it showed a spurious 8/9). A genuine gap (a voter that couldn't reach
+    the relay) must still be flagged, now against the dynamic denominator.
+    """
+
+    ACTIVE_VOTERS = ['bastet', 'dannenberg', 'dizum', 'faravahar',
+                     'longclaw', 'maatuska', 'moria1', 'tor26']
+
+    def test_no_partial_reachability_when_authority_removed(self):
+        registry = get_authority_registry()
+        try:
+            update_voting_authorities(self.ACTIVE_VOTERS)  # gabelmoo removed -> 8 voters
+            consensus_data = {
+                'in_consensus': True,
+                'authority_votes': [{'wfu': 0.99, 'tk': 30 * SECONDS_PER_DAY}],
+                'reachability': {
+                    'ipv4_reachable_count': 8,
+                    'ipv4_reachable_authorities': self.ACTIVE_VOTERS,
+                    'ipv6_reachable_count': 8,
+                    'ipv6_not_tested_authorities': [],
+                },
+                'flag_eligibility': {},
+            }
+            issues = generate_issues_from_consensus(consensus_data)
+            titles = [i['title'] for i in issues]
+            assert 'Partial IPv4 reachability' not in titles
+            assert 'IPv4 reachability issues' not in titles
+        finally:
+            registry.clear_voting_authorities()
+
+    def test_partial_reachability_still_flagged_for_real_gap(self):
+        """A voter that genuinely can't reach the relay still warns, using 7/8."""
+        registry = get_authority_registry()
+        try:
+            update_voting_authorities(self.ACTIVE_VOTERS)  # 8 voters
+            reachable = self.ACTIVE_VOTERS[:-1]  # all but 'tor26' can reach (7/8)
+            consensus_data = {
+                'in_consensus': True,
+                'authority_votes': [{'wfu': 0.99, 'tk': 30 * SECONDS_PER_DAY}],
+                'reachability': {
+                    'ipv4_reachable_count': 7,
+                    'ipv4_reachable_authorities': reachable,
+                    'ipv6_reachable_count': 7,
+                    'ipv6_not_tested_authorities': [],
+                },
+                'flag_eligibility': {},
+            }
+            issues = generate_issues_from_consensus(consensus_data)
+            partial = [i for i in issues if i['title'] == 'Partial IPv4 reachability']
+            assert len(partial) == 1
+            assert '7/8' in partial[0]['description']
+            assert 'tor26' in partial[0]['suggestion']  # the one missing voter
+        finally:
+            registry.clear_voting_authorities()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A Tor relay operator reported that after directory authority **gabelmoo** went offline and was removed from the consensus (Tor Metrics now lists 9 authorities), every one of their relays still showed:

> Partial IPv4 reachability: 8/9 authorities can reach this relay

This is a **false positive** — the relays are reachable by all currently‑voting authorities. The tool kept gabelmoo hardcoded in the voting‑authority denominator even though it no longer votes.

## Root cause

`get_voting_authority_names()` / `get_voting_authority_count()` always returned a hardcoded list of 9 voting authorities (including gabelmoo). Reachability display, the per‑authority table, and diagnostics all read those hardcoded globals, so a relay reachable by all 8 active voting authorities showed `8/9` plus a spurious "Partial IPv4 reachability" note — on every relay in the network.

## Changes

- **Dynamic voting‑authority set** (`collector_fetcher.py`, `relays.py`) — derive the voting authorities from those that actually voted this consensus round (CollecTor `flag-thresholds`), updated early in `enrich_with_api_data` so reachability, the per‑authority table, and diagnostics all use the correct denominator. The registry is reset at each generation boundary so a collector‑less run in the same process never reuses a stale dynamic list; falls back to the hardcoded 9 only when no vote data is present.
- **Retain removed authorities on the Directory Authorities page** (`collector_fetcher.py`, `page_writer.py`, `misc-authorities.html`) — a small hardcoded `KNOWN_OFFLINE_AUTHORITIES` bridge list (currently only gabelmoo) keeps a removed authority visible as offline once it has aged out of all live data. Per the [Onionoo protocol](https://metrics.torproject.org/onionoo.html), relays not seen in a network status within the past week (~7 days) are dropped from its documents, so such an authority would otherwise vanish entirely. The entry is merged **only when not present dynamically** (deduped by fingerprint/nickname); it is display‑only and never affects any counts. A dynamic "🔴 N offline" header sub‑bullet reflects any non‑running authority.
- **Tests** — new coverage for the dynamic voting list, the "no false partial reachability after removal" regression (and that genuine gaps are still flagged), and the DA‑page merge (absent → offline row, present → no duplicate). `tests/integration/test_authorities.py` migrated from unittest to pytest, with shared `make_relays` / `temp_dir` / `mock_uptime_response` / `voting_registry_8_voters` fixtures in `tests/conftest.py`.

## Review feedback addressed (Bugbot + CodeRabbit)

- Uppercase `country: 'DE'` for the offline row (matches `_preprocess_template_data` and `country/DE/` URLs); trailing whitespace stripped.
- `update_voting_authorities()` returns the effective voter count (never `0`) after an ignored empty update.
- Voting registry reset at each generation boundary (`clear_voting_authorities()` in `enrich_with_api_data`).
- DA‑page summary fallback prefers the voting registry (populated from vote keys) over the Onionoo Authority‑flag count when `flag_thresholds` is absent.
- unittest → pytest migration with shared fixtures in `tests/conftest.py` (including a yielding registry fixture replacing try/finally cleanup).
- Module‑level logger in `page_writer.py` for the known‑offline fetch fallback instead of silent swallowing.
- Defensive copies from `get_voting_authority_names()` (both branches) and `get_known_offline_authorities()`.
- `total_authorities` (the voting denominator) asserted in the offline‑merge test.
- Merged latest `master` (post‑simplification module layout: `write_misc(relays, ...)` module function).

## Verification

- Full test suite: **1053 passed / 56 deselected** after the master merge; `flake8 --select=E9,F63,F7,F82` clean repo‑wide.
- End‑to‑end output comparison of a pre‑change build vs. this change (`compare_outputs.py`): **0 pages added/removed**; all remaining diffs are benign (timestamps, live‑API drift on ~120 relay pages, pre‑existing country‑list ordering nondeterminism). DA page still shows `8/8 Voted` and retains the gabelmoo offline row.
- Earlier frozen‑input comparison (original submission): **10,245 relay pages** corrected `IPv4: 8/9 → 8/8` (exact 1:1); spurious "Partial IPv4 reachability" notes **10,297 → 52** (the 52 remaining are genuine partial‑reachability cases, correctly preserved).
- DA page before/after screenshots (gabelmoo vanished → retained as an offline row with header sub‑bullet and legend entry) are attached as artifacts on the original agent run.

## Notes / caveats

- `KNOWN_OFFLINE_AUTHORITIES` is a deliberately minimal hardcode — prune gabelmoo if it permanently leaves or returns. Fully dynamic tracking after an authority ages out of both Onionoo and CollecTor would require cross‑run state persistence (out of scope here).
- The output directories used for verification (`allium/www_baseline`, `allium/www_after`) are gitignored and not part of this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bd7126a-debb-4d6e-96c4-d6339bf6b7dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bd7126a-debb-4d6e-96c4-d6339bf6b7dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directory-authority pages now merge “known offline” authorities as offline-only historical context, with expandable offline details and clearer legend/notes.
  * Offline entries are rendered as non-links, and known-offline authorities no longer affect consensus math.
  * Voting-authority sets can update dynamically from live collector data to drive authority counts.

* **Bug Fixes**
  * Fixed voting/denominator and reachability calculations so offline/context entries don’t inflate totals or trigger partial reachability warnings.
  * Avoided duplicate offline placeholders when an authority is present in live data.

* **Tests**
  * Migrated integration tests to pytest and added unit coverage for dynamic voting updates and known-offline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->