### PR TITLE
LOC reduction: delete dead code and merge verbatim duplication (plan 2 of #211)

### DIFF
--- a/allium/allium.py
+++ b/allium/allium.py
@@ -35,7 +35,7 @@ def ensure_output_directory(output_dir):
     """
     try:
         os.makedirs(output_dir, exist_ok=True)
-    except PermissionError as e:
+    except PermissionError:
         print(f"❌ Error: Permission denied creating output directory '{output_dir}'")
         print(f"💡 Try running with a different output directory:")
         print(f"   python3 allium.py --out ~/allium-output --progress")

--- a/allium/lib/aroi_validation.py
+++ b/allium/lib/aroi_validation.py
@@ -14,7 +14,6 @@ dns-familyid-ed25519, uri-familyid-ed25519). Spec:
 https://nusenu.github.io/ContactInfo-Information-Sharing-Specification/
 """
 
-import json
 import logging
 import re
 from collections import defaultdict

--- a/allium/lib/aroileaders.py
+++ b/allium/lib/aroileaders.py
@@ -111,21 +111,6 @@ def _top_n(operators, metric, n=50, filter_fn=None):
     return sorted(source.items(), key=lambda x: x[1][metric], reverse=True)[:n]
 
 
-def normalize_contact_info(contact_info):
-    """
-    Normalize contact information by removing common artifacts and standardizing.
-    
-    This function cleans up contact information to improve grouping accuracy.
-    
-    Args:
-        contact_info (str): Raw contact information string
-        
-    Returns:
-        str: Normalized contact information
-    """
-    return contact_info.strip()
-
-
 def _format_bandwidth_with_auto_unit(bandwidth_value, bandwidth_formatter, decimal_places=1):
     """
     Helper function to format bandwidth with automatic unit determination.

--- a/allium/lib/aroileaders.py
+++ b/allium/lib/aroileaders.py
@@ -333,31 +333,23 @@ def _format_breakdown_details(breakdown_items, max_chars, formatter_func=None):
     if formatter_func is None:
         formatter_func = lambda count, country: f"{count} in {country}"
     
-    # Create full breakdown for tooltip and short breakdown for display
-    full_breakdown = []
-    short_breakdown = []
-    
-    for country, count in breakdown_items:
-        detail = formatter_func(count, country)
-        full_breakdown.append(detail)
-        short_breakdown.append(detail)
-    
-    tooltip_text = ", ".join(full_breakdown)
-    
+    details = [formatter_func(count, country) for country, count in breakdown_items]
+    tooltip_text = ", ".join(details)
+
     # Create short version with truncation
-    short_text = ", ".join(short_breakdown)
+    short_text = tooltip_text
     if len(short_text) > max_chars:
         # Find the last complete entry that fits
         chars_used = 0
-        for i, detail in enumerate(short_breakdown):
+        for i, detail in enumerate(details):
             if i > 0:
                 chars_used += 2  # for ", "
             if chars_used + len(detail) <= max_chars - 3:  # leave 3 chars for "..."
                 chars_used += len(detail)
             else:
-                short_breakdown = short_breakdown[:i]
+                details = details[:i]
                 break
-        details_text = ", ".join(short_breakdown) + "..."
+        details_text = ", ".join(details) + "..."
     else:
         details_text = short_text
     
@@ -1003,23 +995,258 @@ def _rank_operators(aroi_operators):
     return leaderboards
 
 
+# ---------------------------------------------------------------------------
+# Table-driven per-category formatting config for _format_leaderboard_entries.
+# The VARYING parts of the former 19-category switchboard live in these tables;
+# genuinely unique logic lives in the small _*_extras() helpers below.
+# ---------------------------------------------------------------------------
+
+# Categories whose primary bandwidth column shows a historical average
+# instead of the current total bandwidth.
+_PRIMARY_BANDWIDTH_KEYS = {
+    'bandwidth_masters': 'bandwidth_6m_average',
+    'bandwidth_legends': 'bandwidth_5y_average',
+}
+
+# Achievement titles for top 3 operators: category -> (entry field,
+# metrics key that must be truthy (None = always), {rank: title}).
+_ACHIEVEMENT_TITLES = {
+    'frontier_builders': ('frontier_achievement_title', 'rare_country_breakdown',
+                          {1: "🌟 Frontier Legend", 2: "⭐ Frontier Master", 3: "✨ Frontier Champion"}),
+    'platform_diversity': ('platform_hero_title', None,
+                           {1: "🏆 Platform Legend", 2: "💻 Platform Master", 3: "🖥️ Platform Champion"}),
+    'most_diverse': ('diversity_master_title', None,
+                     {1: "🌍 Diversity Legend", 2: "🌟 Diversity Master", 3: "🌐 Diversity Champion"}),
+    'ipv4_leaders': ('ipv4_achievement_title', None,
+                     {1: "🥇 IPv4 Legend", 2: "🥈 IPv4 Master", 3: "🥉 IPv4 Champion"}),
+    'ipv6_leaders': ('ipv6_achievement_title', None,
+                     {1: "🥇 IPv6 Legend", 2: "🥈 IPv6 Master", 3: "🥉 IPv6 Champion"}),
+}
+
+# Historical score categories: category -> (metrics key prefix, period label).
+_SCORE_CATEGORIES = {
+    'reliability_masters': ('reliability_6m', '6-month'),
+    'legacy_titans': ('reliability_5y', '5-year'),
+    'bandwidth_masters': ('bandwidth_6m', '6-month'),
+    'bandwidth_legends': ('bandwidth_5y', '5-year'),
+}
+
+# IP-address categories: category -> (metrics key prefix, display label).
+_IP_CATEGORIES = {
+    'ipv4_leaders': ('ipv4', 'IPv4'),
+    'ipv6_leaders': ('ipv6', 'IPv6'),
+}
+
+# Consensus weight metrics rendered as '<key>_pct' entry fields ("{value * 100:.2f}%").
+_PCT_KEYS = ('total_consensus_weight', 'exit_consensus_weight', 'guard_consensus_weight',
+             'ipv4_total_consensus_weight', 'ipv6_total_consensus_weight', 'validated_consensus_weight')
+
+# Metrics copied through to the formatted entry unchanged.
+_PASSTHROUGH_KEYS = (
+    'aroi_domain', 'contact_hash', 'contact_info', 'total_relays', 'guard_count', 'exit_count',
+    'middle_count', 'measured_count', 'unique_as_count', 'platform_count', 'non_linux_count',
+    'non_eu_count', 'rare_country_count', 'relays_in_rare_countries', 'veteran_days',
+    'veteran_relay_scaling_factor', 'unique_ipv4_count', 'unique_ipv6_count', 'ipv4_relay_count',
+    'ipv6_relay_count', 'ipv4_total_bandwidth', 'ipv6_total_bandwidth', 'ipv4_guard_count',
+    'ipv4_exit_count', 'ipv4_middle_count', 'ipv6_guard_count', 'ipv6_exit_count', 'ipv6_middle_count',
+    'validated_relay_count', 'invalid_relay_count', 'validated_guard_count', 'validated_exit_count',
+    'validated_middle_count', 'validated_consensus_weight', 'validated_country_count',
+    'validated_v2_relay_count', 'validated_v3_relay_count', 'v2_relay_count', 'v3_relay_count',
+    'v3_relay_percentage', 'v3_tier',
+)
+
+# Defaults for category-specific entry fields (non-applicable categories keep these).
+_ENTRY_EXTRAS_DEFAULTS = dict.fromkeys((
+    'geographic_achievement', 'geographic_breakdown_details', 'geographic_breakdown_tooltip',
+    'rare_country_details', 'rare_country_tooltip', 'frontier_achievement_title',
+    'platform_hero_title', 'platform_breakdown_details', 'platform_breakdown_tooltip',
+    'diversity_master_title', 'diversity_breakdown_details', 'diversity_breakdown_tooltip',
+    'veteran_details_short', 'veteran_tooltip', 'reliability_details_short', 'reliability_tooltip',
+    'bandwidth_details_short', 'bandwidth_tooltip', 'ipv4_achievement_title', 'ipv6_achievement_title',
+    'ip_address_details', 'ip_address_tooltip', 'validated_bandwidth', 'validated_bandwidth_unit',
+), "")
+# Score fields default to formatted zero/unity values (matching f"{0.0:.1f}" etc.).
+_ENTRY_EXTRAS_DEFAULTS.update({
+    'reliability_score': "0.0", 'reliability_average': "0.0%", 'reliability_weight': "1.0x",
+    'bandwidth_score': "0.0", 'bandwidth_average': "0.0", 'bandwidth_weight': "1.0x",
+})
+
+
+def _truncate_with_ellipsis(text, max_chars):
+    """Truncate to max_chars total, reserving 3 chars for the trailing "..."."""
+    return text[:max_chars - 3] + "..." if len(text) > max_chars else text
+
+
+def _geographic_extras(category, metrics, bandwidth_formatter):
+    """non_eu_leaders: dynamic geographic achievement + non-EU country breakdown
+    (used for the specialization column instead of all countries)."""
+    details, tooltip = _format_breakdown_details(metrics['non_eu_country_breakdown'], 52)
+    return {
+        'geographic_achievement': calculate_geographic_achievement(metrics['countries']),
+        'geographic_breakdown_details': details,
+        'geographic_breakdown_tooltip': tooltip,
+    }
+
+
+def _frontier_extras(category, metrics, bandwidth_formatter):
+    """frontier_builders: rare country breakdown with custom "relay/relays" formatter."""
+    if not metrics['rare_country_breakdown']:
+        return {}
+    details, tooltip = _format_breakdown_details(
+        metrics['rare_country_breakdown'], 44,
+        lambda count, country: f"{count} relay{'s' if count != 1 else ''} in {country}"
+    )
+    return {'rare_country_details': details, 'rare_country_tooltip': tooltip}
+
+
+def _platform_extras(category, metrics, bandwidth_formatter):
+    """platform_diversity: non-Linux platform breakdown for the specialization column."""
+    platform_breakdown = {}
+    for relay in metrics['relays']:
+        platform = relay.get('platform', 'Unknown')
+        if platform and not platform.lower().startswith('linux'):
+            # Extract short platform name (before first space or version number)
+            short_platform = platform.split()[0] if platform else 'Unknown'
+            # Map common platform names to shorter versions
+            for prefix, short_name in (('win', 'Win'), ('mac', 'Mac'), ('darwin', 'Mac'),
+                                       ('freebsd', 'FreeBSD'), ('openbsd', 'OpenBSD'), ('netbsd', 'NetBSD')):
+                if short_platform.lower().startswith(prefix):
+                    short_platform = short_name
+                    break
+            platform_breakdown[short_platform] = platform_breakdown.get(short_platform, 0) + 1
+
+    # Sort by relay count (descending) then by platform name
+    sorted_platform_breakdown = sorted(platform_breakdown.items(),
+                                       key=lambda x: (-x[1], x[0]))
+
+    # Create short format (max 32 chars): "Win: 5, Mac: 3, FreeBSD: 2"
+    platform_breakdown_full = ", ".join(f"{platform}: {count}" for platform, count in sorted_platform_breakdown)
+
+    # Create full tooltip with platform details only (countries not relevant for platform diversity)
+    platform_tooltip_text = ", ".join(f"{count} {platform} relays" for platform, count in sorted_platform_breakdown)
+    return {
+        'platform_breakdown_details': _truncate_with_ellipsis(platform_breakdown_full, 32),
+        'platform_breakdown_tooltip': f"Platform Distribution: {platform_tooltip_text}",
+    }
+
+
+def _diversity_extras(category, metrics, bandwidth_formatter):
+    """most_diverse: diversity calculation breakdown + score tooltip."""
+    country_count = metrics['country_count']
+    platform_count = metrics['platform_count']
+    as_count = metrics['unique_as_count']
+
+    # Create short format (max 20 chars): "5 Countries, 3 OS, 8 AS"
+    diversity_breakdown_full = f"{country_count} Countries, {platform_count} OS, {as_count} AS"
+
+    # Create full tooltip with calculation details
+    return {
+        'diversity_breakdown_details': _truncate_with_ellipsis(diversity_breakdown_full, 20),
+        'diversity_breakdown_tooltip': f"Diversity Score: {country_count} countries x 3.0 + {as_count} AS (rarity-weighted) x 2.0 + {platform_count} platforms x 1.0 = {metrics['diversity_score']:.1f}",
+    }
+
+
+def _veteran_extras(category, metrics, bandwidth_formatter):
+    """network_veterans: veteran tenure tooltip with 20-char short version."""
+    veteran_tooltip = metrics['veteran_details']
+    if not veteran_tooltip:
+        return {}
+    if len(veteran_tooltip) > 20:
+        # Extract just the days and scaling factor for short display
+        days_part = f"{metrics['veteran_days']} days * {metrics['veteran_relay_scaling_factor']}"
+        if len(days_part) > 17:  # leave room for "..."
+            veteran_details_short = f"{metrics['veteran_days']} days..."
+        else:
+            veteran_details_short = days_part + "..."
+    else:
+        veteran_details_short = veteran_tooltip
+    return {'veteran_details_short': veteran_details_short, 'veteran_tooltip': veteran_tooltip}
+
+
+def _score_extras(category, metrics, bandwidth_formatter):
+    """reliability_masters / legacy_titans / bandwidth_masters / bandwidth_legends:
+    period-matched score, average and simplified tooltip (no weighting info)."""
+    prefix, period_label = _SCORE_CATEGORIES[category]
+    score = metrics[prefix + '_score']
+    average = metrics[prefix + '_average']
+    weight = metrics[prefix + '_weight']
+    if prefix.startswith('reliability'):
+        return {
+            'reliability_score': f"{score:.1f}",
+            'reliability_average': f"{average:.1f}%",
+            'reliability_weight': f"{weight:.1f}x",
+            'reliability_details_short': f"{average:.1f}% avg",
+            'reliability_tooltip': f"{period_label} reliability: {average:.1f}% average uptime ({metrics['total_relays']} relays)",
+        }
+    # Format bandwidth average with unit (reuse existing formatters)
+    formatted_avg, unit = _format_bandwidth_with_auto_unit(average, bandwidth_formatter)
+    return {
+        'bandwidth_score': f"{score:.1f}",
+        'bandwidth_average': f"{average:.1f}",
+        'bandwidth_weight': f"{weight:.1f}x",
+        'bandwidth_details_short': f"{formatted_avg} {unit} avg",
+        'bandwidth_tooltip': f"{period_label} bandwidth: {formatted_avg} {unit} average bandwidth ({metrics['total_relays']} relays)",
+    }
+
+
+def _ip_extras(category, metrics, bandwidth_formatter):
+    """ipv4_leaders / ipv6_leaders: unique-address details + infrastructure tooltip."""
+    prefix, label = _IP_CATEGORIES[category]
+    unique_count = metrics['unique_' + prefix + '_count']
+    # Format IP-specific bandwidth with unit (reuse existing formatters)
+    formatted_ip_bandwidth, ip_bandwidth_unit = _format_bandwidth_with_auto_unit(
+        metrics[prefix + '_total_bandwidth'], bandwidth_formatter
+    )
+    return {
+        'ip_address_details': f"{unique_count} unique {label}",
+        'ip_address_tooltip': f"{label} Infrastructure: {unique_count} unique addresses across {metrics[prefix + '_relay_count']} relays with {formatted_ip_bandwidth} {ip_bandwidth_unit} bandwidth",
+    }
+
+
+def _validated_extras(category, metrics, bandwidth_formatter):
+    """validated_relays: validated-only bandwidth (skipped for other categories)."""
+    formatted, unit = _format_bandwidth_with_auto_unit(metrics['validated_bandwidth'], bandwidth_formatter)
+    return {'validated_bandwidth': formatted, 'validated_bandwidth_unit': unit}
+
+
+# Dispatch table: category -> extras handler (absent categories use defaults only).
+_CATEGORY_EXTRAS = {
+    'non_eu_leaders': _geographic_extras,
+    'frontier_builders': _frontier_extras,
+    'platform_diversity': _platform_extras,
+    'most_diverse': _diversity_extras,
+    'network_veterans': _veteran_extras,
+    'reliability_masters': _score_extras,
+    'legacy_titans': _score_extras,
+    'bandwidth_masters': _score_extras,
+    'bandwidth_legends': _score_extras,
+    'ipv4_leaders': _ip_extras,
+    'ipv6_leaders': _ip_extras,
+    'validated_relays': _validated_extras,
+}
+
+
 def _format_leaderboard_entries(leaderboards, aroi_operators, relays_instance):
     """
     Format leaderboard entries for Jinja2 template rendering.
     
     Converts raw operator metrics into display-ready strings with units,
     percentages, achievement badges, and tooltips.
-    
+
+    Per-category variations (achievement titles, score periods, IP labels,
+    breakdown details/tooltips) are table-driven via the _CATEGORY_EXTRAS,
+    _ACHIEVEMENT_TITLES and related config tables defined above.
+
     Returns:
         dict with 'leaderboards' (formatted), 'summary' (stats), 'raw_operators'
     """
     from .bandwidth_formatter import format_data_volume_with_unit, compute_total_data_pct
-    
+
     # Get per-period network totals for period-matched percentage calculations
     _net_by_period = {}
     if hasattr(relays_instance, 'json') and relays_instance.json.get('network_health'):
         _net_by_period = relays_instance.json['network_health'].get('network_total_data_by_period', {})
-    
+
     # Format data for template rendering with bandwidth units (reuse existing formatters)
     formatted_leaderboards = {}
     for category, data in leaderboards.items():
@@ -1027,411 +1254,74 @@ def _format_leaderboard_entries(leaderboards, aroi_operators, relays_instance):
         for rank, (operator_key, metrics) in enumerate(data, 1):
             # Use existing bandwidth formatting methods (top10 specific formatting)
             # For bandwidth categories, use historical bandwidth instead of current bandwidth
-            if category in ['bandwidth_masters', 'bandwidth_legends']:
-                if category == 'bandwidth_masters':
-                    bandwidth_value = metrics['bandwidth_6m_average']
-                else:  # bandwidth_legends
-                    bandwidth_value = metrics['bandwidth_5y_average']
-            else:
-                bandwidth_value = metrics['total_bandwidth']
-            
+            bandwidth_value = metrics[_PRIMARY_BANDWIDTH_KEYS.get(category, 'total_bandwidth')]
             formatted_bandwidth, bandwidth_unit = _format_bandwidth_with_auto_unit(
                 bandwidth_value, relays_instance.bandwidth_formatter
             )
-            
-            # Format exit-specific bandwidth for exit categories (exit_authority, exit_operators)
-            formatted_exit_bandwidth, exit_bandwidth_unit = _format_bandwidth_with_auto_unit(
-                metrics['exit_bandwidth'], relays_instance.bandwidth_formatter
-            )
-            
-            # Format guard-specific bandwidth for guard categories (guard_authority, guard_operators)
-            formatted_guard_bandwidth, guard_bandwidth_unit = _format_bandwidth_with_auto_unit(
-                metrics['guard_bandwidth'], relays_instance.bandwidth_formatter
-            )
-            
-            # Format diversity-specific bandwidth (only counts relays matching diversity criteria)
-            formatted_non_linux_bandwidth, non_linux_bandwidth_unit = _format_bandwidth_with_auto_unit(
-                metrics['non_linux_bandwidth'], relays_instance.bandwidth_formatter
-            )
-            formatted_non_eu_bandwidth, non_eu_bandwidth_unit = _format_bandwidth_with_auto_unit(
-                metrics['non_eu_bandwidth'], relays_instance.bandwidth_formatter
-            )
-            formatted_rare_country_bandwidth, rare_country_bandwidth_unit = _format_bandwidth_with_auto_unit(
-                metrics['rare_country_bandwidth'], relays_instance.bandwidth_formatter
-            )
-            
-            # Calculate geographic achievement for non_eu_leaders category
-            geographic_achievement = ""
-            geographic_breakdown_details = ""
-            geographic_breakdown_tooltip = ""
-            if category == 'non_eu_leaders':
-                geographic_achievement = calculate_geographic_achievement(metrics['countries'])
-                # Use non-EU country breakdown for specialization column instead of all countries
-                geographic_breakdown_details, geographic_breakdown_tooltip = _format_breakdown_details(
-                    metrics['non_eu_country_breakdown'], 52
-                )
-            
-            # Format rare country breakdown for frontier_builders category
-            rare_country_details = ""
-            rare_country_tooltip = ""
-            frontier_achievement_title = ""
-            platform_hero_title = ""
-            diversity_master_title = ""
-            
-            if category == 'frontier_builders' and metrics['rare_country_breakdown']:
-                # Use helper function with custom formatter for rare countries (includes "relay/relays")
-                rare_country_details, rare_country_tooltip = _format_breakdown_details(
-                    metrics['rare_country_breakdown'], 44,
-                    lambda count, country: f"{count} relay{'s' if count != 1 else ''} in {country}"
-                )
-                
-                # Add achievement titles for top 3 frontier builders
-                if rank == 1:
-                    frontier_achievement_title = "🌟 Frontier Legend"
-                elif rank == 2:
-                    frontier_achievement_title = "⭐ Frontier Master"
-                elif rank == 3:
-                    frontier_achievement_title = "✨ Frontier Champion"
-            
-            # Add achievement titles for top 3 platform diversity heroes
-            platform_breakdown_details = ""
-            platform_breakdown_tooltip = ""
-            if category == 'platform_diversity':
-                if rank == 1:
-                    platform_hero_title = "🏆 Platform Legend"
-                elif rank == 2:
-                    platform_hero_title = "💻 Platform Master"
-                elif rank == 3:
-                    platform_hero_title = "🖥️ Platform Champion"
-                
-                # Format platform breakdown for specialization column (non-Linux only)
-                platform_breakdown = {}
-                for relay in metrics['relays']:
-                    platform = relay.get('platform', 'Unknown')
-                    if platform and not platform.lower().startswith('linux'):
-                        # Extract short platform name (before first space or version number)
-                        short_platform = platform.split()[0] if platform else 'Unknown'
-                        # Map common platform names to shorter versions
-                        if short_platform.lower().startswith('win'):
-                            short_platform = 'Win'
-                        elif short_platform.lower().startswith('mac') or short_platform.lower().startswith('darwin'):
-                            short_platform = 'Mac'
-                        elif short_platform.lower().startswith('freebsd'):
-                            short_platform = 'FreeBSD'
-                        elif short_platform.lower().startswith('openbsd'):
-                            short_platform = 'OpenBSD'
-                        elif short_platform.lower().startswith('netbsd'):
-                            short_platform = 'NetBSD'
-                        platform_breakdown[short_platform] = platform_breakdown.get(short_platform, 0) + 1
-                
-                # Sort by relay count (descending) then by platform name
-                sorted_platform_breakdown = sorted(platform_breakdown.items(), 
-                                                  key=lambda x: (-x[1], x[0]))
-                
-                # Create short format (max 32 chars): "Win: 5, Mac: 3, FreeBSD: 2"
-                platform_parts = []
-                for platform, count in sorted_platform_breakdown:
-                    platform_parts.append(f"{platform}: {count}")
-                
-                platform_breakdown_full = ", ".join(platform_parts)
-                if len(platform_breakdown_full) > 32:
-                    platform_breakdown_details = platform_breakdown_full[:29] + "..."
-                else:
-                    platform_breakdown_details = platform_breakdown_full
-                
-                # Create full tooltip with platform details only (countries not relevant for platform diversity)
-                platform_tooltip_parts = []
-                for platform, count in sorted_platform_breakdown:
-                    platform_tooltip_parts.append(f"{count} {platform} relays")
-                platform_tooltip_text = ", ".join(platform_tooltip_parts)
-                
-                platform_breakdown_tooltip = f"Platform Distribution: {platform_tooltip_text}"
-            
-            # Add achievement titles for top 3 diversity masters
-            diversity_breakdown_details = ""
-            diversity_breakdown_tooltip = ""
-            if category == 'most_diverse':
-                if rank == 1:
-                    diversity_master_title = "🌍 Diversity Legend"
-                elif rank == 2:
-                    diversity_master_title = "🌟 Diversity Master"
-                elif rank == 3:
-                    diversity_master_title = "🌐 Diversity Champion"
-                
-                # Format diversity calculation breakdown
-                country_count = metrics['country_count']
-                platform_count = metrics['platform_count']
-                as_count = metrics['unique_as_count']
-                
-                # Create short format (max 20 chars): "5 Countries, 3 OS, 8 AS"
-                diversity_breakdown_full = f"{country_count} Countries, {platform_count} OS, {as_count} AS"
-                if len(diversity_breakdown_full) > 20:
-                    diversity_breakdown_details = diversity_breakdown_full[:17] + "..."
-                else:
-                    diversity_breakdown_details = diversity_breakdown_full
-                
-                # Create full tooltip with calculation details
-                diversity_breakdown_tooltip = f"Diversity Score: {country_count} countries x 3.0 + {as_count} AS (rarity-weighted) x 2.0 + {platform_count} platforms x 1.0 = {metrics['diversity_score']:.1f}"
-            
-            # Format veteran details for network_veterans category
-            veteran_details_short = ""
-            veteran_tooltip = ""
-            if category == 'network_veterans' and metrics['veteran_details']:
-                veteran_tooltip = metrics['veteran_details']
-                
-                # Create short version (max 20 chars for table)
-                if len(veteran_tooltip) > 20:
-                    # Extract just the days and scaling factor for short display
-                    days_part = f"{metrics['veteran_days']} days * {metrics['veteran_relay_scaling_factor']}"
-                    if len(days_part) > 17:  # leave room for "..."
-                        veteran_details_short = f"{metrics['veteran_days']} days..."
-                    else:
-                        veteran_details_short = days_part + "..."
-                else:
-                    veteran_details_short = veteran_tooltip
 
-            # Format reliability details for reliability categories (REUSE veteran pattern)
-            reliability_details_short = ""
-            reliability_tooltip = ""
-            reliability_score_raw = 0.0
-            reliability_average = 0.0
-            reliability_weight = 1.0
-            
-            if category in ['reliability_masters', 'legacy_titans']:
-                # Determine which reliability data to use
-                if category == 'reliability_masters':
-                    reliability_score_raw = metrics['reliability_6m_score']
-                    reliability_average = metrics['reliability_6m_average']
-                    reliability_weight = metrics['reliability_6m_weight']
-                    period_label = "6-month"
-                else:  # legacy_titans
-                    reliability_score_raw = metrics['reliability_5y_score']
-                    reliability_average = metrics['reliability_5y_average']
-                    reliability_weight = metrics['reliability_5y_weight']
-                    period_label = "5-year"
-                
-                # Create tooltip without weighting information (simplified)
-                reliability_tooltip = f"{period_label} reliability: {reliability_average:.1f}% average uptime ({metrics['total_relays']} relays)"
-                
-                # Create short version for table display (simplified, no weight)
-                reliability_details_short = f"{reliability_average:.1f}% avg"
-            
-            # Format bandwidth details for bandwidth categories (NEW, similar to reliability pattern)
-            bandwidth_details_short = ""
-            bandwidth_tooltip = ""
-            bandwidth_score_raw = 0.0
-            bandwidth_average = 0.0
-            bandwidth_weight = 1.0
-            
-            if category in ['bandwidth_masters', 'bandwidth_legends']:
-                # Determine which bandwidth data to use
-                if category == 'bandwidth_masters':
-                    bandwidth_score_raw = metrics['bandwidth_6m_score']
-                    bandwidth_average = metrics['bandwidth_6m_average']
-                    bandwidth_weight = metrics['bandwidth_6m_weight']
-                    period_label = "6-month"
-                else:  # bandwidth_legends
-                    bandwidth_score_raw = metrics['bandwidth_5y_score']
-                    bandwidth_average = metrics['bandwidth_5y_average']
-                    bandwidth_weight = metrics['bandwidth_5y_weight']
-                    period_label = "5-year"
-                
-                # Format bandwidth with unit (reuse existing formatters)
-                formatted_bandwidth_avg, bandwidth_unit = _format_bandwidth_with_auto_unit(
-                    bandwidth_average, relays_instance.bandwidth_formatter
-                )
-                
-                # Create tooltip without weighting information (simplified)
-                bandwidth_tooltip = f"{period_label} bandwidth: {formatted_bandwidth_avg} {bandwidth_unit} average bandwidth ({metrics['total_relays']} relays)"
-                
-                # Create short version for table display (simplified, no weight)
-                bandwidth_details_short = f"{formatted_bandwidth_avg} {bandwidth_unit} avg"
-            
-            # Format IPv4/IPv6 specific details for IP address categories (NEW)
-            ipv4_achievement_title = ""
-            ipv6_achievement_title = ""
-            ip_address_details = ""
-            ip_address_tooltip = ""
-            
-            if category == 'ipv4_leaders':
-                # Add achievement titles for top 3 IPv4 leaders
-                if rank == 1:
-                    ipv4_achievement_title = "🥇 IPv4 Legend"
-                elif rank == 2:
-                    ipv4_achievement_title = "🥈 IPv4 Master"
-                elif rank == 3:
-                    ipv4_achievement_title = "🥉 IPv4 Champion"
-                
-                # Format IPv4 bandwidth with unit (reuse existing formatters)
-                formatted_ipv4_bandwidth, ipv4_bandwidth_unit = _format_bandwidth_with_auto_unit(
-                    metrics['ipv4_total_bandwidth'], relays_instance.bandwidth_formatter
-                )
-                
-                ip_address_details = f"{metrics['unique_ipv4_count']} unique IPv4"
-                ip_address_tooltip = f"IPv4 Infrastructure: {metrics['unique_ipv4_count']} unique addresses across {metrics['ipv4_relay_count']} relays with {formatted_ipv4_bandwidth} {ipv4_bandwidth_unit} bandwidth"
-                
-            elif category == 'ipv6_leaders':
-                # Add achievement titles for top 3 IPv6 leaders
-                if rank == 1:
-                    ipv6_achievement_title = "🥇 IPv6 Legend"
-                elif rank == 2:
-                    ipv6_achievement_title = "🥈 IPv6 Master"
-                elif rank == 3:
-                    ipv6_achievement_title = "🥉 IPv6 Champion"
-                
-                # Format IPv6 bandwidth with unit (reuse existing formatters)
-                formatted_ipv6_bandwidth, ipv6_bandwidth_unit = _format_bandwidth_with_auto_unit(
-                    metrics['ipv6_total_bandwidth'], relays_instance.bandwidth_formatter
-                )
-                
-                ip_address_details = f"{metrics['unique_ipv6_count']} unique IPv6"
-                ip_address_tooltip = f"IPv6 Infrastructure: {metrics['unique_ipv6_count']} unique addresses across {metrics['ipv6_relay_count']} relays with {formatted_ipv6_bandwidth} {ipv6_bandwidth_unit} bandwidth"
-            
-            # Format validated bandwidth only for validated_relays category (optimization)
-            formatted_validated_bandwidth = ""
-            validated_bandwidth_unit = ""
-            if category == 'validated_relays':
-                formatted_validated_bandwidth, validated_bandwidth_unit = _format_bandwidth_with_auto_unit(
-                    metrics['validated_bandwidth'], relays_instance.bandwidth_formatter
-                )
-            
+            # Category-specific extras: defaults for non-applicable categories,
+            # overridden by the table-driven handler for the current category
+            extras = dict(_ENTRY_EXTRAS_DEFAULTS)
+            handler = _CATEGORY_EXTRAS.get(category)
+            if handler:
+                extras.update(handler(category, metrics, relays_instance.bandwidth_formatter))
+
+            # Add achievement titles for top 3 operators (table-driven)
+            title_config = _ACHIEVEMENT_TITLES.get(category)
+            if title_config and (title_config[1] is None or metrics[title_config[1]]):
+                extras[title_config[0]] = title_config[2].get(rank, "")
+
             # Format total data transferred for all categories (reused in template)
             raw_total_data = metrics.get('total_data_transferred', 0)
             raw_total_data_period = metrics.get('total_data_period')
             formatted_total_data_transferred = format_data_volume_with_unit(raw_total_data)
             total_data_pct = compute_total_data_pct(raw_total_data, raw_total_data_period, _net_by_period) if raw_total_data_period else ""
 
-            
             display_name = metrics['aroi_domain'] if metrics['aroi_domain'] and metrics['aroi_domain'] != 'none' else operator_key
 
-            # Calculate percentages for guard and exit relay ratios
+            # Calculate percentages for guard, exit and non-EU relay ratios
             guard_percentage = (metrics['guard_count'] / metrics['total_relays'] * 100) if metrics['total_relays'] > 0 else 0
             exit_percentage = (metrics['exit_count'] / metrics['total_relays'] * 100) if metrics['total_relays'] > 0 else 0
-            
-            # Calculate non-EU percentage for geographic champions
             non_eu_percentage = (metrics['non_eu_count'] / metrics['total_relays'] * 100) if metrics['total_relays'] > 0 else 0
 
-            formatted_entry = {
+            # Assemble the entry: raw passthrough metrics, per-role bandwidth columns,
+            # consensus weight percentages, computed display fields, then category extras
+            formatted_entry = {key: metrics[key] for key in _PASSTHROUGH_KEYS}
+
+            # Format role/diversity-specific bandwidth columns (exit, guard, non-Linux,
+            # non-EU and rare-country bandwidth only count relays matching each criteria)
+            for prefix in ('exit', 'guard', 'non_linux', 'non_eu', 'rare_country'):
+                bw, unit = _format_bandwidth_with_auto_unit(
+                    metrics[prefix + '_bandwidth'], relays_instance.bandwidth_formatter
+                )
+                formatted_entry[prefix + '_bandwidth'] = bw
+                formatted_entry[prefix + '_bandwidth_unit'] = unit
+
+            formatted_entry.update({key + '_pct': f"{metrics[key] * 100:.2f}%" for key in _PCT_KEYS})
+
+            formatted_entry.update({
                 'rank': rank,
                 'operator_key': operator_key,
                 'display_name': display_name,
-                'aroi_domain': metrics['aroi_domain'],
-                'contact_hash': metrics['contact_hash'],
-                'contact_info': metrics['contact_info'],
                 'contact_info_escaped': safe_html_escape(metrics['contact_info']),
-                'total_relays': metrics['total_relays'],
                 'total_bandwidth': formatted_bandwidth,
                 'bandwidth_unit': bandwidth_unit,
-                'exit_bandwidth': formatted_exit_bandwidth,
-                'exit_bandwidth_unit': exit_bandwidth_unit,
-                'guard_bandwidth': formatted_guard_bandwidth,
-                'guard_bandwidth_unit': guard_bandwidth_unit,
-                'total_consensus_weight_pct': f"{metrics['total_consensus_weight'] * 100:.2f}%",
-                'exit_consensus_weight_pct': f"{metrics['exit_consensus_weight'] * 100:.2f}%",
-                'guard_consensus_weight_pct': f"{metrics['guard_consensus_weight'] * 100:.2f}%",
-                'guard_count': metrics['guard_count'],
-                'exit_count': metrics['exit_count'],
                 'guard_percentage': f"{guard_percentage:.0f}%",
                 'exit_percentage': f"{exit_percentage:.0f}%",
-                'middle_count': metrics['middle_count'],
-                'measured_count': metrics['measured_count'],
-                'unique_as_count': metrics['unique_as_count'],
                 # Frontier Builders should show only rare country count, not total country count
                 'country_count': metrics['rare_country_count'] if category == 'frontier_builders' else metrics['country_count'],
                 'countries': metrics['countries'][:5],  # Top 5 countries for display
-                'platform_count': metrics['platform_count'],
                 'platforms': metrics['platforms'][:3],  # Top 3 platforms for display
-                'non_linux_count': metrics['non_linux_count'],
-                'non_linux_bandwidth': formatted_non_linux_bandwidth,
-                'non_linux_bandwidth_unit': non_linux_bandwidth_unit,
-                'non_eu_count': metrics['non_eu_count'],
-                'non_eu_bandwidth': formatted_non_eu_bandwidth,
-                'non_eu_bandwidth_unit': non_eu_bandwidth_unit,
                 'non_eu_count_with_percentage': f"{metrics['non_eu_count']} ({non_eu_percentage:.0f}%)",
-                'rare_country_count': metrics['rare_country_count'],
-                'relays_in_rare_countries': metrics['relays_in_rare_countries'],
-                'rare_country_bandwidth': formatted_rare_country_bandwidth,
-                'rare_country_bandwidth_unit': rare_country_bandwidth_unit,
-                'rare_country_details': rare_country_details,
-                'rare_country_tooltip': rare_country_tooltip,
-                'frontier_achievement_title': frontier_achievement_title,
-                'platform_hero_title': platform_hero_title,
-                'platform_breakdown_details': platform_breakdown_details,
-                'platform_breakdown_tooltip': platform_breakdown_tooltip,
-                'diversity_master_title': diversity_master_title,
-                'diversity_breakdown_details': diversity_breakdown_details,
-                'diversity_breakdown_tooltip': diversity_breakdown_tooltip,
                 'diversity_score': f"{metrics['diversity_score']:.1f}",
                 'uptime_percentage': f"{metrics['uptime_percentage']:.1f}%",
                 'veteran_score': f"{metrics['veteran_score']:.0f}",
-                'veteran_days': metrics['veteran_days'],
-                'veteran_relay_scaling_factor': metrics['veteran_relay_scaling_factor'],
-                'veteran_details_short': veteran_details_short,
-                'veteran_tooltip': veteran_tooltip,
                 'first_seen_date': metrics['first_seen'].split(' ')[0] if metrics['first_seen'] else 'Unknown',
-                'geographic_achievement': geographic_achievement,  # Add dynamic achievement
-                'geographic_breakdown_details': geographic_breakdown_details,  # Add geographic breakdown
-                'geographic_breakdown_tooltip': geographic_breakdown_tooltip,  # Add geographic tooltip
-                
-                # === RELIABILITY FIELDS (REUSE existing pattern) ===
-                'reliability_score': f"{reliability_score_raw:.1f}",
-                'reliability_average': f"{reliability_average:.1f}%",
-                'reliability_weight': f"{reliability_weight:.1f}x",
-                'reliability_details_short': reliability_details_short,
-                'reliability_tooltip': reliability_tooltip,
-                
-                # === BANDWIDTH FIELDS (NEW) ===
-                'bandwidth_score': f"{bandwidth_score_raw:.1f}",
-                'bandwidth_average': f"{bandwidth_average:.1f}",
-                'bandwidth_weight': f"{bandwidth_weight:.1f}x",
-                'bandwidth_details_short': bandwidth_details_short,
-                'bandwidth_tooltip': bandwidth_tooltip,
-                
-                # === IPv4/IPv6 ADDRESS FIELDS (NEW) ===
-                'unique_ipv4_count': metrics['unique_ipv4_count'],
-                'unique_ipv6_count': metrics['unique_ipv6_count'],
-                'ipv4_relay_count': metrics['ipv4_relay_count'],
-                'ipv6_relay_count': metrics['ipv6_relay_count'],
-                'ipv4_total_bandwidth': metrics['ipv4_total_bandwidth'],
-                'ipv6_total_bandwidth': metrics['ipv6_total_bandwidth'],
-                'ipv4_total_consensus_weight_pct': f"{metrics['ipv4_total_consensus_weight'] * 100:.2f}%",
-                'ipv6_total_consensus_weight_pct': f"{metrics['ipv6_total_consensus_weight'] * 100:.2f}%",
-                'ipv4_guard_count': metrics['ipv4_guard_count'],
-                'ipv4_exit_count': metrics['ipv4_exit_count'],
-                'ipv4_middle_count': metrics['ipv4_middle_count'],
-                'ipv6_guard_count': metrics['ipv6_guard_count'],
-                'ipv6_exit_count': metrics['ipv6_exit_count'],
-                'ipv6_middle_count': metrics['ipv6_middle_count'],
-                'ipv4_achievement_title': ipv4_achievement_title,
-                'ipv6_achievement_title': ipv6_achievement_title,
-                'ip_address_details': ip_address_details,
-                'ip_address_tooltip': ip_address_tooltip,
-                
-                # === AROI VALIDATION FIELDS (NEW) ===
-                'validated_relay_count': metrics['validated_relay_count'],
-                'invalid_relay_count': metrics['invalid_relay_count'],
-                'validated_guard_count': metrics['validated_guard_count'],
-                'validated_exit_count': metrics['validated_exit_count'],
-                'validated_middle_count': metrics['validated_middle_count'],
-                'validated_bandwidth': formatted_validated_bandwidth,
-                'validated_bandwidth_unit': validated_bandwidth_unit,
-                'validated_consensus_weight': metrics['validated_consensus_weight'],
-                'validated_consensus_weight_pct': f"{metrics['validated_consensus_weight'] * 100:.2f}%",
-                'validated_country_count': metrics['validated_country_count'],
-
-                # === B4.1: v2/v3 migration metadata propagated to row dict ===
-                'validated_v2_relay_count': metrics['validated_v2_relay_count'],
-                'validated_v3_relay_count': metrics['validated_v3_relay_count'],
-                'v2_relay_count': metrics['v2_relay_count'],
-                'v3_relay_count': metrics['v3_relay_count'],
-                'v3_relay_percentage': metrics['v3_relay_percentage'],
                 'v3_relay_pct_str': f"{metrics['v3_relay_percentage']:.0f}%",
-                'v3_tier': metrics['v3_tier'],
-                
-                # === TOTAL DATA TRANSFERRED (NEW) ===
                 'total_data_transferred': formatted_total_data_transferred,
                 'total_data_pct': total_data_pct,
-            }
+            })
+            formatted_entry.update(extras)
             formatted_data.append(formatted_entry)
         
         formatted_leaderboards[category] = formatted_data

--- a/allium/lib/aroileaders.py
+++ b/allium/lib/aroileaders.py
@@ -6,10 +6,7 @@ Processes operator rankings based on Onionoo API data grouped by contact informa
 Reuses existing contact calculations and only computes new metrics not already available
 """
 
-import hashlib
-from collections import defaultdict
 import re
-import html
 
 # Import centralized IP parsing from ip_utils (canonical home)
 from .ip_utils import safe_parse_ip_address as _safe_parse_ip_address
@@ -19,7 +16,6 @@ from .aroi_validation import classify_v3_tier as _classify_v3_tier_local
 # Import centralized country utilities
 from .country_utils import (
     count_non_eu_countries, 
-    count_frontier_countries_weighted_with_existing_data,
     calculate_diversity_score, 
     calculate_geographic_achievement,
     calculate_operator_as_diversity_score,
@@ -27,7 +23,8 @@ from .country_utils import (
 )
 
 # Import HTML escaping utility
-from .string_utils import safe_html_escape, extract_contact_display_name
+from .html_escape_utils import safe_html_escape
+from .string_utils import extract_contact_display_name
 
 
 # Pre-compiled url-token regex for the Option A incomplete-AROI fallback.

--- a/allium/lib/bandwidth_utils.py
+++ b/allium/lib/bandwidth_utils.py
@@ -7,28 +7,6 @@ to enable historic bandwidth leaderboard categories similar to uptime leaderboar
 
 import statistics
 
-def calculate_network_cv_statistics(all_operators_data):
-    """Calculate network-wide CV statistics for dynamic threshold setting."""
-    if not all_operators_data or len(all_operators_data) < 10:
-        return None
-        
-    try:
-        cv_values = sorted([cv for cv in all_operators_data if cv >= 0])
-        if len(cv_values) < 10:
-            return None
-            
-        return {
-            'p25': statistics.quantiles(cv_values, n=4)[0],
-            'p50': statistics.median(cv_values),
-            'p75': statistics.quantiles(cv_values, n=4)[2],
-            'p90': statistics.quantiles(cv_values, n=10)[8],
-            'total_operators': len(cv_values),
-            'mean': statistics.mean(cv_values),
-            'std_dev': statistics.stdev(cv_values)
-        }
-    except Exception:
-        return None
-
 def calculate_total_data_from_history(history_data):
     """Calculate total bytes transferred from an Onionoo bandwidth history object.
     

--- a/allium/lib/bandwidth_utils.py
+++ b/allium/lib/bandwidth_utils.py
@@ -190,39 +190,11 @@ def _calculate_growth_trend(operator_relays, bandwidth_map, period):
     """Calculate simplified growth trend metrics."""
     if period != '6_months':
         return None
-        
-    # Build relay bandwidth arrays
-    relay_arrays = []
-    for relay in operator_relays:
-        fingerprint = relay.get('fingerprint', '')
-        relay_bandwidth = bandwidth_map.get(fingerprint)
-        if relay_bandwidth and relay_bandwidth.get('read_history'):
-            period_data = relay_bandwidth['read_history'].get(period, {})
-            if period_data.get('values') and period_data.get('factor'):
-                relay_arrays.append({
-                    'values': period_data['values'],
-                    'factor': period_data['factor']
-                })
-    
-    if not relay_arrays:
-        return None
-    
-    # Calculate daily totals
-    max_length = max(len(r['values']) for r in relay_arrays)
-    daily_totals = []
-    
-    for day_index in range(max_length):
-        day_total = valid_count = 0
-        for relay_data in relay_arrays:
-            if day_index < len(relay_data['values']):
-                value = relay_data['values'][day_index]
-                if value is not None and isinstance(value, (int, float)) and value >= 0:
-                    day_total += value * relay_data['factor']
-                    valid_count += 1
-        
-        if valid_count > 0:
-            daily_totals.append(day_total)
-    
+
+    # Shared daily-totals aggregation (bandwidth_map already built by caller)
+    daily_totals = extract_operator_daily_bandwidth_totals(
+        operator_relays, None, period, bandwidth_map)['daily_totals']
+
     if len(daily_totals) < 60:  # Need at least ~2 months
         return None
     

--- a/allium/lib/consensus/authority_monitor.py
+++ b/allium/lib/consensus/authority_monitor.py
@@ -5,12 +5,10 @@ Monitor directory authority health and status.
 Provides latency checks and voting participation metrics.
 """
 
-import urllib.request
-import urllib.error
 import socket
 import time
 import concurrent.futures
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional
 from datetime import datetime, timezone
 import logging
 

--- a/allium/lib/consensus/collector_fetcher.py
+++ b/allium/lib/consensus/collector_fetcher.py
@@ -15,7 +15,7 @@ import urllib.request
 import urllib.error
 import socket
 import concurrent.futures
-from typing import Dict, List, Optional, Tuple, Any, Callable
+from typing import Dict, List, Optional
 from datetime import datetime, timezone
 import logging
 import time
@@ -24,7 +24,6 @@ import time
 from ..workers import (
     _fetch_url_with_total_timeout,
     _retry_with_backoff,
-    _is_retryable_error,
     TotalTimeoutError,
 )
 
@@ -216,16 +215,7 @@ from .flag_thresholds import (
     SECONDS_PER_DAY,
     GUARD_BW_GUARANTEE as AUTH_DIR_GUARD_BW_GUARANTEE,  # Backward compat alias
     GUARD_TK_DEFAULT,
-    GUARD_WFU_DEFAULT,
     HSDIR_TK_DEFAULT,
-    HSDIR_WFU_DEFAULT,
-    FAST_BW_GUARANTEE,
-    parse_wfu_threshold,
-    format_time_as_days,
-    check_guard_eligibility,
-    check_hsdir_eligibility,
-    check_fast_eligibility,
-    check_stable_eligibility,
 )
 
 COLLECTOR_BASE = 'https://collector.torproject.org'
@@ -1096,7 +1086,6 @@ class CollectorFetcher:
             })
             
             # Stable flag eligibility
-            stable_uptime = thresholds.get('stable-uptime', 0)
             stable_mtbf = thresholds.get('stable-mtbf', 0)
             relay_mtbf = vote_info.get('mtbf', 0)
             

--- a/allium/lib/consensus/consensus_evaluation.py
+++ b/allium/lib/consensus/consensus_evaluation.py
@@ -594,20 +594,17 @@ def _format_relay_values(consensus_data: dict, flag_thresholds: dict = None, obs
     
     # Set relay values from stats
     relay_tk = tk_stats['primary_value']
-    relay_mtbf = mtbf_stats['primary_value']
     
     # Calculate HSDir TK statistics for display
     # dir-spec default: 25 hours (HSDIR_TK_DEFAULT)
     # Consensus needs majority (5/9), so if 8 authorities use 25h and 1 uses 10d,
     # relay only needs 25h to get HSDir from majority
-    hsdir_tk_min = HSDIR_TK_DEFAULT  # dir-spec default (25 hours)
     hsdir_tk_max = hsdir_tk_threshold  # strictest (currently moria1's ~10 days)
     hsdir_tk_consensus = HSDIR_TK_DEFAULT  # what majority requires (dir-spec default)
     hsdir_tk_strict_auths = [name for name, val in hsdir_tk_values if val > HSDIR_TK_DEFAULT * 2]  # significantly stricter
     
     # Count per-authority HSDir metric evaluations for Summary table
     # (avoids conflating overall HSDir flag assignment count with per-metric counts)
-    hsdir_wfu_meets_count = sum(1 for v in all_wfu_values if v is not None and v >= hsdir_wfu_threshold)
     hsdir_tk_meets_count = 0
     for vote in authority_votes:
         if vote.get('voted'):
@@ -620,7 +617,6 @@ def _format_relay_values(consensus_data: dict, flag_thresholds: dict = None, obs
     
     # Calculate Fast speed statistics
     # Most authorities use ~102 KB/s, moria1 uses ~1 MB/s
-    fast_speed_min = min(fast_speed_values) if fast_speed_values else FAST_BW_GUARANTEE
     fast_speed_max = max(fast_speed_values) if fast_speed_values else FAST_BW_GUARANTEE
     fast_speed_typical = sorted(fast_speed_values)[len(fast_speed_values)//2] if fast_speed_values else FAST_BW_GUARANTEE
     fast_speed_strict_auths = [name for name, val in fast_speed_by_auth.items() if val > fast_speed_typical * 2]
@@ -658,15 +654,12 @@ def _format_relay_values(consensus_data: dict, flag_thresholds: dict = None, obs
     guard_bw_meets_top25_count = sum(1 for bw in guard_bw_values if guard_bw_value >= bw) if guard_bw_values else 0
     # Relay meets Guard BW if it meets the guarantee OR is in top 25% for any authority
     guard_bw_meets = guard_bw_meets_guarantee or guard_bw_meets_top25_count > 0
-    guard_bw_meets_all = guard_bw_meets_guarantee or (guard_bw_meets_top25_count == len(guard_bw_values) if guard_bw_values else False)
     guard_bw_meets_some = guard_bw_meets
     guard_bw_meets_count = total_authorities if guard_bw_meets_guarantee else guard_bw_meets_top25_count
     
     # Calculate Stable analysis
     stable_meets_count = flag_eligibility.get('stable', {}).get('eligible_count', 0)
     stable_meets_all = stable_meets_count == total_authorities
-    stable_range = _format_range(stable_uptime_values, _format_days) if stable_uptime_values else 'N/A'
-    stable_mtbf_range = _format_range(stable_mtbf_values, _format_days) if stable_mtbf_values else 'N/A'
     
     # Extract Guard prerequisite flag counts from flag_eligibility
     # Per Tor dir-spec Section 3.4.2: Guard requires Fast, Stable, and V2Dir flags
@@ -684,12 +677,10 @@ def _format_relay_values(consensus_data: dict, flag_thresholds: dict = None, obs
     hsdir_prereq_v2dir_count = sum(1 for d in guard_details if d.get('has_v2dir', False))
     
     # Calculate Fast analysis using observed_bandwidth
-    fast_range = _format_range(fast_speed_values, bw_formatter) if fast_speed_values else 'N/A'
     
     # Check if observed_bandwidth meets Fast eligibility
     fast_meets_minimum = guard_bw_value >= FAST_BW_MINIMUM
     fast_meets_threshold_count = sum(1 for fs in fast_speed_values if guard_bw_value >= fs) if fast_speed_values else 0
-    fast_meets = fast_meets_minimum or fast_meets_threshold_count > 0
     fast_meets_all = fast_meets_minimum or (fast_meets_threshold_count == len(fast_speed_values) if fast_speed_values else False)
     fast_meets_count = total_authorities if fast_meets_minimum else fast_meets_threshold_count
     

--- a/allium/lib/coordinator.py
+++ b/allium/lib/coordinator.py
@@ -76,7 +76,6 @@ class Coordinator:
             self.progress_logger = ProgressLogger(self.start_time, self.progress_step, self.total_steps, self.progress)
         
         # Worker management
-        self.workers = {}
         self.worker_data = {}
         self.worker_threads = []
         
@@ -359,12 +358,6 @@ class Coordinator:
         Get consensus health data if available.
         """
         return self.worker_data.get('consensus_health')
-
-    def get_collector_data(self):
-        """
-        Get collector data if available (legacy)
-        """
-        return self.worker_data.get('collector')
 
     def get_collector_consensus_data(self):
         """

--- a/allium/lib/coordinator.py
+++ b/allium/lib/coordinator.py
@@ -12,11 +12,10 @@ from .workers import (
     fetch_onionoo_details, fetch_onionoo_uptime, fetch_onionoo_bandwidth,
     fetch_aroi_validation, fetch_exit_dns_health, fetch_collector_consensus_data,
     fetch_collector_descriptors,
-    get_worker_status, get_all_worker_status
+    get_all_worker_status
 )
 from .relays import Relays
 from .progress_logger import ProgressLogger
-from .error_handlers import handle_worker_errors, handle_calculation_errors
 from .first_seen_correction import correct_first_seen
 
 

--- a/allium/lib/country_utils.py
+++ b/allium/lib/country_utils.py
@@ -167,10 +167,6 @@ def is_eu_political(country_code):
     """Check if country is in EU political union."""
     return country_code.upper() in EU_POLITICAL_REGION
 
-def is_eu_geographic(country_code):
-    """Check if country is in geographic Europe region."""
-    return country_code.upper() in EU_GEOGRAPHIC_REGION
-
 def is_frontier_country(country_code):
     """Check if country is classified as frontier/rare."""
     return country_code.upper() in FRONTIER_COUNTRIES
@@ -463,73 +459,6 @@ def calculate_regional_factor(country_code):
 
 
 
-def assign_rarity_tier(rarity_score):
-    """
-    Assign tier classification based on weighted rarity score.
-    
-    Args:
-        rarity_score (int): Calculated rarity score
-        
-    Returns:
-        str: Tier classification
-    """
-    if rarity_score >= 15:   return 'legendary'    # 🏆
-    elif rarity_score >= 10: return 'epic'         # ⭐
-    elif rarity_score >= 6:  return 'rare'         # 🎖️
-    elif rarity_score >= 3:  return 'emerging'     # 📍
-    else:                    return 'common'       # Standard
-
-
-
-
-def count_frontier_countries_weighted_with_existing_data(countries, country_data, total_relays, min_score=6):
-    """
-    Ultra-optimized version that uses pre-calculated country data from relays.py.
-    
-    This is the most efficient implementation as it leverages existing work from relays.py
-    categorization instead of re-scanning the entire relay dataset.
-    
-    Args:
-        countries (list): List of country codes to evaluate
-        country_data (dict): Pre-calculated country data from relays.json["sorted"]["country"]
-        total_relays (int): Total number of relays in the network
-        min_score (int): Minimum score to be considered rare
-        
-    Returns:
-        int: Number of rare countries in the list
-    """
-    if not country_data or total_relays == 0:
-        return 0  # No country data available, return 0 rare countries
-    
-    rare_count = 0
-    for country in countries:
-        if country:
-            country_upper = country.upper()
-            
-            # Get relay count from existing country data (zero-cost lookup)
-            country_relays = 0
-            if country_upper in country_data:
-                country_relays = len(country_data[country_upper].get('relays', []))
-            
-            # Calculate factors efficiently without any relay scanning
-            relay_count_factor = calculate_relay_count_factor(country_relays)
-            network_percentage_factor = calculate_network_percentage_factor(country_relays, total_relays)
-            geopolitical_factor = calculate_geopolitical_factor(country)
-            regional_factor = calculate_regional_factor(country)
-            
-            # Apply weighted formula
-            rarity_score = (
-                (relay_count_factor * 4) +
-                (network_percentage_factor * 3) +
-                (geopolitical_factor * 2) +
-                (regional_factor * 1)
-            )
-            
-            if rarity_score >= min_score:
-                rare_count += 1
-    
-    return rare_count
-
 def get_rare_countries_weighted_with_existing_data(country_data, total_relays, min_score=6):
     """
     Ultra-optimized version that uses pre-calculated country data from relays.py.
@@ -594,7 +523,3 @@ def get_rare_countries_weighted_with_existing_data(country_data, total_relays, m
     return rare_countries
 
 # === REQUIRED FOR INTELLIGENCE ENGINE ===
-
-def get_geographic_regions_for_analysis():
-    """Return geographic regional mapping for intelligence analysis HHI calculations"""
-    return CORE_REGIONS.copy()

--- a/allium/lib/error_handlers.py
+++ b/allium/lib/error_handlers.py
@@ -159,39 +159,3 @@ def handle_calculation_errors(operation: str = "calculation", default_return: An
         return wrapper
     return decorator
 
-
-def safe_file_operation(operation_func: Callable, default_return: Any = None, 
-                       error_prefix: str = "File operation"):
-    """
-    Utility function for safe file operations without decorators.
-    
-    Args:
-        operation_func: Function to execute safely
-        default_return: Value to return on error
-        error_prefix: Prefix for error messages
-    """
-    try:
-        return operation_func()
-    except Exception as e:
-        print(f"Warning: {error_prefix} failed: {e}")
-        return default_return
-
-
-def safe_json_operation(operation_func: Callable, default_return: Any = None,
-                       error_prefix: str = "JSON operation"):
-    """
-    Utility function for safe JSON operations without decorators.
-    
-    Args:
-        operation_func: Function to execute safely
-        default_return: Value to return on error
-        error_prefix: Prefix for error messages
-    """
-    try:
-        return operation_func()
-    except (json.JSONDecodeError, ValueError) as e:
-        print(f"Warning: {error_prefix} failed: {e}")
-        return default_return
-    except Exception as e:
-        print(f"Warning: Unexpected error during {error_prefix}: {e}")
-        return default_return

--- a/allium/lib/error_handlers.py
+++ b/allium/lib/error_handlers.py
@@ -7,7 +7,6 @@ across workers.py, coordinator.py, and relays.py files.
 
 import functools
 import json
-import traceback
 import urllib.error
 from typing import Any, Callable
 
@@ -134,42 +133,6 @@ def handle_json_errors(operation: str = "parse JSON", default_return: Any = None
             except Exception as e:
                 print(f"Warning: Unexpected error during {operation}: {e}")
                 return default_return
-        return wrapper
-    return decorator
-
-
-def handle_worker_errors(api_name: str, enable_ci_debug: bool = True):
-    """
-    Decorator for handling worker execution errors in coordinator.
-    
-    Args:
-        api_name: Name of the API worker
-        enable_ci_debug: Whether to enable CI debugging output
-    """
-    def decorator(func: Callable) -> Callable:
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            try:
-                return func(*args, **kwargs)
-            except Exception as e:
-                # Extract coordinator instance if available
-                coordinator = None
-                if args and hasattr(args[0], '_log_progress_with_step_increment'):
-                    coordinator = args[0]
-                
-                if coordinator:
-                    api_display_name = coordinator._get_api_display_name(api_name)
-                    coordinator._log_progress_with_step_increment(f"{api_display_name} - error: {str(e)}")
-                    coordinator.worker_data[api_name] = None
-                
-                # CI debugging
-                if enable_ci_debug:
-                    import os
-                    if os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS'):
-                        print(f"🔧 CI Debug: {api_name} worker failed with: {e}")
-                        traceback.print_exc()
-                
-                return None
         return wrapper
     return decorator
 

--- a/allium/lib/error_handlers.py
+++ b/allium/lib/error_handlers.py
@@ -7,10 +7,9 @@ across workers.py, coordinator.py, and relays.py files.
 
 import functools
 import json
-import os
 import traceback
 import urllib.error
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 
 
 def handle_http_errors(api_name: str, cache_loader: Callable, cache_saver: Callable, 

--- a/allium/lib/file_io_utils.py
+++ b/allium/lib/file_io_utils.py
@@ -11,11 +11,9 @@ This module provides:
 """
 
 import json
-import os
-import tempfile
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 from .error_handlers import handle_file_io_errors, handle_json_errors
 
 
@@ -279,152 +277,6 @@ class StateManager(FileIOManager):
         return self.save_state(current_state)
 
 
-class TestFileHelper:
-    """Helper utilities for creating test files and directories."""
-    
-    @staticmethod
-    def create_temp_directory() -> tempfile.TemporaryDirectory:
-        """Create temporary directory for testing."""
-        return tempfile.TemporaryDirectory()
-    
-    @staticmethod
-    def create_test_json_file(directory: str, filename: str, data: Dict[str, Any]) -> str:
-        """
-        Create a test JSON file with specified data.
-        
-        Args:
-            directory: Directory to create file in
-            filename: Name of file to create
-            data: JSON data to write
-            
-        Returns:
-            str: Full path to created file
-        """
-        file_path = os.path.join(directory, filename)
-        with open(file_path, 'w') as f:
-            json.dump(data, f, indent=2)
-        return file_path
-    
-    @staticmethod
-    def create_corrupted_json_file(directory: str, filename: str, 
-                                  content: str = '{"invalid": json}') -> str:
-        """
-        Create a corrupted JSON file for error testing.
-        
-        Args:
-            directory: Directory to create file in
-            filename: Name of file to create
-            content: Invalid JSON content
-            
-        Returns:
-            str: Full path to created file
-        """
-        file_path = os.path.join(directory, filename)
-        with open(file_path, 'w') as f:
-            f.write(content)
-        return file_path
-    
-    @staticmethod
-    def create_test_cache_structure(base_dir: str) -> Dict[str, str]:
-        """
-        Create standard test cache directory structure.
-        
-        Args:
-            base_dir: Base directory for cache structure
-            
-        Returns:
-            dict: Dictionary of created directory paths
-        """
-        cache_dir = os.path.join(base_dir, "cache")
-        data_dir = base_dir
-        
-        os.makedirs(cache_dir, exist_ok=True)
-        os.makedirs(data_dir, exist_ok=True)
-        
-        return {
-            'cache_dir': cache_dir,
-            'data_dir': data_dir,
-            'state_file': os.path.join(data_dir, 'state.json')
-        }
-
-
-class BulkFileOperations:
-    """Bulk file operations for common patterns."""
-    
-    def __init__(self, base_directory: str):
-        """Initialize with base directory."""
-        self.base_directory = Path(base_directory)
-        self.file_manager = FileIOManager(base_directory)
-    
-    def copy_files_with_pattern(self, pattern: str, destination: str) -> List[str]:
-        """
-        Copy files matching pattern to destination.
-        
-        Args:
-            pattern: File pattern to match (glob-style)
-            destination: Destination directory
-            
-        Returns:
-            List[str]: List of copied file paths
-        """
-        import shutil
-        
-        copied_files = []
-        dest_path = Path(destination)
-        dest_path.mkdir(parents=True, exist_ok=True)
-        
-        for file_path in self.base_directory.glob(pattern):
-            if file_path.is_file():
-                dest_file = dest_path / file_path.name
-                shutil.copy2(file_path, dest_file)
-                copied_files.append(str(dest_file))
-        
-        return copied_files
-    
-    def delete_files_with_pattern(self, pattern: str) -> List[str]:
-        """
-        Delete files matching pattern.
-        
-        Args:
-            pattern: File pattern to match (glob-style)
-            
-        Returns:
-            List[str]: List of deleted file paths
-        """
-        deleted_files = []
-        
-        for file_path in self.base_directory.glob(pattern):
-            if file_path.is_file():
-                try:
-                    file_path.unlink()
-                    deleted_files.append(str(file_path))
-                except OSError:
-                    continue
-        
-        return deleted_files
-    
-    def get_files_by_age(self, max_age_seconds: float) -> List[str]:
-        """
-        Get files older than specified age.
-        
-        Args:
-            max_age_seconds: Maximum age in seconds
-            
-        Returns:
-            List[str]: List of old file paths
-        """
-        current_time = time.time()
-        old_files = []
-        
-        for file_path in self.base_directory.rglob("*"):
-            if file_path.is_file():
-                file_age = current_time - file_path.stat().st_mtime
-                if file_age > max_age_seconds:
-                    old_files.append(str(file_path))
-        
-        return old_files
-
-
 # Convenience functions for backward compatibility
 def create_cache_manager(cache_directory: str) -> CacheManager:
     """Create a new cache manager instance."""
@@ -441,35 +293,4 @@ def create_state_manager(state_file_path: str) -> StateManager:
     return StateManager(state_file_path)
 
 
-def create_test_helper() -> TestFileHelper:
-    """Create a new test file helper instance."""
-    return TestFileHelper()
-
-
 # Factory function for unified file I/O operations
-def create_unified_file_manager(base_directory: str, 
-                               cache_subdir: str = "cache",
-                               state_filename: str = "state.json") -> Dict[str, Any]:
-    """
-    Create unified file managers for common use cases.
-    
-    Args:
-        base_directory: Base directory for all operations
-        cache_subdir: Subdirectory for cache files
-        state_filename: Name of state file
-        
-    Returns:
-        dict: Dictionary containing all manager instances
-    """
-    base_path = Path(base_directory)
-    cache_path = base_path / cache_subdir
-    state_path = base_path / state_filename
-    
-    return {
-        'file_manager': FileIOManager(str(base_path)),
-        'cache_manager': CacheManager(str(cache_path)),
-        'timestamp_manager': TimestampManager(str(cache_path)),
-        'state_manager': StateManager(str(state_path)),
-        'bulk_operations': BulkFileOperations(str(base_path)),
-        'test_helper': TestFileHelper()
-    }

--- a/allium/lib/first_seen_correction.py
+++ b/allium/lib/first_seen_correction.py
@@ -97,7 +97,6 @@ PEP 484 comment-style annotations for the public API.
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional
 
 from .time_utils import parse_onionoo_timestamp
 

--- a/allium/lib/flag_analysis.py
+++ b/allium/lib/flag_analysis.py
@@ -262,7 +262,6 @@ def process_flag_uptime_display(relays, network_flag_statistics):
             
             if period in flag_data[selected_flag]:
                 uptime_val = flag_data[selected_flag][period]['uptime']
-                data_points = flag_data[selected_flag][period].get('data_points', 0)
                 
                 # Compare flag uptime with regular uptime before adding prefix
                 regular_uptime_val = regular_uptime.get(period, 0.0)
@@ -276,9 +275,6 @@ def process_flag_uptime_display(relays, network_flag_statistics):
                 
                 # Format without prefix
                 percentage_str = f"{uptime_val:.1f}%"
-                
-                # Apply FLAG RELIABILITY color coding (not uptime color coding)
-                color_class = ''
                 
                 # Add network comparison for color determination
                 if (selected_flag in network_flag_statistics and 

--- a/allium/lib/flag_analysis.py
+++ b/allium/lib/flag_analysis.py
@@ -116,236 +116,193 @@ def apply_statistical_coloring(relays, network_statistics):
         # Join with forward slashes
         relay["uptime_api_display"] = "/".join(display_parts)
 
-def process_flag_bandwidth_display(relays, network_flag_statistics, bandwidth_formatter):
+def _process_flag_metric_display(relays, metric, no_priority_msg, periods,
+                                 build_period_parts, all_dash_display=None):
     """
-    Process flag bandwidth data into display format with tooltips.
-    
-    Calculates flag-specific bandwidth display strings using priority system:
-    Exit > Guard > Fast > Running flags. Only shows flags the relay actually has.
-    
-    Args:
-        network_flag_statistics (dict): Network-wide flag statistics for comparison
+    Shared skeleton for flag uptime/bandwidth display processing: priority
+    flag selection (Exit > Guard > Fast > Running, only flags the relay
+    actually has), N/A fallbacks, per-period part collection, and result
+    storage. All metric-specific formatting lives in build_period_parts,
+    which maps (relay, selected_flag, flag_periods, period, period_short) to
+    a (display_part, tooltip_part) pair — keeping each variant's output
+    byte-identical. When all_dash_display is set and every period produced a
+    dash, it is stored instead (the uptime variant's "Match" case).
     """
+    data_key = f"_flag_{metric}_data"
+    display_key = f"flag_{metric}_display"
+    tooltip_key = f"flag_{metric}_tooltip"
+
     for relay in relays:
-        # Get actual flags this relay has
         relay_flags = set(relay.get('flags', []))
-        flag_data = relay.get("_flag_bandwidth_data", {})
-        
+        flag_data = relay.get(data_key, {})
+
         if not flag_data or not relay_flags:
-            relay["flag_bandwidth_display"] = "N/A"
-            relay["flag_bandwidth_tooltip"] = "No flag bandwidth data available"
+            relay[display_key] = "N/A"
+            relay[tooltip_key] = f"No flag {metric} data available"
             continue
-        
+
         # Determine priority flag from flags the relay ACTUALLY HAS
         selected_flag = None
         best_priority = float('inf')
-        
         for flag in flag_data.keys():
-            # Only consider flags the relay actually has
             if flag in FLAG_PRIORITY and flag in relay_flags and FLAG_PRIORITY[flag] < best_priority:
                 selected_flag = flag
                 best_priority = FLAG_PRIORITY[flag]
-        
+
         if not selected_flag or selected_flag not in flag_data:
-            relay["flag_bandwidth_display"] = "N/A"
-            relay["flag_bandwidth_tooltip"] = "No prioritized flag bandwidth data available"
+            relay[display_key] = "N/A"
+            relay[tooltip_key] = no_priority_msg
             continue
-        
-        # Build display string with formatting
+
         display_parts = []
         tooltip_parts = []
         flag_display = FLAG_DISPLAY_NAMES[selected_flag]
-        
-        for period in ['6_months', '1_year', '5_years']:
-            # Map to short period names for tooltip
-            period_short = PERIOD_SHORT_NAMES[period]
-            
-            if period in flag_data[selected_flag] and flag_data[selected_flag][period] > 0:
-                bandwidth_val = flag_data[selected_flag][period]
-                data_points = 0  # Not tracked in simplified structure
-                
-                # Format bandwidth value
-                unit = bandwidth_formatter.determine_unit(bandwidth_val)
-                formatted_bw = bandwidth_formatter.format_bandwidth_with_unit(bandwidth_val, unit)
-                bandwidth_str = f"{formatted_bw} {unit}"
-                
-                # Apply FLAG BANDWIDTH color coding
-                color_class = ''
-                if (selected_flag in network_flag_statistics and 
-                    period in network_flag_statistics[selected_flag] and
-                    network_flag_statistics[selected_flag][period]):
-                    
-                    net_stats = network_flag_statistics[selected_flag][period]
-                    
-                    # Color coding based on statistical position
-                    if bandwidth_val <= net_stats['two_sigma_low']:
-                        color_class = 'statistical-outlier-low'
-                    elif bandwidth_val > net_stats['two_sigma_high']:
-                        color_class = 'statistical-outlier-high'
-                    elif bandwidth_val < net_stats['mean']:
-                        color_class = 'below-mean'
-                    # High performance threshold (top 10% or above 2x mean)
-                    elif bandwidth_val > net_stats['mean'] * 2:
-                        color_class = 'high-performance'
-                
-                # Apply color styling based on class
-                if color_class == 'high-performance':
-                    styled_bandwidth = f'<span class="al-status-success-bold">{bandwidth_str}</span>'
-                elif color_class == 'statistical-outlier-low':
-                    styled_bandwidth = f'<span class="al-status-danger-bold">{bandwidth_str}</span>'
-                elif color_class == 'statistical-outlier-high':
-                    styled_bandwidth = f'<span class="al-status-success-bold">{bandwidth_str}</span>'
-                elif color_class == 'below-mean':
-                    styled_bandwidth = f'<span class="al-status-warning-bold">{bandwidth_str}</span>'
-                else:
-                    styled_bandwidth = bandwidth_str
-                
-                display_parts.append(styled_bandwidth)
-                tooltip_parts.append(f"{period_short}: {bandwidth_str} ({data_points} data points)")
-            else:
-                # No data for this period
-                display_parts.append("—")
-                tooltip_parts.append(f"{period_short}: No flag bandwidth data")
-        
-        # Store results
-        relay["flag_bandwidth_display"] = "/".join(display_parts)
-        # Generate tooltip in same format as flag reliability
-        relay["flag_bandwidth_tooltip"] = f"{flag_display} flag bandwidth over time periods: " + ", ".join(tooltip_parts)
+        for period in periods:
+            display_part, tooltip_part = build_period_parts(
+                relay, selected_flag, flag_data[selected_flag], period, PERIOD_SHORT_NAMES[period]
+            )
+            display_parts.append(display_part)
+            tooltip_parts.append(tooltip_part)
+
+        # If all periods show dashes (no differences), show the match display instead
+        if all_dash_display and all(part == "—" for part in display_parts):
+            relay[display_key] = all_dash_display
+            relay[tooltip_key] = f"{flag_display} flag {metric} matches overall uptime across all periods"
+        else:
+            relay[display_key] = "/".join(display_parts)
+            relay[tooltip_key] = f"{flag_display} flag {metric} over time periods: " + ", ".join(tooltip_parts)
+
+# Maps flag bandwidth color classes to the bold al-status-* span classes
+# (flag uptime uses the non-bold variants inline below — do not unify)
+_FLAG_BANDWIDTH_SPAN_CLASSES = {
+    'high-performance': 'al-status-success-bold',
+    'statistical-outlier-low': 'al-status-danger-bold',
+    'statistical-outlier-high': 'al-status-success-bold',
+    'below-mean': 'al-status-warning-bold',
+}
+
+def process_flag_bandwidth_display(relays, network_flag_statistics, bandwidth_formatter):
+    """
+    Process flag bandwidth data into display format with tooltips.
+
+    Calculates flag-specific bandwidth display strings using priority system:
+    Exit > Guard > Fast > Running flags. Only shows flags the relay actually has.
+
+    Args:
+        network_flag_statistics (dict): Network-wide flag statistics for comparison
+    """
+    def build_period_parts(relay, selected_flag, flag_periods, period, period_short):
+        if not (period in flag_periods and flag_periods[period] > 0):
+            return "—", f"{period_short}: No flag bandwidth data"
+
+        bandwidth_val = flag_periods[period]
+        data_points = 0  # Not tracked in simplified structure
+        unit = bandwidth_formatter.determine_unit(bandwidth_val)
+        formatted_bw = bandwidth_formatter.format_bandwidth_with_unit(bandwidth_val, unit)
+        bandwidth_str = f"{formatted_bw} {unit}"
+
+        # Apply FLAG BANDWIDTH color coding based on statistical position
+        color_class = ''
+        if (selected_flag in network_flag_statistics and
+            period in network_flag_statistics[selected_flag] and
+            network_flag_statistics[selected_flag][period]):
+
+            net_stats = network_flag_statistics[selected_flag][period]
+            if bandwidth_val <= net_stats['two_sigma_low']:
+                color_class = 'statistical-outlier-low'
+            elif bandwidth_val > net_stats['two_sigma_high']:
+                color_class = 'statistical-outlier-high'
+            elif bandwidth_val < net_stats['mean']:
+                color_class = 'below-mean'
+            # High performance threshold (top 10% or above 2x mean)
+            elif bandwidth_val > net_stats['mean'] * 2:
+                color_class = 'high-performance'
+
+        span_class = _FLAG_BANDWIDTH_SPAN_CLASSES.get(color_class)
+        styled_bandwidth = f'<span class="{span_class}">{bandwidth_str}</span>' if span_class else bandwidth_str
+        return styled_bandwidth, f"{period_short}: {bandwidth_str} ({data_points} data points)"
+
+    _process_flag_metric_display(
+        relays, 'bandwidth', "No prioritized flag bandwidth data available",
+        ['6_months', '1_year', '5_years'], build_period_parts
+    )
 
 def process_flag_uptime_display(relays, network_flag_statistics):
     """
     Process flag uptime data into display format with tooltips.
-    
+
     Calculates flag-specific uptime display strings using priority system:
     Exit > Guard > Fast > Running flags. Only shows flags the relay actually has.
     Only displays flag uptime values when they differ from regular uptime.
-    
+
     Args:
         network_flag_statistics (dict): Network-wide flag statistics for comparison
     """
-    for relay in relays:
-        # Get actual flags this relay has
-        relay_flags = set(relay.get('flags', []))
-        flag_data = relay.get("_flag_uptime_data", {})
-        
-        if not flag_data or not relay_flags:
-            relay["flag_uptime_display"] = "N/A"
-            relay["flag_uptime_tooltip"] = "No flag uptime data available"
-            continue
-        
-        # Determine priority flag from flags the relay ACTUALLY HAS
-        selected_flag = None
-        best_priority = float('inf')
-        
-        for flag in flag_data.keys():
-            # Only consider flags the relay actually has
-            if flag in FLAG_PRIORITY and flag in relay_flags and FLAG_PRIORITY[flag] < best_priority:
-                selected_flag = flag
-                best_priority = FLAG_PRIORITY[flag]
-        
-        if not selected_flag or selected_flag not in flag_data:
-            relay["flag_uptime_display"] = "N/A"
-            relay["flag_uptime_tooltip"] = "No prioritized flag data available"
-            continue
-        
-        # Build display string with color coding and prefix
-        display_parts = []
-        tooltip_parts = []
-        flag_display = FLAG_DISPLAY_NAMES[selected_flag]
-        
-        # Get regular uptime percentages for comparison
-        regular_uptime = relay.get("uptime_percentages", {})
-        
-        for period in ['1_month', '6_months', '1_year', '5_years']:
-            # Map to short period names for tooltip
-            period_short = PERIOD_SHORT_NAMES[period]
-            
-            if period in flag_data[selected_flag]:
-                uptime_val = flag_data[selected_flag][period]['uptime']
-                
-                # Compare flag uptime with regular uptime before adding prefix
-                regular_uptime_val = regular_uptime.get(period, 0.0)
-                
-                # Only show flag uptime if it differs from regular uptime (allowing for small floating point differences)
-                if abs(uptime_val - regular_uptime_val) < 0.1:
-                    # Values are essentially the same, skip showing flag uptime for this period
-                    display_parts.append("—")  # Show dash to indicate "same as uptime"
-                    tooltip_parts.append(f"{period_short}: Same as uptime ({uptime_val:.1f}%)")
-                    continue
-                
-                # Format without prefix
-                percentage_str = f"{uptime_val:.1f}%"
-                
-                # Add network comparison for color determination
-                if (selected_flag in network_flag_statistics and 
-                    period in network_flag_statistics[selected_flag] and
-                    network_flag_statistics[selected_flag][period]):
-                    
-                    net_stats = network_flag_statistics[selected_flag][period]
-                    net_mean = net_stats.get('mean', 0)
-                    two_sigma_low = net_stats.get('two_sigma_low', 0)
-                    two_sigma_high = net_stats.get('two_sigma_high', float('inf'))
-                    
-                    # Enhanced color coding logic matching flag reliability:
-                    # Special handling for very low values (≤1%) - likely to be statistical outliers
-                    if uptime_val <= 1.0:
-                        colored_str = f'<span class="al-status-danger">{percentage_str}</span>'  # Red
-                    elif uptime_val <= two_sigma_low:
-                        colored_str = f'<span class="al-status-danger">{percentage_str}</span>'  # Red
-                    elif uptime_val >= 99.0:
-                        colored_str = f'<span class="al-status-success">{percentage_str}</span>'  # Green
-                    elif uptime_val > two_sigma_high:
-                        colored_str = f'<span class="al-status-success">{percentage_str}</span>'  # Green
-                    elif uptime_val < net_mean:
-                        colored_str = f'<span class="al-status-warning">{percentage_str}</span>'  # Yellow
-                    else:
-                        # Above mean but within normal range - no special coloring
-                        colored_str = percentage_str
-                else:
-                    # Fallback color coding when no network statistics available
-                    if uptime_val <= 1.0:
-                        colored_str = f'<span class="al-status-danger">{percentage_str}</span>'  # Red
-                    elif uptime_val >= 99.0:
-                        colored_str = f'<span class="al-status-success">{percentage_str}</span>'  # Green
-                    else:
-                        # Default: no special coloring
-                        colored_str = percentage_str
-                
-                display_parts.append(colored_str)
-                
-                # Add network comparison for tooltip (if available)
-                network_comparison = ""
-                if (selected_flag in network_flag_statistics and 
-                    period in network_flag_statistics[selected_flag] and
-                    network_flag_statistics[selected_flag][period]):
-                    
-                    net_stats = network_flag_statistics[selected_flag][period]
-                    net_mean = net_stats.get('mean', 0)
-                    if net_mean > 0:
-                        if uptime_val >= net_stats.get('two_sigma_high', float('inf')):
-                            network_comparison = f" (exceptional vs network μ {net_mean:.1f}%)"
-                        elif uptime_val <= net_stats.get('two_sigma_low', 0):
-                            network_comparison = f" (low vs network μ {net_mean:.1f}%)"
-                        elif uptime_val < net_mean:
-                            network_comparison = f" (below network μ {net_mean:.1f}%)"
-                        else:
-                            network_comparison = f" (above network μ {net_mean:.1f}%)"
-                
-                tooltip_parts.append(f"{period_short}: {uptime_val:.1f}%{network_comparison}")
+    def build_period_parts(relay, selected_flag, flag_periods, period, period_short):
+        if period not in flag_periods:
+            return "—", f"{period_short}: No flag data"
+
+        uptime_val = flag_periods[period]['uptime']
+
+        # Only show flag uptime if it differs from regular uptime (allowing for
+        # small floating point differences); a dash indicates "same as uptime"
+        regular_uptime_val = relay.get("uptime_percentages", {}).get(period, 0.0)
+        if abs(uptime_val - regular_uptime_val) < 0.1:
+            return "—", f"{period_short}: Same as uptime ({uptime_val:.1f}%)"
+
+        percentage_str = f"{uptime_val:.1f}%"
+        network_comparison = ""
+
+        if (selected_flag in network_flag_statistics and
+            period in network_flag_statistics[selected_flag] and
+            network_flag_statistics[selected_flag][period]):
+
+            net_stats = network_flag_statistics[selected_flag][period]
+            net_mean = net_stats.get('mean', 0)
+            two_sigma_low = net_stats.get('two_sigma_low', 0)
+            two_sigma_high = net_stats.get('two_sigma_high', float('inf'))
+
+            # FLAG RELIABILITY color coding; very low values (≤1%) are likely
+            # statistical outliers, values above mean within normal range stay plain
+            if uptime_val <= 1.0:
+                colored_str = f'<span class="al-status-danger">{percentage_str}</span>'  # Red
+            elif uptime_val <= two_sigma_low:
+                colored_str = f'<span class="al-status-danger">{percentage_str}</span>'  # Red
+            elif uptime_val >= 99.0:
+                colored_str = f'<span class="al-status-success">{percentage_str}</span>'  # Green
+            elif uptime_val > two_sigma_high:
+                colored_str = f'<span class="al-status-success">{percentage_str}</span>'  # Green
+            elif uptime_val < net_mean:
+                colored_str = f'<span class="al-status-warning">{percentage_str}</span>'  # Yellow
             else:
-                # No data for this period
-                display_parts.append("—")
-                tooltip_parts.append(f"{period_short}: No flag data")
-        
-        # Store results
-        # If all periods show dashes (no differences), show "N/A" instead
-        if all(part == "—" for part in display_parts):
-            relay["flag_uptime_display"] = "Match"
-            relay["flag_uptime_tooltip"] = f"{flag_display} flag uptime matches overall uptime across all periods"
+                colored_str = percentage_str
+
+            # Add network comparison for tooltip (if available)
+            if net_mean > 0:
+                if uptime_val >= two_sigma_high:
+                    network_comparison = f" (exceptional vs network μ {net_mean:.1f}%)"
+                elif uptime_val <= two_sigma_low:
+                    network_comparison = f" (low vs network μ {net_mean:.1f}%)"
+                elif uptime_val < net_mean:
+                    network_comparison = f" (below network μ {net_mean:.1f}%)"
+                else:
+                    network_comparison = f" (above network μ {net_mean:.1f}%)"
         else:
-            relay["flag_uptime_display"] = "/".join(display_parts)
-            # Generate tooltip in same format as flag reliability
-            relay["flag_uptime_tooltip"] = f"{flag_display} flag uptime over time periods: " + ", ".join(tooltip_parts)
+            # Fallback color coding when no network statistics available
+            if uptime_val <= 1.0:
+                colored_str = f'<span class="al-status-danger">{percentage_str}</span>'  # Red
+            elif uptime_val >= 99.0:
+                colored_str = f'<span class="al-status-success">{percentage_str}</span>'  # Green
+            else:
+                colored_str = percentage_str
+
+        return colored_str, f"{period_short}: {uptime_val:.1f}%{network_comparison}"
+
+    _process_flag_metric_display(
+        relays, 'uptime', "No prioritized flag data available",
+        ['1_month', '6_months', '1_year', '5_years'], build_period_parts,
+        all_dash_display="Match"
+    )
 
 def basic_uptime_processing(relays):
     """

--- a/allium/lib/html_escape_utils.py
+++ b/allium/lib/html_escape_utils.py
@@ -45,18 +45,6 @@ class HTMLEscaper:
             return fallback
         return html.escape(str(value))
     
-    def escape_with_unknown_fallback(self, value: Any) -> str:
-        """Escape with 'Unknown' fallback for user-visible fields."""
-        return self.safe_escape(value, self.constants.UNKNOWN_ESCAPED)
-    
-    def escape_with_none_fallback(self, value: Any) -> str:
-        """Escape with 'none' fallback for technical fields."""
-        return self.safe_escape(value, self.constants.NONE_ESCAPED)
-    
-    def escape_with_lowercase_unknown_fallback(self, value: Any) -> str:
-        """Escape with 'unknown' fallback for lowercase contexts."""
-        return self.safe_escape(value, self.constants.UNKNOWN_LOWERCASE)
-    
     def escape_list(self, values: List[Any], fallback: str = "") -> List[str]:
         """
         Escape a list of values with consistent fallback handling.
@@ -294,7 +282,6 @@ class BulkRelayEscaper:
         
         # Date field escaping
         first_seen_data = self.field_escaper.escape_date_field(relay.get("first_seen"))
-        relay["first_seen_date"] = first_seen_data['date_escaped'].replace('&', '&amp;')  # Unescape for raw date
         relay["first_seen_date_escaped"] = first_seen_data['date_escaped']
         
         return relay
@@ -314,65 +301,6 @@ class BulkRelayEscaper:
         return [self.escape_all_relay_fields(relay) for relay in relays_list]
 
 
-class TemplateEscapingHelpers:
-    """Helper functions for template-specific escaping patterns."""
-    
-    def __init__(self):
-        """Initialize with base escaper."""
-        self.escaper = HTMLEscaper()
-    
-    def escape_breadcrumb_data(self, breadcrumb_data: Dict[str, Any]) -> Dict[str, str]:
-        """
-        Escape breadcrumb navigation data consistently.
-        
-        Consolidates breadcrumb escaping patterns from templates.
-        
-        Args:
-            breadcrumb_data: Dictionary of breadcrumb data
-            
-        Returns:
-            Dict[str, str]: Escaped breadcrumb data
-        """
-        escaped_data = {}
-        
-        # Standard breadcrumb fields
-        standard_fields = [
-            'as_number', 'country_name', 'platform_name', 'nickname',
-            'contact_hash', 'family_hash', 'date', 'flag_name', 'aroi_domain'
-        ]
-        
-        for field in standard_fields:
-            if field in breadcrumb_data:
-                escaped_data[field] = self.escaper.safe_escape(breadcrumb_data[field])
-        
-        # Special handling for hash truncation
-        if 'contact_hash' in breadcrumb_data:
-            escaped_data['contact_hash_short'] = self.escaper.safe_escape(
-                str(breadcrumb_data['contact_hash'])[:8]
-            )
-        
-        if 'family_hash' in breadcrumb_data:
-            escaped_data['family_hash_short'] = self.escaper.safe_escape(
-                str(breadcrumb_data['family_hash'])[:8]
-            )
-        
-        return escaped_data
-    
-    def escape_or_addresses(self, or_addresses: List[str]) -> List[str]:
-        """
-        Escape OR addresses list for template usage.
-        
-        Addresses the OR address escaping patterns in relay-info.html.
-        
-        Args:
-            or_addresses: List of OR addresses
-            
-        Returns:
-            List[str]: List of escaped OR addresses
-        """
-        return self.escaper.escape_list(or_addresses)
-
-
 # Convenience functions for backward compatibility and ease of use
 def safe_html_escape(value: Any, fallback: str = "") -> str:
     """
@@ -384,24 +312,9 @@ def safe_html_escape(value: Any, fallback: str = "") -> str:
     return escaper.safe_escape(value, fallback)
 
 
-def escape_relay_field(relay: Dict[str, Any], field_name: str, fallback: str = "") -> str:
-    """
-    Escape a specific field from a relay object.
-    
-    Convenience function for template usage.
-    """
-    escaper = HTMLEscaper()
-    return escaper.safe_escape(relay.get(field_name), fallback)
-
-
 def create_bulk_escaper() -> BulkRelayEscaper:
     """Create a new bulk relay escaper instance."""
     return BulkRelayEscaper()
-
-
-def create_template_helpers() -> TemplateEscapingHelpers:
-    """Create a new template escaping helpers instance."""
-    return TemplateEscapingHelpers()
 
 
 # Constants for external use

--- a/allium/lib/html_escape_utils.py
+++ b/allium/lib/html_escape_utils.py
@@ -10,7 +10,7 @@ This module provides:
 """
 
 import html
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List
 
 
 class HTMLEscapeConstants:

--- a/allium/lib/intelligence_engine.py
+++ b/allium/lib/intelligence_engine.py
@@ -4,7 +4,6 @@ All calculations moved from Jinja2 templates to Python for maximum performance.
 """
 
 import statistics
-import math
 from .statistical_utils import StatisticalUtils
 
 class IntelligenceEngine:

--- a/allium/lib/network_health.py
+++ b/allium/lib/network_health.py
@@ -13,7 +13,6 @@ from .time_utils import parse_onionoo_timestamp, create_time_thresholds
 from .string_utils import format_percentage_from_fraction
 from .consensus.consensus_evaluation import _port_in_rules
 from .country_utils import is_eu_political, is_frontier_country, get_rare_countries_weighted_with_existing_data
-from .uptime_utils import find_relay_uptime_data, calculate_relay_uptime_average
 from .consensus.collector_fetcher import get_voting_authority_names, get_voting_authority_count
 
 

--- a/allium/lib/operator_analysis.py
+++ b/allium/lib/operator_analysis.py
@@ -949,390 +949,354 @@ def compute_contact_display_data(i, bandwidth_unit, operator_reliability, v, mem
     
     return display_data
 
+def _compute_contact_flag_metric_analysis(members, relay_set, metric, none_msg,
+                                          no_data_msg, failure_prefix,
+                                          collect_flag_periods, process_results):
+    """
+    Shared skeleton for contact flag uptime/bandwidth analysis: pulls the
+    consolidated per-relay flag data off relay_set (attribute and key names
+    derived from metric, 'uptime' or 'bandwidth'), filters it to the flags
+    each member relay currently has, then delegates per-period collection to
+    collect_flag_periods(flag_bucket, flag_periods, relay, fingerprint) and
+    final processing to process_results(operator_flag_data,
+    network_flag_statistics). Variant-specific error wording (none_msg — or
+    None to skip the falsy-results check — no_data_msg, failure_prefix) is
+    parameterized so each variant's output stays byte-identical.
+    """
+    try:
+        # Use consolidated results if available (from the _reprocess_* step)
+        if not hasattr(relay_set, f'_consolidated_{metric}_results'):
+            return {'has_flag_data': False, 'error': f'Consolidated {metric} processing not available'}
+
+        consolidated_results = getattr(relay_set, f'_consolidated_{metric}_results')
+        if none_msg is not None and not consolidated_results:
+            return {'has_flag_data': False, 'error': none_msg}
+
+        relay_metric_data = consolidated_results[f'relay_{metric}_data']
+        network_flag_statistics = consolidated_results.get('network_flag_statistics', {})
+
+        # Extract flag data for operator relays using pre-computed data,
+        # only for flags each relay currently has
+        operator_flag_data = {}
+        for relay in members:
+            fingerprint = relay.get('fingerprint', '')
+            relay_flags = set(relay.get('flags', []))
+            if fingerprint in relay_metric_data:
+                for flag, flag_periods in relay_metric_data[fingerprint]['flag_data'].items():
+                    if flag in relay_flags:
+                        if flag not in operator_flag_data:
+                            operator_flag_data[flag] = {}
+                        collect_flag_periods(operator_flag_data[flag], flag_periods, relay, fingerprint)
+
+        if not operator_flag_data:
+            return {'has_flag_data': False, 'error': no_data_msg}
+
+        # Process flag reliability using pre-computed network statistics
+        results = process_results(operator_flag_data, network_flag_statistics)
+        return {
+            'has_flag_data': True,
+            'flag_reliabilities': results['flag_reliabilities'],
+            'available_periods': results['available_periods'],
+            'period_display': results['period_display'],
+            'source': 'consolidated_processing'
+        }
+
+    except Exception as e:
+        return {
+            'has_flag_data': False,
+            'error': f'{failure_prefix}: {str(e)}',
+            'source': 'error'
+        }
+
 def compute_contact_flag_analysis(contact_hash, members, relay_set):
     """
     Compute flag reliability analysis for contact operator using consolidated uptime data.
-    
+
     This method uses pre-computed results from _reprocess_uptime_data(). If consolidated
     processing isn't available, no flag data is returned (section won't be shown).
-    
+
     Args:
         contact_hash: Contact hash for the operator
         members: List of relay objects for the operator
-        
+
     Returns:
         dict: Flag reliability analysis data or indication that no data is available
     """
-    try:
-        # Use consolidated uptime results if available (from _reprocess_uptime_data)
-        if hasattr(relay_set, '_consolidated_uptime_results'):
-            consolidated_results = relay_set._consolidated_uptime_results
-            relay_uptime_data = consolidated_results['relay_uptime_data']
-            network_flag_statistics = consolidated_results.get('network_flag_statistics', {})
-            
-            # Extract flag data for operator relays using pre-computed data
-            operator_flag_data = {}
-            
-            for relay in members:
-                fingerprint = relay.get('fingerprint', '')
-                
-                # Get actual flags this relay currently has (same approach as line 561)
-                relay_flags = set(relay.get('flags', []))
-                
-                if fingerprint in relay_uptime_data:
-                    flag_data = relay_uptime_data[fingerprint]['flag_data']
-                    
-                    for flag, periods in flag_data.items():
-                        # Only include flag data for flags the relay currently has
-                        if flag in relay_flags:
-                            if flag not in operator_flag_data:
-                                operator_flag_data[flag] = {}
-                            for period, data in periods.items():
-                                if period not in operator_flag_data[flag]:
-                                    operator_flag_data[flag][period] = []
-                                operator_flag_data[flag][period].append({
-                                    'relay_nickname': data['relay_info']['nickname'],
-                                    'relay_fingerprint': data['relay_info']['fingerprint'],
-                                    'uptime': data['uptime'],
-                                    'data_points': data['data_points']
-                                })
-            
-            if not operator_flag_data:
-                return {'has_flag_data': False, 'error': 'No flag data available for operator relays'}
-            
-            # Process flag reliability using pre-computed network statistics
-            flag_reliability_results = process_operator_flag_reliability(
-                operator_flag_data, network_flag_statistics
-            )
-            
-            return {
-                'has_flag_data': True,
-                'flag_reliabilities': flag_reliability_results['flag_reliabilities'],
-                'available_periods': flag_reliability_results['available_periods'],
-                'period_display': flag_reliability_results['period_display'],
-                'source': 'consolidated_processing'
-            }
-            
-        else:
-            # No consolidated results available - don't show flag reliability section
-            return {'has_flag_data': False, 'error': 'Consolidated uptime processing not available'}
-            
-    except Exception as e:
-        return {
-            'has_flag_data': False, 
-            'error': f'Flag analysis processing failed: {str(e)}',
-            'source': 'error'
-        }
+    def collect_flag_periods(flag_bucket, flag_periods, relay, fingerprint):
+        for period, data in flag_periods.items():
+            if period not in flag_bucket:
+                flag_bucket[period] = []
+            flag_bucket[period].append({
+                'relay_nickname': data['relay_info']['nickname'],
+                'relay_fingerprint': data['relay_info']['fingerprint'],
+                'uptime': data['uptime'],
+                'data_points': data['data_points']
+            })
+
+    return _compute_contact_flag_metric_analysis(
+        members, relay_set, 'uptime', none_msg=None,
+        no_data_msg='No flag data available for operator relays',
+        failure_prefix='Flag analysis processing failed',
+        collect_flag_periods=collect_flag_periods,
+        process_results=process_operator_flag_reliability
+    )
 
 def compute_contact_flag_bandwidth_analysis(contact_hash, members, relay_set):
     """
     Compute flag bandwidth analysis for contact operator using consolidated bandwidth data.
-    
+
     This method uses pre-computed results from _reprocess_bandwidth_data(). If consolidated
     processing isn't available, no flag bandwidth data is returned.
-    
+
     Args:
         contact_hash: Contact hash for the operator
         members: List of relay objects for the operator
-        
+
     Returns:
         dict: Flag bandwidth analysis data or indication that no data is available
     """
-    try:
-        # Use consolidated bandwidth results if available (from _reprocess_bandwidth_data)
-        if not hasattr(relay_set, '_consolidated_bandwidth_results'):
-            return {'has_flag_data': False, 'error': 'Consolidated bandwidth processing not available'}
-        
-        consolidated_results = relay_set._consolidated_bandwidth_results
-        if not consolidated_results:
-            return {'has_flag_data': False, 'error': 'Consolidated bandwidth results are None'}
-        
-        relay_bandwidth_data = consolidated_results['relay_bandwidth_data']
-        network_flag_statistics = consolidated_results.get('network_flag_statistics', {})
-        
-        # Extract flag bandwidth data for operator relays using pre-computed data
-        operator_flag_data = {}
-        
-        for relay in members:
-            fingerprint = relay.get('fingerprint', '')
-            nickname = relay.get('nickname', 'Unknown')
-            
-            # Get actual flags this relay currently has
-            relay_flags = set(relay.get('flags', []))
-            
-            if fingerprint in relay_bandwidth_data:
-                flag_data = relay_bandwidth_data[fingerprint]['flag_data']
-                
-                for flag, bandwidth_averages in flag_data.items():
-                    # Only include flag data for flags the relay currently has
-                    if flag in relay_flags:
-                        if flag not in operator_flag_data:
-                            operator_flag_data[flag] = {}
-                        for period in ['6_months', '1_year', '5_years']:
-                            if period in bandwidth_averages and bandwidth_averages[period] > 0:
-                                if period not in operator_flag_data[flag]:
-                                    operator_flag_data[flag][period] = []
-                                operator_flag_data[flag][period].append({
-                                    'relay_nickname': nickname,
-                                    'relay_fingerprint': fingerprint,
-                                    'bandwidth': bandwidth_averages[period],
-                                    'data_points': 0  # Not tracked in simplified structure
-                                })
-        
-        if not operator_flag_data:
-            return {'has_flag_data': False, 'error': 'No flag bandwidth data available for operator relays'}
-            
-        # Process flag bandwidth reliability using pre-computed network statistics
-        flag_bandwidth_results = process_operator_flag_bandwidth_reliability(
+    def collect_flag_periods(flag_bucket, bandwidth_averages, relay, fingerprint):
+        nickname = relay.get('nickname', 'Unknown')
+        for period in ['6_months', '1_year', '5_years']:
+            if period in bandwidth_averages and bandwidth_averages[period] > 0:
+                if period not in flag_bucket:
+                    flag_bucket[period] = []
+                flag_bucket[period].append({
+                    'relay_nickname': nickname,
+                    'relay_fingerprint': fingerprint,
+                    'bandwidth': bandwidth_averages[period],
+                    'data_points': 0  # Not tracked in simplified structure
+                })
+
+    def process_results(operator_flag_data, network_flag_statistics):
+        return process_operator_flag_bandwidth_reliability(
             operator_flag_data, network_flag_statistics, relay_set
         )
-        
-        return {
-            'has_flag_data': True,
-            'flag_reliabilities': flag_bandwidth_results['flag_reliabilities'],
-            'available_periods': flag_bandwidth_results['available_periods'],
-            'period_display': flag_bandwidth_results['period_display'],
-            'source': 'consolidated_processing'
+
+    return _compute_contact_flag_metric_analysis(
+        members, relay_set, 'bandwidth', none_msg='Consolidated bandwidth results are None',
+        no_data_msg='No flag bandwidth data available for operator relays',
+        failure_prefix='Flag bandwidth analysis processing failed',
+        collect_flag_periods=collect_flag_periods,
+        process_results=process_results
+    )
+
+def _process_operator_flag_metric(operator_flag_data, network_flag_statistics,
+                                  flag_order, flag_display_mapping, periods,
+                                  period_order, build_period_entry):
+    """
+    Shared skeleton for operator flag uptime/bandwidth reliability processing:
+    iterates flags in flag_order (skipping ones absent from operator_flag_data
+    or flag_display_mapping), tracks which short periods have data, and
+    assembles the template-ready result dict. All metric-specific work
+    (averaging field, formatting, color coding, tooltip wording) lives in
+    build_period_entry, which maps (flag, period_short, period_relays,
+    net_stats or None) to a period entry dict — or None to skip — keeping
+    each variant's output byte-identical.
+    """
+    flag_reliabilities = {}
+
+    # Track which time periods have data across all flags
+    periods_with_data = set()
+
+    # Process flags in the specified order
+    for flag in flag_order:
+        if flag not in operator_flag_data:
+            continue
+
+        flag_periods = operator_flag_data[flag]
+
+        if flag not in flag_display_mapping:
+            continue
+
+        flag_info = {
+            'icon': flag_display_mapping[flag]['icon'],
+            'display_name': flag_display_mapping[flag]['display_name'],
+            'periods': {}
         }
-            
-    except Exception as e:
-        return {
-            'has_flag_data': False, 
-            'error': f'Flag bandwidth analysis processing failed: {str(e)}',
-            'source': 'error'
-        }
+
+        for period in periods:
+            period_short = PERIOD_SHORT_NAMES.get(period, period)
+
+            if period in flag_periods and flag_periods[period]:
+                # Network comparison statistics, if available
+                if (flag in network_flag_statistics and
+                    period in network_flag_statistics[flag] and
+                    network_flag_statistics[flag][period]):
+                    net_stats = network_flag_statistics[flag][period]
+                else:
+                    net_stats = None
+
+                entry = build_period_entry(flag, period_short, flag_periods[period], net_stats)
+                if entry is not None:
+                    periods_with_data.add(period_short)
+                    flag_info['periods'][period_short] = entry
+
+        # Only include flag if it has data for at least one period
+        if flag_info['periods']:
+            flag_reliabilities[flag] = flag_info
+
+    # Generate dynamic period display string
+    available_periods = [p for p in period_order if p in periods_with_data]
+    period_display = '/'.join(available_periods) if available_periods else 'No Data'
+
+    return {
+        'flag_reliabilities': flag_reliabilities,
+        'available_periods': available_periods,
+        'period_display': period_display,
+        'has_data': bool(available_periods)
+    }
 
 def process_operator_flag_bandwidth_reliability(operator_flag_data, network_flag_statistics, relay_set):
     """
     Process operator flag bandwidth data into display format with color coding.
     Mirrors the uptime flag processing but for bandwidth metrics.
-    
+
     Args:
         operator_flag_data (dict): Flag bandwidth data for the operator
         network_flag_statistics (dict): Network-wide flag bandwidth statistics
-        
+
     Returns:
         dict: Processed flag bandwidth data for template display
     """
-    flag_reliabilities = {}
-    periods_with_data = set()
-    
-    # Flag processing order (Exit > Guard > Fast > Running)
-    flag_order = ['Exit', 'Guard', 'Fast', 'Running', 'Authority', 'HSDir', 'Stable', 'V2Dir']
-    
-    # Flag display configuration
-    flag_display_mapping = {
-        'Exit': {'icon': '🚪', 'display_name': 'Exit Node'},
-        'Guard': {'icon': '🛡️', 'display_name': 'Entry Guard'},
-        'Fast': {'icon': '⚡', 'display_name': 'Fast Relay'},
-        'Running': {'icon': '🟢', 'display_name': 'Running'},
-        'Authority': {'icon': '👑', 'display_name': 'Directory Authority'},
-        'HSDir': {'icon': '📁', 'display_name': 'Hidden Service Directory'},
-        'Stable': {'icon': '🎯', 'display_name': 'Stable Relay'},
-        'V2Dir': {'icon': '📋', 'display_name': 'Version 2 Directory'}
-    }
-    
-    # Process flags in the specified order
-    for flag in flag_order:
-        if flag not in operator_flag_data:
-            continue
-            
-        periods = operator_flag_data[flag]
-        
-        if flag not in flag_display_mapping:
-            continue
-            
-        flag_info = {
-            'icon': flag_display_mapping[flag]['icon'],
-            'display_name': flag_display_mapping[flag]['display_name'],
-            'periods': {}
+    formatter = relay_set.bandwidth_formatter
+
+    def build_period_entry(flag, period_short, period_relays, net_stats):
+        # Average bandwidth for operator relays with this flag; include all
+        # values >= 0 (0 is valid data meaning relay had no bandwidth)
+        bandwidth_values = [relay_data['bandwidth'] for relay_data in period_relays]
+        avg_bandwidth = sum(bandwidth_values) / len(bandwidth_values)
+        if not avg_bandwidth >= 0:
+            return None
+
+        unit = formatter.determine_unit(avg_bandwidth)
+        formatted_bw = formatter.format_bandwidth_with_unit(avg_bandwidth, unit)
+        bandwidth_display = f"{formatted_bw} {unit}"
+
+        color_class = ''  # Default: no special coloring (black text)
+        tooltip = f'{flag} flag bandwidth over {period_short}: {bandwidth_display}'
+
+        if net_stats:
+            net_mean_unit = formatter.determine_unit(net_stats["mean"])
+            net_mean_formatted = formatter.format_bandwidth_with_unit(net_stats["mean"], net_mean_unit)
+            tooltip += f' (network μ: {net_mean_formatted} {net_mean_unit})'
+
+            # Enhanced color coding logic for bandwidth - match legend
+            if avg_bandwidth <= net_stats['two_sigma_low']:
+                color_class = 'statistical-outlier-low'  # Red - Poor (≥2σ from network μ)
+            elif avg_bandwidth > net_stats['mean'] * 1.5:  # High performance threshold
+                color_class = 'high-performance'  # Green - High performance (>1.5x μ)
+            elif avg_bandwidth < net_stats['mean']:
+                color_class = 'below-mean'  # Yellow - Below average (<μ of network)
+            # EXPLICIT: Values between mean and 1.5x mean get no color_class (black)
+
+        else:
+            # Fallback color coding when no network statistics available
+            if avg_bandwidth <= 0:
+                color_class = 'statistical-outlier-low'
+            # Default: no special coloring (black)
+
+        return {
+            'value': avg_bandwidth,
+            'value_display': bandwidth_display,
+            'color_class': color_class,
+            'tooltip': tooltip,
+            'relay_count': len(period_relays)
         }
-        
-        for period in ['6_months', '1_year', '5_years']:
-            period_short = PERIOD_SHORT_NAMES.get(period, period)
-            
-            if period in periods and periods[period]:
-                # Calculate average bandwidth for operator relays with this flag
-                bandwidth_values = [relay_data['bandwidth'] for relay_data in periods[period]]
-                avg_bandwidth = sum(bandwidth_values) / len(bandwidth_values)
-                
-                # Include all values >= 0 (0 is valid data meaning relay had no bandwidth)
-                if avg_bandwidth >= 0:
-                    periods_with_data.add(period_short)
-                    
-                    # Format bandwidth for display
-                    unit = relay_set.bandwidth_formatter.determine_unit(avg_bandwidth)
-                    formatted_bw = relay_set.bandwidth_formatter.format_bandwidth_with_unit(avg_bandwidth, unit)
-                    bandwidth_display = f"{formatted_bw} {unit}"
-                    
-                    # Determine color coding and tooltip
-                    color_class = ''  # Default: no special coloring (black text)
-                    tooltip = f'{flag} flag bandwidth over {period_short}: {bandwidth_display}'
-                    
-                    # Add network comparison if available
-                    if (flag in network_flag_statistics and 
-                        period in network_flag_statistics[flag] and
-                        network_flag_statistics[flag][period]):
-                        
-                        net_stats = network_flag_statistics[flag][period]
-                        net_mean_unit = relay_set.bandwidth_formatter.determine_unit(net_stats["mean"])
-                        net_mean_formatted = relay_set.bandwidth_formatter.format_bandwidth_with_unit(net_stats["mean"], net_mean_unit)
-                        tooltip += f' (network μ: {net_mean_formatted} {net_mean_unit})'
-                        
-                        # Enhanced color coding logic for bandwidth - match legend
-                        if avg_bandwidth <= net_stats['two_sigma_low']:
-                            color_class = 'statistical-outlier-low'  # Red - Poor (≥2σ from network μ)
-                        elif avg_bandwidth > net_stats['mean'] * 1.5:  # High performance threshold
-                            color_class = 'high-performance'  # Green - High performance (>1.5x μ)
-                        elif avg_bandwidth < net_stats['mean']:
-                            color_class = 'below-mean'  # Yellow - Below average (<μ of network)
-                        # EXPLICIT: Values between mean and 1.5x mean get no color_class (black)
-                    
-                    else:
-                        # Fallback color coding when no network statistics available
-                        if avg_bandwidth <= 0:
-                            color_class = 'statistical-outlier-low'
-                        # Default: no special coloring (black)
-                    
-                    flag_info['periods'][period_short] = {
-                        'value': avg_bandwidth,
-                        'value_display': bandwidth_display,
-                        'color_class': color_class,
-                        'tooltip': tooltip,
-                        'relay_count': len(periods[period])
-                    }
-            
-        # Only include flag if it has data for at least one period
-        if flag_info['periods']:
-            flag_reliabilities[flag] = flag_info
-    
-    # Generate dynamic period display string
-    period_order = ['6M', '1Y', '5Y']
-    available_periods = [p for p in period_order if p in periods_with_data]
-    period_display = '/'.join(available_periods) if available_periods else 'No Data'
-    
-    return {
-        'flag_reliabilities': flag_reliabilities,
-        'available_periods': available_periods,
-        'period_display': period_display,
-        'has_data': bool(available_periods)
-    }
+
+    return _process_operator_flag_metric(
+        operator_flag_data, network_flag_statistics,
+        # Flag processing order (Exit > Guard > Fast > Running)
+        flag_order=['Exit', 'Guard', 'Fast', 'Running', 'Authority', 'HSDir', 'Stable', 'V2Dir'],
+        # Flag display configuration
+        flag_display_mapping={
+            'Exit': {'icon': '🚪', 'display_name': 'Exit Node'},
+            'Guard': {'icon': '🛡️', 'display_name': 'Entry Guard'},
+            'Fast': {'icon': '⚡', 'display_name': 'Fast Relay'},
+            'Running': {'icon': '🟢', 'display_name': 'Running'},
+            'Authority': {'icon': '👑', 'display_name': 'Directory Authority'},
+            'HSDir': {'icon': '📁', 'display_name': 'Hidden Service Directory'},
+            'Stable': {'icon': '🎯', 'display_name': 'Stable Relay'},
+            'V2Dir': {'icon': '📋', 'display_name': 'Version 2 Directory'}
+        },
+        periods=['6_months', '1_year', '5_years'],
+        period_order=['6M', '1Y', '5Y'],
+        build_period_entry=build_period_entry
+    )
 
 def process_operator_flag_reliability(operator_flag_data, network_flag_statistics):
     """
     Process flag reliability metrics for an operator using pre-computed network statistics.
-    
+
     Args:
         operator_flag_data: Operator's flag-specific uptime data
         network_flag_statistics: Network-wide flag statistics for comparison
-        
+
     Returns:
         dict: Processed flag reliability metrics with available periods info
     """
-    flag_display_mapping = {
-        'Running': {'icon': '🟢', 'display_name': 'Running Operation'},
-        'Fast': {'icon': '⚡', 'display_name': 'Fast Relay'},
-        'Stable': {'icon': '🛡️', 'display_name': 'Stable Operation'}, 
-        'Guard': {'icon': '🛡️', 'display_name': 'Entry Guard'},
-        'Exit': {'icon': '🚪', 'display_name': 'Exit Node'},
-        'HSDir': {'icon': '📂', 'display_name': 'Hidden Services'},
-        'Authority': {'icon': '⚖️', 'display_name': 'Directory Authority'},
-        'V2Dir': {'icon': '📁', 'display_name': 'Directory Services'},
-        'BadExit': {'icon': '🚫', 'display_name': 'Bad Exit'}
-    }
-    
-    # Define flag ordering for consistent display - Hidden Services before Directory Services
-    flag_order = ['BadExit', 'Stable', 'Fast', 'Running', 'Authority', 'Guard', 'Exit', 'HSDir', 'V2Dir']
-    
-    flag_reliabilities = {}
-    
-    # Track which time periods have data across all flags
-    periods_with_data = set()
-    
-    # Process flags in the specified order
-    for flag in flag_order:
-        if flag not in operator_flag_data:
-            continue
-            
-        periods = operator_flag_data[flag]
-        
-        if flag not in flag_display_mapping:
-            continue
-            
-        flag_info = {
-            'icon': flag_display_mapping[flag]['icon'],
-            'display_name': flag_display_mapping[flag]['display_name'],
-            'periods': {}
+    def build_period_entry(flag, period_short, period_relays, net_stats):
+        # Average uptime for operator relays with this flag; include all
+        # values >= 0 (0% is valid data meaning relay never had this flag)
+        uptime_values = [relay_data['uptime'] for relay_data in period_relays]
+        avg_uptime = sum(uptime_values) / len(uptime_values)
+        if not avg_uptime >= 0:
+            return None
+
+        color_class = ''
+        tooltip = f'{flag} flag uptime over {period_short}: {avg_uptime:.1f}%'
+
+        if net_stats:
+            tooltip += f' (network μ: {net_stats["mean"]:.1f}%, 2σ: {net_stats["two_sigma_low"]:.1f}%)'
+
+            # Enhanced color coding logic: prioritize statistical outliers over >99%
+            # Special handling for very low values (≤1%) - likely to be statistical outliers
+            if avg_uptime <= 1.0:
+                color_class = 'statistical-outlier-low'
+            elif avg_uptime <= net_stats['two_sigma_low']:
+                color_class = 'statistical-outlier-low'
+            elif avg_uptime >= 99.0:
+                color_class = 'high-performance'
+            elif avg_uptime > net_stats['two_sigma_high']:
+                color_class = 'statistical-outlier-high'
+            elif avg_uptime < net_stats['mean']:
+                color_class = 'below-mean'
+            # Note: Removed default above-mean green coloring per user feedback
+
+        else:
+            # Fallback color coding when no network statistics available
+            if avg_uptime <= 1.0:
+                color_class = 'statistical-outlier-low'
+            elif avg_uptime >= 99.0:
+                color_class = 'high-performance'
+            # Default: no special coloring
+
+        return {
+            'value': avg_uptime,
+            'color_class': color_class,
+            'tooltip': tooltip,
+            'relay_count': len(period_relays)
         }
-        
-        for period in ['1_month', '6_months', '1_year', '5_years']:
-            period_short = PERIOD_SHORT_NAMES.get(period, period)
-            
-            if period in periods and periods[period]:
-                # Calculate average uptime for operator relays with this flag
-                uptime_values = [relay_data['uptime'] for relay_data in periods[period]]
-                avg_uptime = sum(uptime_values) / len(uptime_values)
-                
-                # Include all values >= 0 (0% is valid data meaning relay never had this flag)
-                if avg_uptime >= 0:
-                    periods_with_data.add(period_short)
-                    
-                    # Determine color coding and tooltip
-                    color_class = ''
-                    tooltip = f'{flag} flag uptime over {period_short}: {avg_uptime:.1f}%'
-                    
-                    # Add network comparison if available
-                    if (flag in network_flag_statistics and 
-                        period in network_flag_statistics[flag] and
-                        network_flag_statistics[flag][period]):
-                        
-                        net_stats = network_flag_statistics[flag][period]
-                        tooltip += f' (network μ: {net_stats["mean"]:.1f}%, 2σ: {net_stats["two_sigma_low"]:.1f}%)'
-                        
-                        # Enhanced color coding logic: prioritize statistical outliers over >99%
-                        # Special handling for very low values (≤1%) - likely to be statistical outliers
-                        if avg_uptime <= 1.0:
-                            color_class = 'statistical-outlier-low'
-                        elif avg_uptime <= net_stats['two_sigma_low']:
-                            color_class = 'statistical-outlier-low'
-                        elif avg_uptime >= 99.0:
-                            color_class = 'high-performance'
-                        elif avg_uptime > net_stats['two_sigma_high']:
-                            color_class = 'statistical-outlier-high'
-                        elif avg_uptime < net_stats['mean']:
-                            color_class = 'below-mean'
-                        # Note: Removed default above-mean green coloring per user feedback
-                    
-                    else:
-                        # Fallback color coding when no network statistics available
-                        if avg_uptime <= 1.0:
-                            color_class = 'statistical-outlier-low'
-                        elif avg_uptime >= 99.0:
-                            color_class = 'high-performance'
-                        # Default: no special coloring
-                    
-                    flag_info['periods'][period_short] = {
-                        'value': avg_uptime,
-                        'color_class': color_class,
-                        'tooltip': tooltip,
-                        'relay_count': len(periods[period])
-                    }
-            
-        # Only include flag if it has data for at least one period
-        if flag_info['periods']:
-            flag_reliabilities[flag] = flag_info
-    
-    # Generate dynamic period display string
-    period_order = ['1M', '6M', '1Y', '5Y']
-    available_periods = [p for p in period_order if p in periods_with_data]
-    period_display = '/'.join(available_periods) if available_periods else 'No Data'
-    
-    return {
-        'flag_reliabilities': flag_reliabilities,
-        'available_periods': available_periods,
-        'period_display': period_display,
-        'has_data': bool(available_periods)
-    }
+
+    return _process_operator_flag_metric(
+        operator_flag_data, network_flag_statistics,
+        # Define flag ordering for consistent display - Hidden Services before Directory Services
+        flag_order=['BadExit', 'Stable', 'Fast', 'Running', 'Authority', 'Guard', 'Exit', 'HSDir', 'V2Dir'],
+        flag_display_mapping={
+            'Running': {'icon': '🟢', 'display_name': 'Running Operation'},
+            'Fast': {'icon': '⚡', 'display_name': 'Fast Relay'},
+            'Stable': {'icon': '🛡️', 'display_name': 'Stable Operation'},
+            'Guard': {'icon': '🛡️', 'display_name': 'Entry Guard'},
+            'Exit': {'icon': '🚪', 'display_name': 'Exit Node'},
+            'HSDir': {'icon': '📂', 'display_name': 'Hidden Services'},
+            'Authority': {'icon': '⚖️', 'display_name': 'Directory Authority'},
+            'V2Dir': {'icon': '📁', 'display_name': 'Directory Services'},
+            'BadExit': {'icon': '🚫', 'display_name': 'Bad Exit'}
+        },
+        periods=['1_month', '6_months', '1_year', '5_years'],
+        period_order=['1M', '6M', '1Y', '5Y'],
+        build_period_entry=build_period_entry
+    )
 
 def calculate_operator_downtime_alerts(contact_hash, operator_relays, contact_data, bandwidth_unit, relay_set):
     """

--- a/allium/lib/operator_analysis.py
+++ b/allium/lib/operator_analysis.py
@@ -10,17 +10,6 @@ import html as _html
 import statistics
 
 from .time_utils import format_time_ago, PERIOD_SHORT_NAMES, PERIOD_DISPLAY_NAMES
-from .uptime_utils import (
-    extract_relay_uptime_for_period,
-    calculate_statistical_outliers,
-    find_operator_percentile_position,
-    format_network_percentiles_display,
-)
-from .bandwidth_utils import (
-    extract_relay_bandwidth_for_period,
-    extract_operator_daily_bandwidth_totals,
-    calculate_bandwidth_reliability_metrics,
-)
 
 
 def _build_contact_rankings_index(relay_set):
@@ -828,7 +817,6 @@ def compute_contact_display_data(i, bandwidth_unit, operator_reliability, v, mem
     
     # Format version status display (only show counts > 0) with version tooltips and percentages
     # Add status indicators based on recommended status ratio (similar to version compliance)
-    version_status_parts = []
     version_status_tooltips = {}
     
     recommended_count = version_status_counts.get('recommended', 0)
@@ -987,7 +975,6 @@ def compute_contact_flag_analysis(contact_hash, members, relay_set):
             
             for relay in members:
                 fingerprint = relay.get('fingerprint', '')
-                nickname = relay.get('nickname', 'Unknown')
                 
                 # Get actual flags this relay currently has (same approach as line 561)
                 relay_flags = set(relay.get('flags', []))

--- a/allium/lib/page_context.py
+++ b/allium/lib/page_context.py
@@ -9,8 +9,7 @@ This module provides:
 - Centralized breadcrumb management
 """
 
-from typing import Any, Dict, Optional, Union
-import os
+from typing import Any, Dict, Optional
 
 
 class PageContextGenerator:

--- a/allium/lib/page_context.py
+++ b/allium/lib/page_context.py
@@ -321,12 +321,3 @@ def get_detail_page_context(category: str, value: str) -> Dict[str, Any]:
     generator = PageContextGenerator()
     return generator.get_detail_context(category, value)
 
-
-def create_template_context_builder(relays_instance=None) -> TemplateContextBuilder:
-    """Create a new template context builder."""
-    return TemplateContextBuilder(relays_instance)
-
-
-def create_standard_contexts(relays_instance=None) -> StandardTemplateContexts:
-    """Create a new standard template contexts instance."""
-    return StandardTemplateContexts(relays_instance)

--- a/allium/lib/page_writer.py
+++ b/allium/lib/page_writer.py
@@ -1049,26 +1049,15 @@ def write_pages_by_key(relay_set, k):
         # Generate page context with correct breadcrumb data
         page_ctx = get_detail_page_context(relay_set, k, v)
         
-        # Generate contact rankings for AROI leaderboards (only for contact pages)
+        # Contact pages never reach this loop (routed to dedicated renderers
+        # above); contact-specific template args stay at their defaults.
         contact_rankings = []
         operator_reliability = None
         contact_display_data = None
         primary_country_data = None
         contact_validation_status = None
         aroi_validation_timestamp = None
-        if k == "contact":
-            contact_rankings = relay_set._generate_contact_rankings(v)
-            # Calculate operator reliability statistics
-            operator_reliability = relay_set._calculate_operator_reliability(v, members)
-            # Pre-compute all contact-specific display data
-            contact_display_data = relay_set._compute_contact_display_data(
-                i, bandwidth_unit, operator_reliability, v, members
-            )
-            # Store contact_display_data in the contact structure for relay pages to access
-            i['contact_display_data'] = contact_display_data
-            # Get primary country data for this contact
-            primary_country_data = i.get("primary_country_data")
-        
+
         # Add family-specific data for family templates (used by detail_summary macro)
         family_aroi_domain = None
         family_contact = None
@@ -1078,19 +1067,15 @@ def write_pages_by_key(relay_set, k):
             family_contact = i.get("contact", "")
             family_contact_md5 = i.get("contact_md5", "")
         
-        # AROI validation status for contact and family pages (DRY - shared logic)
-        if k in ("contact", "family"):
-            contact_validation_status = (i.get("aroi_validation_full") or 
-                                         i.get("contact_validation_status") or 
+        # AROI validation status for family pages
+        if k == "family":
+            contact_validation_status = (i.get("aroi_validation_full") or
+                                         i.get("contact_validation_status") or
                                          relay_set._get_contact_validation_status(members))
             aroi_validation_timestamp = relay_set._aroi_validation_timestamp
-        
-        # Check if this contact has a validated AROI domain for vanity URL display
+
         is_validated_aroi = False
-        if k == "contact" and members and hasattr(relay_set, 'validated_aroi_domains'):
-            aroi_domain = members[0].get("aroi_domain")
-            is_validated_aroi = aroi_domain and aroi_domain != "none" and aroi_domain in relay_set.validated_aroi_domains
-        
+
         # Family support counts for summary bullet (DRY helper)
         family_support_counts = _get_family_support_counts(k, contact_display_data, i)
         exit_dns_health_summary = _get_exit_dns_health_summary(k, i, members)
@@ -1169,25 +1154,6 @@ def write_pages_by_key(relay_set, k):
         with open(html_path, "w", encoding="utf8") as html:
             html.write(rendered)
         io_time += time.time() - io_start
-        
-        # Create vanity URL for validated AROI domains (copy and adjust paths)
-        # Only create if base_url is configured - Place at root level (e.g., /domain/ instead of /contact/domain/)
-        if relay_set.base_url and k == "contact" and members and hasattr(relay_set, 'validated_aroi_domains'):
-            aroi_domain = members[0].get("aroi_domain")
-            if aroi_domain and aroi_domain != "none" and aroi_domain in relay_set.validated_aroi_domains:
-                # Lowercase domain for case-insensitive URLs
-                safe_domain = _sanitize_path_component(aroi_domain.lower())
-                # Use parent directory (root level) instead of output_path (contact subdirectory)
-                vanity_dir = os.path.join(os.path.dirname(output_path), safe_domain)
-                try:
-                    os.makedirs(vanity_dir, exist_ok=True)
-                    # Adjust path prefix from depth 2 (../../) to depth 1 (../)
-                    # Uses the in-memory rendered string to avoid reading the file back from disk
-                    adjusted_html = rendered.replace('href="../../', 'href="../').replace('src="../../', 'src="../')
-                    with open(os.path.join(vanity_dir, "index.html"), 'w', encoding='utf8') as f:
-                        f.write(adjusted_html)
-                except OSError:
-                    pass  # Silent fail - don't break generation for vanity URL issues
         
         page_count += 1
         
@@ -1319,11 +1285,11 @@ def write_pages_parallel(relay_set, k, sorted_values, template, output_path, the
     """
     validated_aroi_domains = getattr(relay_set, 'validated_aroi_domains', set())
     page_args = []
-    vanity_url_tasks = []  # Collect vanity URL tasks for post-processing
-    
+
+    # Contact pages never reach this function (routed to dedicated renderers
+    # in write_pages_by_key), so no vanity-URL handling is needed here.
     for v in sorted_values:
-        i = relay_set.json["sorted"][k][v]
-        # Sanitize for filesystem paths only (raw v used for data lookup above and by workers)
+        # Sanitize for filesystem paths only (raw v used for data lookup by workers)
         v_safe = _sanitize_path_component(v)
         dir_path = os.path.join(output_path, v_safe.lower() if k == "flag" else v_safe)
         os.makedirs(dir_path, exist_ok=True)
@@ -1331,13 +1297,6 @@ def write_pages_parallel(relay_set, k, sorted_values, template, output_path, the
         # OPTIMIZED: Pass only (html_path, value) - workers build template args from forked memory
         # Raw v is passed so workers can look up data in relay_set.json["sorted"][k][v]
         page_args.append((html_path, v))
-        
-        # Collect vanity URL tasks for contact pages (to be processed after parallel generation)
-        # Uses precomputed aroi_domain to avoid re-fetching members
-        if k == "contact" and relay_set.base_url and i.get("is_validated_aroi"):
-            aroi_domain = i.get("aroi_domain")
-            if aroi_domain and aroi_domain != "none":
-                vanity_url_tasks.append((html_path, aroi_domain, output_path))
     
     pool = None
     try:
@@ -1348,22 +1307,7 @@ def write_pages_parallel(relay_set, k, sorted_values, template, output_path, the
         pool.map(_render_page_mp, page_args)
         pool.close()
         pool.join()
-        
-        # Post-process vanity URLs for contact pages (after parallel generation)
-        if vanity_url_tasks:
-            for html_path, aroi_domain, contact_output_path in vanity_url_tasks:
-                try:
-                    safe_domain = _sanitize_path_component(aroi_domain.lower())
-                    vanity_dir = os.path.join(os.path.dirname(contact_output_path), safe_domain)
-                    os.makedirs(vanity_dir, exist_ok=True)
-                    with open(html_path, 'r', encoding='utf8') as f:
-                        html_content = f.read()
-                    adjusted_html = html_content.replace('href="../../', 'href="../').replace('src="../../', 'src="../')
-                    with open(os.path.join(vanity_dir, "index.html"), 'w', encoding='utf8') as f:
-                        f.write(adjusted_html)
-                except OSError:
-                    pass  # Silent fail for vanity URL issues
-        
+
         total_time = time.time() - start_time
         relay_set.progress_logger.log(f"{k} page generation complete - Generated {len(page_args)} pages in {total_time:.2f}s")
         if relay_set.progress:

--- a/allium/lib/page_writer.py
+++ b/allium/lib/page_writer.py
@@ -7,7 +7,6 @@ page writing functions.
 Extracted from relays.py for better modularity.
 """
 
-import functools
 import multiprocessing as mp
 import os
 import time
@@ -19,7 +18,6 @@ from .contact_sorting import (
     CONTACT_SORT_FILE_MAP,
     CONTACT_SORT_MODES,
     CONTACT_DEFAULT_SORT_MODE,
-    CONTACT_SECTION_KEYS,
     adjust_vanity_paths as _adjust_vanity_paths,
     contact_sort_links as _contact_sort_links,
     build_contact_variant_args as _build_contact_variant_args,
@@ -27,9 +25,6 @@ from .contact_sorting import (
     contact_relay_count as _contact_relay_count,
 )
 from .bandwidth_formatter import (
-    BandwidthFormatter,
-    determine_unit,
-    get_divisor_for_unit,
     format_bandwidth_with_unit,
     determine_unit_filter,
     format_bandwidth_filter,
@@ -338,7 +333,7 @@ def _precompute_contact_worker(args):
         result = _compute_contact_predata(
             _precompute_relay_set, contact_hash, aroi_validation_timestamp, validated_aroi_domains)
         return (contact_hash, result)
-    except Exception as e:
+    except Exception:
         return (contact_hash, None)
 
 
@@ -412,7 +407,7 @@ def _precompute_family_worker(args):
     try:
         result = _compute_family_predata(_precompute_relay_set, family_hash)
         return (family_hash, result)
-    except Exception as e:
+    except Exception:
         return (family_hash, None)
 
 
@@ -545,7 +540,6 @@ def get_directory_authorities_data(relay_set):
     Prepare directory authorities data for template rendering.
     Reuses existing authority uptime calculations and z-score infrastructure.
     """
-    from datetime import datetime, timezone
     
     # Filter authorities from existing relay data (no new processing)
     authorities = [relay for relay in relay_set.json["relays"] if 'Authority' in relay.get('flags', [])]
@@ -612,14 +606,12 @@ def get_directory_authorities_data(relay_set):
             )
             
             # Get per-authority consensus methods from consensus_method_info
-            auth_consensus_methods = None
             auth_max_method = None
             if collector_data:
                 cm_per_auth = collector_data.get('consensus_method_info', {}).get('per_authority', {})
                 # Try matching by nickname (vote auth names are lowercase)
                 auth_methods = cm_per_auth.get(auth_nickname)
                 if auth_methods:
-                    auth_consensus_methods = auth_methods
                     auth_max_method = max(auth_methods) if auth_methods else None
             
             authority['collector_data'] = {
@@ -686,7 +678,7 @@ def get_directory_authorities_data(relay_set):
                         latency_down_count += 1
                         authority_alerts.append(f"{authority.get('nickname', 'Unknown')} is not responding (latency check failed)")
                     break
-    except Exception as e:
+    except Exception:
         # Latency check failed - continue without it
         pass
     
@@ -1053,7 +1045,6 @@ def write_pages_by_key(relay_set, k):
         # Calculate network position using DRY helper
         network_position = _compute_network_position_safe(
             i["guard_count"], i["middle_count"], i["exit_count"], len(members))
-        network_position_display = network_position.get('formatted_string', 'unknown')
         
         # Generate page context with correct breadcrumb data
         page_ctx = get_detail_page_context(relay_set, k, v)

--- a/allium/lib/progress.py
+++ b/allium/lib/progress.py
@@ -7,7 +7,6 @@ components, including memory usage reporting and time formatting.
 
 import time
 import sys
-import os
 import resource
 import threading
 

--- a/allium/lib/progress_logger.py
+++ b/allium/lib/progress_logger.py
@@ -117,42 +117,6 @@ class ProgressLogger:
         with _step_lock:
             self.progress_step += 1
     
-    def update_from_other_logger(self, other_logger):
-        """
-        Update this logger's step count from another ProgressLogger instance.
-        Thread-safe.
-        
-        Args:
-            other_logger: Another ProgressLogger instance to sync from
-        """
-        with _step_lock:
-            if isinstance(other_logger, ProgressLogger):
-                self.progress_step = other_logger.progress_step
-            else:
-                # Handle cases where we're passed a simple step counter
-                if hasattr(other_logger, 'progress_step'):
-                    self.progress_step = other_logger.progress_step
-    
-    def create_child_logger(self, api_name=""):
-        """
-        Create a child logger that includes an API name prefix in messages.
-        
-        Args:
-            api_name: Name to prefix in log messages
-            
-        Returns:
-            Function that can be used as a progress logger with API prefix
-        """
-        def child_log(message):
-            if api_name:
-                formatted_message = f"{api_name} - {message}"
-            else:
-                formatted_message = message
-            self.log_with_increment(formatted_message)
-        
-        return child_log
-
-
 def create_progress_logger(start_time=None, progress_step=0, total_steps=53, progress_enabled=True):
     """
     Factory function to create a ProgressLogger instance.
@@ -170,23 +134,3 @@ def create_progress_logger(start_time=None, progress_step=0, total_steps=53, pro
 
 
 # Legacy compatibility functions that delegate to ProgressLogger
-def log_step_progress(message, start_time, progress_step, total_steps, progress_enabled, increment=True):
-    """
-    Legacy compatibility function for allium.py log_step_progress.
-    
-    Note: This returns the updated progress_step for backwards compatibility.
-    """
-    logger = ProgressLogger(start_time, progress_step, total_steps, progress_enabled)
-    logger.log(message, increment_step=increment)
-    return logger.progress_step
-
-
-def log_progress_with_step_increment(message, logger):
-    """
-    Legacy compatibility function for coordinator.py _log_progress_with_step_increment.
-    
-    Args:
-        message: Progress message
-        logger: ProgressLogger instance to use
-    """
-    logger.log_with_increment(message)

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -10,23 +10,15 @@ import functools
 import hashlib
 import multiprocessing as mp
 import os
-import re
 import time
 from .aroileaders import _calculate_aroi_leaderboards
 from .ip_utils import safe_parse_ip_address as _safe_parse_ip_address
 from .progress_logger import ProgressLogger
-from .bandwidth_formatter import (
-    BandwidthFormatter,
-    format_bandwidth_with_unit,
-    determine_unit_filter,
-    format_bandwidth_filter
-)
+from .bandwidth_formatter import BandwidthFormatter
 from .stability_utils import compute_relay_stability
 from .intelligence_engine import IntelligenceEngine
-from .ip_utils import is_private_ip_address, determine_ipv6_support
 from .time_utils import (
     parse_onionoo_timestamp,
-    create_time_thresholds,
     format_timestamp_gmt,
     format_time_ago,
 )
@@ -47,7 +39,6 @@ from .aroi_validation import (
 
 # Page writing infrastructure imported from page_writer.py
 from .page_writer import (
-    _compute_network_position_safe,
     _compute_contact_predata,
     _compute_family_predata,
     _init_precompute_worker,

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -888,19 +888,6 @@ class Relays:
         from .flag_analysis import sort_by_observed_bandwidth
         sort_by_observed_bandwidth(self.json)
 
-    def _write_timestamp(self):
-        """
-        Store encoded timestamp in a file to retain time of last request, passed
-        to onionoo via If-Modified-Since header during fetch() if exists
-        """
-        timestamp = time.time()
-        f_timestamp = format_timestamp_gmt(timestamp)
-        if self.json is not None:
-            with open(self.ts_file, "w", encoding="utf8") as ts_file:
-                ts_file.write(f_timestamp)
-        
-        return f_timestamp
-
     def _calculate_network_totals(self):
         """Calculate network totals using three counting methodologies."""
         from .categorization import calculate_network_totals
@@ -1251,11 +1238,6 @@ class Relays:
         self.json['smart_context'] = engine.analyze_all_layers()
         self.progress_step += 1
         self._log_progress("Tier 1 intelligence analysis complete")
-
-    def create_output_dir(self):
-        """Ensure self.output_dir exists (required for write functions)."""
-        from .page_writer import create_output_dir
-        create_output_dir(self)
 
     def write_misc(self, template, path, page_ctx=None, sorted_by=None, reverse=True, is_index=False):
         """Render and write unsorted HTML listings to disk."""

--- a/allium/lib/statistical_utils.py
+++ b/allium/lib/statistical_utils.py
@@ -8,7 +8,6 @@ This module consolidates statistical calculations that were duplicated across:
 - relays.py (z-score calculations)
 """
 
-import math
 import statistics
 import sys
 from typing import List, Dict, Optional
@@ -230,108 +229,7 @@ class StatisticalUtils:
             # Handle case where all values are identical (std dev = 0)
             return {'low_outliers': [], 'high_outliers': []}
     
-    @staticmethod
-    def calculate_z_score(value: float, mean: float, std_dev: float) -> Optional[float]:
-        """
-        Calculate z-score (standard score) for a value.
-        
-        Consolidates z-score calculation logic from relays.py.
-        
-        Args:
-            value: Value to calculate z-score for
-            mean: Mean of the distribution
-            std_dev: Standard deviation of the distribution
-            
-        Returns:
-            Z-score or None if std_dev is 0
-        """
-        if std_dev == 0:
-            return None
-        
-        return (value - mean) / std_dev
-    
-    @staticmethod
-    def classify_by_z_score(z_score: Optional[float], 
-                           thresholds: Dict[str, float] = None) -> str:
-        """
-        Classify a value based on its z-score.
-        
-        Consolidates z-score classification logic from relays.py.
-        
-        Args:
-            z_score: Calculated z-score
-            thresholds: Custom thresholds for classification
-            
-        Returns:
-            Classification string
-        """
-        if z_score is None:
-            return 'insufficient_data'
-        
-        if thresholds is None:
-            thresholds = {
-                'high_outlier': 2.0,
-                'above_average': 0.3,
-                'low_outlier': -2.0
-            }
-        
-        if z_score >= thresholds.get('high_outlier', 2.0):
-            return 'high_outlier'
-        elif z_score >= thresholds.get('above_average', 0.3):
-            return 'above_average'
-        elif z_score <= thresholds.get('low_outlier', -2.0):
-            return 'low_outlier'
-        else:
-            return 'normal'
-    
-    @staticmethod
-    def calculate_confidence_intervals(values: List[float], confidence_level: float = 0.95) -> Optional[Dict[str, float]]:
-        """
-        Calculate confidence intervals for a dataset.
-        
-        Provides additional statistical utility for future enhancements.
-        
-        Args:
-            values: List of numeric values
-            confidence_level: Confidence level (0.0-1.0)
-            
-        Returns:
-            Dictionary with lower_bound, upper_bound, margin_of_error
-        """
-        if len(values) < 2:
-            return None
-        
-        try:
-            mean = statistics.mean(values)
-            std_dev = statistics.stdev(values)
-            n = len(values)
-            
-            # Use t-distribution for small samples (n < 30) or normal for large samples
-            if n < 30:
-                # Simplified t-distribution approximation
-                t_value = 2.0 if confidence_level >= 0.95 else 1.7
-            else:
-                # Normal distribution z-scores
-                t_value = 1.96 if confidence_level >= 0.95 else 1.64
-            
-            margin_of_error = t_value * (std_dev / math.sqrt(n))
-            
-            return {
-                'lower_bound': mean - margin_of_error,
-                'upper_bound': mean + margin_of_error,
-                'margin_of_error': margin_of_error,
-                'mean': mean
-            }
-        except statistics.StatisticsError:
-            return None
-
-
 # Convenience functions for backwards compatibility
-def calculate_percentile(data: List[float], percentile: float) -> float:
-    """Backwards compatibility wrapper for StatisticalUtils.calculate_percentile"""
-    return StatisticalUtils.calculate_percentile(data, percentile)
-
-
 def calculate_statistical_outliers(values: List[float], data_mapping: Dict[str, Dict] = None, 
                                   std_dev_threshold: float = 2.0) -> Dict[str, List[Dict]]:
     """Backwards compatibility wrapper for StatisticalUtils.calculate_outliers"""

--- a/allium/lib/statistical_utils.py
+++ b/allium/lib/statistical_utils.py
@@ -228,9 +228,3 @@ class StatisticalUtils:
         except statistics.StatisticsError:
             # Handle case where all values are identical (std dev = 0)
             return {'low_outliers': [], 'high_outliers': []}
-    
-# Convenience functions for backwards compatibility
-def calculate_statistical_outliers(values: List[float], data_mapping: Dict[str, Dict] = None, 
-                                  std_dev_threshold: float = 2.0) -> Dict[str, List[Dict]]:
-    """Backwards compatibility wrapper for StatisticalUtils.calculate_outliers"""
-    return StatisticalUtils.calculate_outliers(values, data_mapping, std_dev_threshold)

--- a/allium/lib/statistical_utils.py
+++ b/allium/lib/statistical_utils.py
@@ -11,7 +11,7 @@ This module consolidates statistical calculations that were duplicated across:
 import math
 import statistics
 import sys
-from typing import List, Dict, Any, Optional, Tuple
+from typing import List, Dict, Optional
 
 
 class StatisticalUtils:

--- a/allium/lib/string_utils.py
+++ b/allium/lib/string_utils.py
@@ -11,13 +11,7 @@ This module is maintained for backward compatibility.
 from typing import Optional
 
 # Import from centralized HTML escaping utilities
-from .html_escape_utils import (
-    safe_html_escape,
-    UNKNOWN_ESCAPED,
-    UNKNOWN_LOWERCASE, 
-    NONE_ESCAPED,
-    NA_FALLBACK
-)
+from .html_escape_utils import NA_FALLBACK
 
 
 def is_valid_aroi(aroi: Optional[str]) -> bool:

--- a/allium/lib/string_utils.py
+++ b/allium/lib/string_utils.py
@@ -41,35 +41,6 @@ def is_valid_aroi(aroi: Optional[str]) -> bool:
     """
     return bool(aroi) and aroi != 'none'
 
-def format_percentage(value, decimals=1, fallback=NA_FALLBACK):
-    """
-    Format a decimal value as a percentage with consistent decimal places.
-    
-    Delegates to format_percentage_from_fraction (identical logic, single implementation).
-    
-    Args:
-        value: Decimal value (e.g., 0.1234 for 12.34%)
-        decimals: Number of decimal places (default: 1)
-        fallback: Fallback string for None/invalid values (default: "N/A")
-    
-    Returns:
-        str: Formatted percentage string (e.g., "12.3%")
-    """
-    return format_percentage_from_fraction(value, decimals, fallback)
-
-def format_percentage_or_na(value, decimals=2):
-    """
-    Format a fraction as percentage or return "N/A" - specialized for relay data.
-    
-    Args:
-        value: Decimal fraction value 
-        decimals: Number of decimal places (default: 2 for relay probabilities)
-    
-    Returns:
-        str: Formatted percentage or "N/A"
-    """
-    return format_percentage(value, decimals, NA_FALLBACK)
-
 def format_percentage_from_fraction(value, decimals=1, fallback=NA_FALLBACK):
     """
     Format a fraction as percentage (multiply by 100) with consistent decimal places.

--- a/allium/lib/uptime_utils.py
+++ b/allium/lib/uptime_utils.py
@@ -10,19 +10,6 @@ from .error_handlers import handle_calculation_errors
 from .statistical_utils import StatisticalUtils
 
 
-def normalize_uptime_value(raw_value):
-    """
-    Normalize uptime value from Onionoo's 0-999 scale to 0-100 percentage.
-    
-    Args:
-        raw_value (int): Raw uptime value from Onionoo API (0-999)
-        
-    Returns:
-        float: Normalized percentage (0.0-100.0)
-    """
-    return raw_value / 999 * 100
-
-
 def _compute_uptime_percentage_and_datapoints(uptime_values):
     """
     Compute uptime percentage and valid datapoint count in a single pass.

--- a/allium/lib/uptime_utils.py
+++ b/allium/lib/uptime_utils.py
@@ -6,7 +6,6 @@ to avoid duplication between aroileaders.py and relays.py.
 """
 
 import statistics
-import math
 from .error_handlers import handle_calculation_errors
 from .statistical_utils import StatisticalUtils
 

--- a/allium/lib/workers.py
+++ b/allium/lib/workers.py
@@ -798,17 +798,10 @@ def fetch_onionoo_details(onionoo_url="https://onionoo.torproject.org/details", 
     Returns:
         dict: JSON response from onionoo API
     """
-    # Create a wrapper logger that prints if no logger provided (for backwards compatibility)
-    def log_wrapper(message):
-        if progress_logger:
-            progress_logger(message)
-        else:
-            print(message)
-    
     return _fetch_with_cache_fallback(
         url=onionoo_url,
         config=DETAILS_CONFIG,
-        progress_logger=log_wrapper,
+        progress_logger=progress_logger or print,
     )
 
 
@@ -883,17 +876,10 @@ def fetch_aroi_validation(aroi_url="https://aroivalidator.1aeo.com/latest.json",
     Returns:
         dict: JSON response with AROI validation data
     """
-    # Create a wrapper logger that prints if no logger provided (for backwards compatibility)
-    def log_wrapper(message):
-        if progress_logger:
-            progress_logger(message)
-        else:
-            print(message)
-    
     return _fetch_with_cache_fallback(
         url=aroi_url,
         config=AROI_CONFIG,
-        progress_logger=log_wrapper,
+        progress_logger=progress_logger or print,
         return_fresh_cache=True,  # Return fresh cache immediately without fetching
         validator=_validate_aroi_response,
     )
@@ -932,16 +918,10 @@ def fetch_exit_dns_health(exit_dns_health_url="https://exitdnshealth.1aeo.com/la
     Returns:
         dict: JSON response with exit DNS health data
     """
-    def log_wrapper(message):
-        if progress_logger:
-            progress_logger(message)
-        else:
-            print(message)
-
     return _fetch_with_cache_fallback(
         url=exit_dns_health_url,
         config=EXIT_DNS_HEALTH_CONFIG,
-        progress_logger=log_wrapper,
+        progress_logger=progress_logger or print,
         return_fresh_cache=True,
         validator=_validate_exit_dns_health_response,
     )

--- a/allium/lib/workers.py
+++ b/allium/lib/workers.py
@@ -10,15 +10,12 @@ import json
 import logging
 import os
 import random
-import sys
 import time
 import urllib.request
 import urllib.error
 import socket
 import threading
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from .error_handlers import handle_file_io_errors, handle_http_errors, handle_json_errors
 
 logger = logging.getLogger(__name__)
@@ -643,8 +640,6 @@ def _fetch_with_cache_fallback(
     
     # If cache is fresh and valid, optionally return immediately
     if return_fresh_cache and cache_age is not None and cache_age < cache_max_age_seconds and cached_data:
-        cache_age_display = cache_age / 3600 if cache_age >= 3600 else cache_age / 60
-        cache_unit = "hours" if cache_age >= 3600 else "minutes"
         log_progress(f"using cached {display_name} data (less than {cache_max_age_hours} hour(s) old)")
         _mark_ready(api_name)
         item_count = len(cached_data.get(config.count_field, []))
@@ -697,7 +692,7 @@ def _fetch_with_cache_fallback(
             log_fn=log_progress,
             operation_name=display_name,
         )
-    except TotalTimeoutError as e:
+    except TotalTimeoutError:
         elapsed = time.time() - fetch_start
         log_progress(f"request exceeded total timeout of {timeout_seconds}s after {elapsed:.1f}s total (includes retries)...")
         if cached_data:

--- a/allium/lib/workers.py
+++ b/allium/lib/workers.py
@@ -306,12 +306,11 @@ EXIT_DNS_HEALTH_CONFIG = APIConfig(
 
 
 # Use centralized file I/O utilities
-from .file_io_utils import create_cache_manager, create_timestamp_manager, create_state_manager
+from .file_io_utils import create_cache_manager, create_timestamp_manager
 
 # Initialize file managers
 _cache_manager = create_cache_manager(CACHE_DIR)
 _timestamp_manager = create_timestamp_manager(CACHE_DIR)
-_state_manager = create_state_manager(STATE_FILE)
 
 def _save_cache(api_name, data):
     """

--- a/compare_outputs.py
+++ b/compare_outputs.py
@@ -148,8 +148,8 @@ def classify_file(args):
             return ('timestamp_only', rel_path)
         return ('content_diff', rel_path)
 
-    # Same line count: only normalize the lines that differ
-    for b_line, a_line in zip(baseline_lines, after_lines, strict=True):
+    # Same line count (verified above): only normalize the lines that differ
+    for b_line, a_line in zip(baseline_lines, after_lines):
         if b_line != a_line:
             if VOLATILE_RE.sub('', b_line) != VOLATILE_RE.sub('', a_line):
                 return ('content_diff', rel_path)

--- a/tests/integration/test_api_timeout.py
+++ b/tests/integration/test_api_timeout.py
@@ -12,6 +12,7 @@ import http.server
 import json
 import os
 import socketserver
+import sys
 import threading
 import time
 from datetime import datetime

--- a/tests/integration/test_aroi_pagination.py
+++ b/tests/integration/test_aroi_pagination.py
@@ -24,7 +24,8 @@ class TestAROIPaginationSystem(unittest.TestCase):
         )
         
         # Add custom filters for template compatibility
-        from allium.lib.relays import determine_unit_filter, format_bandwidth_with_unit, format_bandwidth_filter, format_time_ago
+        from allium.lib.bandwidth_formatter import determine_unit_filter, format_bandwidth_with_unit, format_bandwidth_filter
+        from allium.lib.time_utils import format_time_ago
         self.jinja_env.filters['determine_unit'] = determine_unit_filter
         self.jinja_env.filters['format_bandwidth_with_unit'] = format_bandwidth_with_unit
         self.jinja_env.filters['format_bandwidth'] = format_bandwidth_filter
@@ -404,7 +405,8 @@ class TestPaginationIntegration(unittest.TestCase):
         )
         
         # Add custom filters for template compatibility
-        from allium.lib.relays import determine_unit_filter, format_bandwidth_with_unit, format_bandwidth_filter, format_time_ago
+        from allium.lib.bandwidth_formatter import determine_unit_filter, format_bandwidth_with_unit, format_bandwidth_filter
+        from allium.lib.time_utils import format_time_ago
         jinja_env.filters['determine_unit'] = determine_unit_filter
         jinja_env.filters['format_bandwidth_with_unit'] = format_bandwidth_with_unit
         jinja_env.filters['format_bandwidth'] = format_bandwidth_filter

--- a/tests/integration/test_authorities.py
+++ b/tests/integration/test_authorities.py
@@ -7,6 +7,7 @@ Test suite for directory authorities functionality
 import json
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from unittest.mock import Mock, patch, mock_open

--- a/tests/integration/test_contact_template.py
+++ b/tests/integration/test_contact_template.py
@@ -23,7 +23,8 @@ class TestContactTemplateIntegration(unittest.TestCase):
         )
         
         # Add custom filters for template compatibility
-        from allium.lib.relays import determine_unit_filter, format_bandwidth_with_unit, format_bandwidth_filter, format_time_ago
+        from allium.lib.bandwidth_formatter import determine_unit_filter, format_bandwidth_with_unit, format_bandwidth_filter
+        from allium.lib.time_utils import format_time_ago
         self.jinja_env.filters['determine_unit'] = determine_unit_filter
         self.jinja_env.filters['format_bandwidth_with_unit'] = format_bandwidth_with_unit
         self.jinja_env.filters['format_bandwidth'] = format_bandwidth_filter

--- a/tests/unit/coordinator/test_coordinator.py
+++ b/tests/unit/coordinator/test_coordinator.py
@@ -86,7 +86,6 @@ class TestCoordinator:
         assert coordinator.start_time == start_time
         assert coordinator.progress_step == progress_step
         assert coordinator.total_steps == total_steps
-        assert coordinator.workers == {}
         assert coordinator.worker_data == {}
     
     def test_coordinator_initialization_uses_default_values_when_minimal_parameters_provided(self):
@@ -617,16 +616,6 @@ class TestCoordinatorMultiAPI:
         
         result = coordinator.get_consensus_health_data()
         assert result == mock_health_data
-    
-    def test_get_collector_data(self):
-        """Test getting collector data from coordinator"""
-        mock_collector_data = {"authorities": [{"name": "test"}]}
-        
-        coordinator = make_coordinator()
-        coordinator.worker_data = {'collector': mock_collector_data}
-        
-        result = coordinator.get_collector_data()
-        assert result == mock_collector_data
     
     def test_create_relay_set_with_additional_apis(self):
         """Test relay set creation with additional API data attached via enrich_with_api_data"""

--- a/tests/unit/infrastructure/test_infrastructure.py
+++ b/tests/unit/infrastructure/test_infrastructure.py
@@ -32,7 +32,8 @@ def test_all_jinja2_templates_have_valid_syntax_without_errors():
     env = Environment(loader=FileSystemLoader(template_dir))
     
     # Add custom filters for template compatibility
-    from allium.lib.relays import determine_unit_filter, format_bandwidth_with_unit, format_bandwidth_filter, format_time_ago
+    from allium.lib.bandwidth_formatter import determine_unit_filter, format_bandwidth_with_unit, format_bandwidth_filter
+    from allium.lib.time_utils import format_time_ago
     env.filters['determine_unit'] = determine_unit_filter
     env.filters['format_bandwidth_with_unit'] = format_bandwidth_with_unit
     env.filters['format_bandwidth'] = format_bandwidth_filter

--- a/tests/unit/relays/test_network_health.py
+++ b/tests/unit/relays/test_network_health.py
@@ -6,7 +6,8 @@ Test network health dashboard calculations and metrics
 import unittest
 from unittest.mock import Mock, patch
 
-from allium.lib.relays import Relays, determine_ipv6_support
+from allium.lib.relays import Relays
+from allium.lib.ip_utils import determine_ipv6_support
 
 class TestNetworkHealthDashboard(unittest.TestCase):
     

--- a/tests/unit/uptime/test_flag_uptime.py
+++ b/tests/unit/uptime/test_flag_uptime.py
@@ -18,7 +18,6 @@ from unittest.mock import patch, MagicMock
 
 from allium.lib.relays import Relays
 from allium.lib.uptime_utils import (
-    normalize_uptime_value, 
     calculate_relay_uptime_average,
     extract_relay_uptime_for_period,
     calculate_statistical_outliers
@@ -27,17 +26,6 @@ from allium.lib.uptime_utils import (
 
 class TestFlagUptimeCalculation(unittest.TestCase):
     """Test core flag uptime calculation logic"""
-    
-    def test_uptime_value_normalization(self):
-        """Test conversion from Onionoo 0-999 scale to 0-100 percentage"""
-        # Test boundary values
-        self.assertAlmostEqual(normalize_uptime_value(0), 0.0, places=2)
-        self.assertAlmostEqual(normalize_uptime_value(999), 100.0, places=2)
-        
-        # Test typical values - allow for more precision
-        self.assertAlmostEqual(normalize_uptime_value(950), 95.095, places=2)
-        self.assertAlmostEqual(normalize_uptime_value(800), 80.080, places=2)
-        self.assertAlmostEqual(normalize_uptime_value(500), 50.050, places=2)
     
     def test_relay_uptime_average_calculation(self):
         """Test averaging of multiple uptime data points"""

--- a/tests/unit/uptime/test_percentiles.py
+++ b/tests/unit/uptime/test_percentiles.py
@@ -12,8 +12,7 @@ from allium.lib.uptime_utils import (
     calculate_network_uptime_percentiles,
     find_operator_percentile_position,
     format_network_percentiles_display,
-    calculate_relay_uptime_average,
-    normalize_uptime_value
+    calculate_relay_uptime_average
 )
 
 
@@ -175,12 +174,6 @@ class TestNetworkUptimePercentiles(unittest.TestCase):
         values_low = [10, 5, 8] * 15  # 45 values but very low uptime
         average_low = calculate_relay_uptime_average(values_low)
         self.assertEqual(average_low, 0.0)
-        
-    def test_normalize_uptime_value(self):
-        """Test uptime value normalization from 0-999 to 0-100."""
-        self.assertEqual(normalize_uptime_value(0), 0.0)
-        self.assertEqual(normalize_uptime_value(999), 100.0)
-        self.assertAlmostEqual(normalize_uptime_value(500), 50.05, places=1)
         
     def test_data_filtering_logic(self):
         """Test that data filtering works correctly."""

--- a/tests/unit/uptime/test_uptime_utils.py
+++ b/tests/unit/uptime/test_uptime_utils.py
@@ -15,7 +15,6 @@ import time
 import unittest
 
 from allium.lib.uptime_utils import (
-    normalize_uptime_value,
     calculate_relay_uptime_average,
     find_relay_uptime_data,
     extract_relay_uptime_for_period,
@@ -26,22 +25,6 @@ from allium.lib.uptime_utils import (
 
 class TestUptimeNormalization(unittest.TestCase):
     """Test uptime value normalization functions"""
-    
-    def test_normalize_uptime_value(self):
-        """Test normalization from Onionoo 0-999 scale to 0-100 percentage"""
-        # Test boundary values
-        self.assertAlmostEqual(normalize_uptime_value(0), 0.0, places=3)
-        self.assertAlmostEqual(normalize_uptime_value(999), 100.0, places=3) 
-        
-        # Test typical values
-        self.assertAlmostEqual(normalize_uptime_value(950), 95.095, places=3)
-        self.assertAlmostEqual(normalize_uptime_value(800), 80.080, places=3)
-        self.assertAlmostEqual(normalize_uptime_value(500), 50.050, places=3)
-        self.assertAlmostEqual(normalize_uptime_value(250), 25.025, places=3)
-        
-        # Test mid-range values
-        self.assertAlmostEqual(normalize_uptime_value(750), 75.075, places=3)
-        self.assertAlmostEqual(normalize_uptime_value(900), 90.090, places=3)
     
     def test_calculate_relay_uptime_average(self):
         """Test averaging of multiple uptime data points"""


### PR DESCRIPTION
Implements the LOC-reduction plan from #211: delete verified dead code and merge verbatim duplication with zero behavior change. Net **−1,105 lines** across 8 commits.

## What's in here

- **Batch 4** — unused imports and dead local assignments across 20 production modules (flake8 F401/F811/F841), plus a Python 3.9 compatibility fix for `compare_outputs.py` (`zip(strict=)` is 3.10+; the repo supports 3.8+) and two missing `sys` imports in test `__main__` blocks.
- **Batch 1** — ~30 dead symbols, each grep-gated to definition-only (or definition+tests, deleted together): the unused escaping class hierarchy remnants, z-score/confidence-interval statistics, legacy progress wrappers, dead `Relays` methods, and more. Plan errata found and honored: `_write_timestamp` has a live `workers.py` namesake (kept), `calculate_statistical_outliers`'s uptime_utils twin is the live one.
- **Batch 2** — the unreachable contact-page branches in `page_writer` (contacts are routed to dedicated renderers before the generic loop): sequential contact logic, both vanity-URL blocks. Contact page count verified identical (3,076) before/after.
- **Batch 3** — dead file-io plumbing (`BulkFileOperations`, `TestFileHelper`, unified-manager factory, the `_state_manager` global). The consensus-health path and `fetch_collector_data` are intentionally **kept** per the plan.
- **Batch 5** — five duplication merges, riskiest last: daily-bandwidth aggregation loop, breakdown-details double list, `log_wrapper` closures, the 19-category leaderboard switchboard → module-level dispatch tables, and the flag/operator uptime-vs-bandwidth display-processor pairs (every difference parameterized — `al-status-*` vs `al-status-*-bold` classes, thresholds, error strings — none normalized).

## Verification (every commit)

Full-site byte-diff gate on pinned API inputs (frozen onionoo snapshots served locally, `TZ=UTC`, `PYTHONHASHSEED=0`, back-to-back baseline/after runs): all diffs classified as known clock noise. For the two risky Batch-5 refactors, old-vs-new deep-equality harnesses ran before the site gate (19 categories × 5 ranks × 106 keys deep-equal; 1,416 lines of sorted JSON byte-equal at threshold boundaries). `pytest` green throughout; flake8 `E9,F63,F7,F82` clean.

Part 1 of a 3-PR stack: this PR → #<bug-fixes> → #<simplification>. Merge this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved leaderboard and contact-page displays with richer ranking, badge, and tooltip information.
  * Added clearer reliability and bandwidth indicators in operator and flag views.

* **Bug Fixes**
  * Fixed several edge cases in page rendering and data formatting.
  * Improved error handling and reduced failures from missing or invalid values.

* **Refactor**
  * Streamlined file handling, progress reporting, and page generation for better maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->