### PR TITLE
Fix IPv6 column always showing N/A on contact/family pages

### DIFF
--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -478,7 +478,28 @@ class Relays:
                 relay["ip_address"] = parsed_ip or UNKNOWN_LOWERCASE
             else:
                 relay["ip_address"] = UNKNOWN_LOWERCASE
-                
+
+            # Pre-parse first IPv6 address for the contact/family page IPv6 column.
+            # (Fixes Jinja2 for-loop scoping bug that made the template always render N/A:
+            # {% set %} inside {% for %} does not survive past {% endfor %}.)
+            # NOTE: named ipv6_display_address, NOT ipv6_address — that key already exists
+            # in the collector/consensus vote dicts with different semantics ('a' line
+            # including brackets and port).
+            relay["ipv6_display_address"] = ""
+            for addr in or_addrs or []:
+                parsed_ip, ip_version = _safe_parse_ip_address(addr)
+                if ip_version == 6:
+                    relay["ipv6_display_address"] = parsed_ip
+                    break
+
+            # Guarantee ipv6_support as a preprocessing output (used by the template's
+            # table_has_ipv6 header gate and contact_sorting.relay_has_ipv6). Previously
+            # only set as a side effect of network_health.calculate_network_health_metrics,
+            # which created a hidden pipeline-ordering dependency. network_health keeps its
+            # idempotent assignment (same function, same input).
+            relay["ipv6_support"] = determine_ipv6_support(or_addrs)
+
+
             # Optimization 11: Pre-compute uptime/downtime display based on last_restarted and running status
             relay["uptime_display"] = self._calculate_uptime_display(relay)
             

--- a/allium/lib/relays.py
+++ b/allium/lib/relays.py
@@ -12,7 +12,7 @@ import multiprocessing as mp
 import os
 import time
 from .aroileaders import _calculate_aroi_leaderboards
-from .ip_utils import safe_parse_ip_address as _safe_parse_ip_address
+from .ip_utils import determine_ipv6_support, safe_parse_ip_address as _safe_parse_ip_address
 from .network_health import calculate_network_health_metrics
 from .operator_analysis import calculate_uptime_display
 from .progress_logger import ProgressLogger

--- a/allium/templates/contact-relay-list.html
+++ b/allium/templates/contact-relay-list.html
@@ -291,21 +291,13 @@
             unknown
         {% endif -%}
     </td>
-    {# PERF: IPv6 column uses pre-computed table_has_ipv6 flag (O(1) instead of O(n²)) #}
+    {# PERF: IPv6 address pre-computed in Python (relays.py _preprocess_template_data).
+       Jinja2 set-inside-for does not survive endfor, so the old in-template loop
+       always rendered N/A (scoping bug). #}
     {% if table_has_ipv6 -%}
     <td>
-        {% set ipv6_found = false -%}
-        {% set ipv6_addr = '' -%}
-        {% if relay.get('or_addresses') -%}
-            {% for addr in relay['or_addresses'] -%}
-                {% if ':' in addr and addr.count(':') > 1 and not ipv6_found -%}
-                    {% set ipv6_addr = addr.split(']')[0].lstrip('[') -%}
-                    {% set ipv6_found = true -%}
-                {% endif -%}
-            {% endfor -%}
-        {% endif -%}
-        {% if ipv6_found -%}
-            {{ ipv6_addr|escape }}
+        {% if relay.get('ipv6_display_address') -%}
+            {{ relay['ipv6_display_address']|escape }}
         {% else -%}
             N/A
         {% endif -%}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -313,32 +313,57 @@ def patch_relays_methods():
 
 
 @pytest.fixture
-def jinja_env():
+def templates_dir():
+    """Fixture that provides the allium templates directory as a Path."""
+    return project_root / 'allium' / 'templates'
+
+
+@pytest.fixture
+def jinja_env(templates_dir):
     """Fixture that provides a configured Jinja2 environment for template testing."""
     from jinja2 import Environment, FileSystemLoader, select_autoescape
     
-    template_dir = project_root / 'allium' / 'templates'
     env = Environment(
-        loader=FileSystemLoader(str(template_dir)),
+        loader=FileSystemLoader(str(templates_dir)),
         autoescape=select_autoescape(['html', 'xml'])
     )
     
-    # Add custom filters for template compatibility
-    try:
-        from allium.lib.relays import (
-            determine_unit_filter, 
-            format_bandwidth_with_unit, 
-            format_bandwidth_filter, 
-            format_time_ago
-        )
-        env.filters['determine_unit'] = determine_unit_filter
-        env.filters['format_bandwidth_with_unit'] = format_bandwidth_with_unit
-        env.filters['format_bandwidth'] = format_bandwidth_filter
-        env.filters['format_time_ago'] = format_time_ago
-    except ImportError:
-        pass  # Filters may not be available in all test contexts
+    # Add custom filters for template compatibility.
+    # NOTE: these moved out of allium.lib.relays in the simplification refactor;
+    # import from their canonical homes so the filters are actually registered.
+    from allium.lib.bandwidth_formatter import (
+        determine_unit_filter,
+        format_bandwidth_with_unit,
+        format_bandwidth_filter,
+    )
+    from allium.lib.time_utils import format_time_ago
+    env.filters['determine_unit'] = determine_unit_filter
+    env.filters['format_bandwidth_with_unit'] = format_bandwidth_with_unit
+    env.filters['format_bandwidth'] = format_bandwidth_filter
+    env.filters['format_time_ago'] = format_time_ago
     
     return env
+
+
+@pytest.fixture
+def process_relays(tmp_path):
+    """Factory fixture: run the full (unpatched) Relays init pipeline on raw
+    onionoo-shaped relay dicts and return the Relays instance.
+
+    Use this when a test must exercise real preprocessing
+    (_preprocess_template_data et al.). Unlike
+    TestSetupHelpers.create_test_relays_instance, nothing is mocked out.
+    """
+    def _process(relays):
+        from allium.lib.relays import Relays
+        return Relays(
+            output_dir=str(tmp_path),
+            onionoo_url='https://test.example.com',
+            relay_data={'relays': relays},
+            use_bits=False,
+            progress=False,
+        )
+    return _process
 
 
 # ============================================================================

--- a/tests/integration/test_contact_template.py
+++ b/tests/integration/test_contact_template.py
@@ -874,6 +874,22 @@ class TestContactMultiprocessingRegression(unittest.TestCase):
 
         self.assertFalse(os.path.exists(os.path.join(contact_dir, "by-bandwidth.html")))
 
+        # Regression (IPv6 always-N/A bug): the full pipeline must render the
+        # actual IPv6 address in the IPv6 column, not N/A. Relay1 is dual-stack
+        # ([2001:db8::1]:9001); Relay2/Relay3 are IPv4-only.
+        # This test goes through real preprocessing (relay['ipv6_display_address'])
+        # so it guards the Python↔template contract that hand-built contexts can't.
+        for filename in ("index.html", "by-ipv6.html"):
+            with open(os.path.join(contact_dir, filename), encoding="utf8") as f:
+                rendered = f.read()
+            self.assertIn("2001:db8::1", rendered,
+                          f"{filename}: dual-stack relay's IPv6 address missing from IPv6 column")
+            # IPv4-only relay rows must still render N/A in their IPv6 cell
+            relay2_row = next(chunk for chunk in rendered.split("<tr>")
+                              if 'title="Relay2"' in chunk)
+            self.assertNotIn("2001:db8::1", relay2_row)
+            self.assertIn("N/A", relay2_row)
+
     def test_contact_page_generation_threshold_small_contacts(self):
         """Contacts with ≤2 relays should get only index.html (no sort variants)."""
         relay_set = Relays(
@@ -1268,6 +1284,170 @@ class TestB3V3RelayInfoRendering(unittest.TestCase):
         self.assertIn('🚨', rendered)
         # Pasteable rotation command surfaced
         self.assertIn('tor --keygen-family', rendered)
+
+
+class TestContactTemplateIPv6Column(unittest.TestCase):
+    """Regression tests for the IPv6 column always-N/A bug.
+
+    Root cause: the old template extracted the IPv6 address with {% set %}
+    inside a {% for %} loop; Jinja2 loop-local bindings don't survive past
+    {% endfor %}, so every row rendered N/A. The fix precomputes
+    relay['ipv6_display_address'] in Python and the template does a plain
+    dict lookup. These tests render the real contact.html and assert on the
+    produced HTML (they would have caught the original bug).
+    """
+
+    def setUp(self):
+        template_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'allium', 'templates')
+        self.jinja_env = Environment(
+            loader=FileSystemLoader(template_dir),
+            autoescape=select_autoescape(['html', 'xml'])
+        )
+        from allium.lib.relays import determine_unit_filter, format_bandwidth_with_unit, format_bandwidth_filter, format_time_ago
+        self.jinja_env.filters['determine_unit'] = determine_unit_filter
+        self.jinja_env.filters['format_bandwidth_with_unit'] = format_bandwidth_with_unit
+        self.jinja_env.filters['format_bandwidth'] = format_bandwidth_filter
+        self.jinja_env.filters['format_time_ago'] = format_time_ago
+
+    @staticmethod
+    def _make_relay(fingerprint, nickname, dual_stack):
+        """Relay dict as the pipeline produces it (incl. precomputed fields)."""
+        relay = {
+            'fingerprint': fingerprint,
+            'nickname': nickname,
+            'country': 'us',
+            'country_name': 'United States',
+            'observed_bandwidth': 1000000,
+            'running': True,
+            'flags': ['Running', 'Valid'],
+            'flags_escaped': ['Running', 'Valid'],
+            'flags_lower_escaped': ['running', 'valid'],
+            '_flags_html': '',
+            'effective_family': [],
+            'measured': True,
+            'uptime_display': 'UP 5d 12h',
+            'uptime_api_display': '99.5%',
+            'as': 'AS7922',
+            'as_name': 'Comcast Cable',
+            'platform': 'Linux',
+            'first_seen': '2023-01-01 12:00:00',
+            'first_seen_date_escaped': '2023-01-01',
+            'contact_md5': 'abcd1234',
+        }
+        if dual_stack:
+            relay['or_addresses'] = ['1.2.3.4:9001', '[2001:db8::1]:9001']
+            relay['ipv6_display_address'] = '2001:db8::1'
+            relay['ipv6_support'] = 'both'
+        else:
+            relay['or_addresses'] = ['5.6.7.8:9001']
+            relay['ipv6_display_address'] = ''
+            relay['ipv6_support'] = 'ipv4_only'
+        return relay
+
+    def _base_context(self, relay_subset):
+        return {
+            'contact': 'test@example.com',
+            'contact_hash': 'abcd1234',
+            'bandwidth': '150.0',
+            'bandwidth_unit': 'MB/s',
+            'consensus_weight_fraction': 0.025,
+            'network_position': {
+                'label': 'mixed',
+                'formatted_string': 'Mixed (2 total relays)',
+            },
+            'relay_subset': relay_subset,
+            'relays': {
+                'json': {'relay_subset': relay_subset},
+                'use_bits': False,
+                'timestamp': '2026-01-01 00:00:00',
+            },
+            'page_ctx': {'path_prefix': '../'},
+            'contact_rankings': [],
+            'operator_reliability': None,
+            'contact_display_data': {},
+        }
+
+    @staticmethod
+    def _row_for(rendered, nickname):
+        """Return the <tr> chunk for the row with the given relay nickname."""
+        chunks = [c for c in rendered.split('<tr>') if f'title="{nickname}"' in c]
+        assert len(chunks) >= 1, f"no table row found for {nickname}"
+        return chunks[0]
+
+    def test_single_table_mode_renders_ipv6_address(self):
+        """Single-table mode: dual-stack row shows address, v4-only row shows N/A."""
+        relays = [
+            self._make_relay('A' * 40, 'DualStackRelay', dual_stack=True),
+            self._make_relay('B' * 40, 'V4OnlyRelay', dual_stack=False),
+        ]
+        template = self.jinja_env.get_template('contact.html')
+        rendered = template.render(**self._base_context(relays))
+
+        # The IPv6 column is present (a dual-stack relay is in the table)...
+        self.assertIn('<th>IPv6</th>', rendered)
+        # ...and the actual address is rendered — the original bug rendered
+        # N/A here for every relay.
+        dual_row = self._row_for(rendered, 'DualStackRelay')
+        self.assertIn('2001:db8::1', dual_row)
+
+        # IPv4-only relay must still show N/A in its IPv6 cell (last <td>).
+        v4_row = self._row_for(rendered, 'V4OnlyRelay')
+        self.assertNotIn('2001:db8::1', v4_row)
+        last_cell = v4_row.rsplit('<td>', 1)[-1]
+        self.assertIn('N/A', last_cell)
+
+    def test_ipv6_column_hidden_when_no_ipv6_relays(self):
+        """Column gating unchanged: all-v4 tables omit the IPv6 column."""
+        relays = [
+            self._make_relay('A' * 40, 'V4Relay1', dual_stack=False),
+            self._make_relay('B' * 40, 'V4Relay2', dual_stack=False),
+        ]
+        template = self.jinja_env.get_template('contact.html')
+        rendered = template.render(**self._base_context(relays))
+        self.assertNotIn('<th>IPv6</th>', rendered)
+
+    def test_sectioned_aroi_mode_renders_ipv6_address(self):
+        """4-section AROI layout renders rows through contact_validation_status
+        section entries (pickled relay copies in production) — assert the
+        validated-relays table shows the IPv6 address, not N/A."""
+        from allium.lib.aroi_validation import get_contact_validation_status
+
+        dual = self._make_relay('A' * 40, 'DualStackRelay', dual_stack=True)
+        v4only = self._make_relay('B' * 40, 'V4OnlyRelay', dual_stack=False)
+        for relay in (dual, v4only):
+            relay['aroi_domain'] = 'example.org'
+            relay['aroi_version'] = '2'
+            relay['aroi_proof_type'] = 'uri-rsa'
+            relay['contact'] = 'test@example.com'
+
+        validation_data = {
+            'metadata': {'timestamp': '2026-01-01T00:00:00Z'},
+            'results': [
+                {'fingerprint': 'A' * 40, 'valid': True,
+                 'proof_type': 'uri-rsa', 'proof_uri': 'https://example.org', 'ciissversion': '2'},
+                {'fingerprint': 'B' * 40, 'valid': True,
+                 'proof_type': 'uri-rsa', 'proof_uri': 'https://example.org', 'ciissversion': '2'},
+            ],
+        }
+        cvs = get_contact_validation_status([dual, v4only], validation_data)
+        self.assertEqual(cvs['validation_status'], 'validated')
+
+        context = self._base_context([dual, v4only])
+        context['contact_validation_status'] = cvs
+        context['aroi_validation_timestamp'] = '2026-01-01 00:00 UTC'
+
+        template = self.jinja_env.get_template('contact.html')
+        rendered = template.render(**context)
+
+        # Sectioned layout active (validated table header rendered)
+        self.assertIn('VALIDATED RELAYS', rendered)
+
+        dual_row = self._row_for(rendered, 'DualStackRelay')
+        self.assertIn('2001:db8::1', dual_row)
+        v4_row = self._row_for(rendered, 'V4OnlyRelay')
+        self.assertNotIn('2001:db8::1', v4_row)
+        last_cell = v4_row.rsplit('<td>', 1)[-1]
+        self.assertIn('N/A', last_cell)
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_contact_template.py
+++ b/tests/integration/test_contact_template.py
@@ -1288,8 +1288,9 @@ class TestB3V3RelayInfoRendering(unittest.TestCase):
         self.assertIn('tor --keygen-family', rendered)
 
 
-class TestContactTemplateIPv6Column(unittest.TestCase):
-    """Regression tests for the IPv6 column always-N/A bug.
+class TestContactTemplateIPv6Column:
+    """Regression tests for the IPv6 column always-N/A bug (pytest style,
+    using the shared jinja_env fixture from tests/conftest.py).
 
     Root cause: the old template extracted the IPv6 address with {% set %}
     inside a {% for %} loop; Jinja2 loop-local bindings don't survive past
@@ -1298,19 +1299,6 @@ class TestContactTemplateIPv6Column(unittest.TestCase):
     dict lookup. These tests render the real contact.html and assert on the
     produced HTML (they would have caught the original bug).
     """
-
-    def setUp(self):
-        template_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'allium', 'templates')
-        self.jinja_env = Environment(
-            loader=FileSystemLoader(template_dir),
-            autoescape=select_autoescape(['html', 'xml'])
-        )
-        from allium.lib.bandwidth_formatter import determine_unit_filter, format_bandwidth_with_unit, format_bandwidth_filter
-        from allium.lib.time_utils import format_time_ago
-        self.jinja_env.filters['determine_unit'] = determine_unit_filter
-        self.jinja_env.filters['format_bandwidth_with_unit'] = format_bandwidth_with_unit
-        self.jinja_env.filters['format_bandwidth'] = format_bandwidth_filter
-        self.jinja_env.filters['format_time_ago'] = format_time_ago
 
     @staticmethod
     def _make_relay(fingerprint, nickname, dual_stack):
@@ -1377,39 +1365,39 @@ class TestContactTemplateIPv6Column(unittest.TestCase):
         assert len(chunks) >= 1, f"no table row found for {nickname}"
         return chunks[0]
 
-    def test_single_table_mode_renders_ipv6_address(self):
+    def test_single_table_mode_renders_ipv6_address(self, jinja_env):
         """Single-table mode: dual-stack row shows address, v4-only row shows N/A."""
         relays = [
             self._make_relay('A' * 40, 'DualStackRelay', dual_stack=True),
             self._make_relay('B' * 40, 'V4OnlyRelay', dual_stack=False),
         ]
-        template = self.jinja_env.get_template('contact.html')
+        template = jinja_env.get_template('contact.html')
         rendered = template.render(**self._base_context(relays))
 
         # The IPv6 column is present (a dual-stack relay is in the table)...
-        self.assertIn('<th>IPv6</th>', rendered)
+        assert '<th>IPv6</th>' in rendered
         # ...and the actual address is rendered — the original bug rendered
         # N/A here for every relay.
         dual_row = self._row_for(rendered, 'DualStackRelay')
-        self.assertIn('2001:db8::1', dual_row)
+        assert '2001:db8::1' in dual_row
 
         # IPv4-only relay must still show N/A in its IPv6 cell (last <td>).
         v4_row = self._row_for(rendered, 'V4OnlyRelay')
-        self.assertNotIn('2001:db8::1', v4_row)
+        assert '2001:db8::1' not in v4_row
         last_cell = v4_row.rsplit('<td>', 1)[-1]
-        self.assertIn('N/A', last_cell)
+        assert 'N/A' in last_cell
 
-    def test_ipv6_column_hidden_when_no_ipv6_relays(self):
+    def test_ipv6_column_hidden_when_no_ipv6_relays(self, jinja_env):
         """Column gating unchanged: all-v4 tables omit the IPv6 column."""
         relays = [
             self._make_relay('A' * 40, 'V4Relay1', dual_stack=False),
             self._make_relay('B' * 40, 'V4Relay2', dual_stack=False),
         ]
-        template = self.jinja_env.get_template('contact.html')
+        template = jinja_env.get_template('contact.html')
         rendered = template.render(**self._base_context(relays))
-        self.assertNotIn('<th>IPv6</th>', rendered)
+        assert '<th>IPv6</th>' not in rendered
 
-    def test_sectioned_aroi_mode_renders_ipv6_address(self):
+    def test_sectioned_aroi_mode_renders_ipv6_address(self, jinja_env):
         """4-section AROI layout renders rows through contact_validation_status
         section entries (pickled relay copies in production) — assert the
         validated-relays table shows the IPv6 address, not N/A."""
@@ -1433,24 +1421,24 @@ class TestContactTemplateIPv6Column(unittest.TestCase):
             ],
         }
         cvs = get_contact_validation_status([dual, v4only], validation_data)
-        self.assertEqual(cvs['validation_status'], 'validated')
+        assert cvs['validation_status'] == 'validated'
 
         context = self._base_context([dual, v4only])
         context['contact_validation_status'] = cvs
         context['aroi_validation_timestamp'] = '2026-01-01 00:00 UTC'
 
-        template = self.jinja_env.get_template('contact.html')
+        template = jinja_env.get_template('contact.html')
         rendered = template.render(**context)
 
         # Sectioned layout active (validated table header rendered)
-        self.assertIn('VALIDATED RELAYS', rendered)
+        assert 'VALIDATED RELAYS' in rendered
 
         dual_row = self._row_for(rendered, 'DualStackRelay')
-        self.assertIn('2001:db8::1', dual_row)
+        assert '2001:db8::1' in dual_row
         v4_row = self._row_for(rendered, 'V4OnlyRelay')
-        self.assertNotIn('2001:db8::1', v4_row)
+        assert '2001:db8::1' not in v4_row
         last_cell = v4_row.rsplit('<td>', 1)[-1]
-        self.assertIn('N/A', last_cell)
+        assert 'N/A' in last_cell
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_contact_template.py
+++ b/tests/integration/test_contact_template.py
@@ -1305,7 +1305,8 @@ class TestContactTemplateIPv6Column(unittest.TestCase):
             loader=FileSystemLoader(template_dir),
             autoescape=select_autoescape(['html', 'xml'])
         )
-        from allium.lib.relays import determine_unit_filter, format_bandwidth_with_unit, format_bandwidth_filter, format_time_ago
+        from allium.lib.bandwidth_formatter import determine_unit_filter, format_bandwidth_with_unit, format_bandwidth_filter
+        from allium.lib.time_utils import format_time_ago
         self.jinja_env.filters['determine_unit'] = determine_unit_filter
         self.jinja_env.filters['format_bandwidth_with_unit'] = format_bandwidth_with_unit
         self.jinja_env.filters['format_bandwidth'] = format_bandwidth_filter

--- a/tests/unit/relays/test_ipv6_preprocessing.py
+++ b/tests/unit/relays/test_ipv6_preprocessing.py
@@ -7,15 +7,14 @@ Covers the fix for the contact/family page IPv6 column that always rendered
 not survive past {% endfor %}. The fix precomputes relay['ipv6_display_address']
 (and guarantees relay['ipv6_support']) in Python during preprocessing.
 
-NOTE: These tests construct Relays() directly (full unpatched __init__) so the
-real _preprocess_template_data runs. Do NOT use
+NOTE: These tests use the process_relays fixture (tests/conftest.py), which
+runs the full unpatched Relays init pipeline so the real
+_preprocess_template_data executes. Do NOT use
 TestSetupHelpers.create_test_relays_instance here — it patches
 _preprocess_template_data out.
 """
 
-import unittest
-
-from allium.lib.relays import Relays
+import pytest
 
 
 def _make_relay(fingerprint, or_addresses):
@@ -43,93 +42,54 @@ def _make_relay(fingerprint, or_addresses):
     return relay
 
 
-def _preprocess(or_addresses):
-    """Run the full Relays init pipeline on one relay, return the processed dict."""
-    relay_data = {'relays': [_make_relay('A' * 40, or_addresses)]}
-    relays_obj = Relays(
-        output_dir='/tmp/test-ipv6-preprocessing',
-        onionoo_url='https://test.example.com',
-        relay_data=relay_data,
-        use_bits=False,
-        progress=False,
-    )
-    return relays_obj.json['relays'][0]
+@pytest.mark.parametrize(
+    ('or_addresses', 'expected_address', 'expected_support'),
+    [
+        # dual-stack: IPv4 first, IPv6 second
+        (['1.2.3.4:9001', '[2001:db8::1]:9001'], '2001:db8::1', 'both'),
+        # IPv4 only
+        (['1.2.3.4:9001'], '', 'ipv4_only'),
+        # IPv6 only
+        (['[2001:db8::1]:9001'], '2001:db8::1', 'ipv6_only'),
+        # empty or_addresses
+        ([], '', 'none'),
+        # missing or_addresses key entirely
+        (None, '', 'none'),
+        # malformed entry is skipped, valid IPv6 still found
+        (['garbage', '[2001:db8::2]:443'], '2001:db8::2', 'ipv6_only'),
+        # first IPv6 wins when several are present
+        (['[2001:db8::1]:9001', '[2001:db8::2]:9001'], '2001:db8::1', 'ipv6_only'),
+        # uncompressed/zero-padded input is normalized to canonical form
+        (['[2001:0db8:0000:0000:0000:0000:0000:0001]:9001'], '2001:db8::1', 'ipv6_only'),
+        # real-world onionoo ordering from the bug report (reporter's relay)
+        (['195.133.23.252:443', '[2001:470:1f15:16b::1337:c0de]:443'],
+         '2001:470:1f15:16b::1337:c0de', 'both'),
+    ],
+    ids=[
+        'dual_stack', 'ipv4_only', 'ipv6_only', 'empty', 'missing',
+        'malformed_skipped', 'first_ipv6_wins', 'normalized', 'reporter_relay',
+    ],
+)
+def test_ipv6_display_address_preprocessing(process_relays, or_addresses,
+                                            expected_address, expected_support):
+    """relay['ipv6_display_address'] / ['ipv6_support'] from or_addresses."""
+    relays_obj = process_relays([_make_relay('A' * 40, or_addresses)])
+    relay = relays_obj.json['relays'][0]
+    assert relay['ipv6_display_address'] == expected_address
+    assert relay['ipv6_support'] == expected_support
 
 
-class TestIPv6DisplayAddressPreprocessing(unittest.TestCase):
-    """relay['ipv6_display_address'] extraction from or_addresses."""
-
-    def test_dual_stack_relay(self):
-        relay = _preprocess(['1.2.3.4:9001', '[2001:db8::1]:9001'])
-        self.assertEqual(relay['ipv6_display_address'], '2001:db8::1')
-        self.assertEqual(relay['ipv6_support'], 'both')
-
-    def test_ipv4_only_relay(self):
-        relay = _preprocess(['1.2.3.4:9001'])
-        self.assertEqual(relay['ipv6_display_address'], '')
-        self.assertEqual(relay['ipv6_support'], 'ipv4_only')
-
-    def test_ipv6_only_relay(self):
-        relay = _preprocess(['[2001:db8::1]:9001'])
-        self.assertEqual(relay['ipv6_display_address'], '2001:db8::1')
-        self.assertEqual(relay['ipv6_support'], 'ipv6_only')
-
-    def test_empty_or_addresses(self):
-        relay = _preprocess([])
-        self.assertEqual(relay['ipv6_display_address'], '')
-        self.assertEqual(relay['ipv6_support'], 'none')
-
-    def test_missing_or_addresses(self):
-        relay = _preprocess(None)
-        self.assertEqual(relay['ipv6_display_address'], '')
-        self.assertEqual(relay['ipv6_support'], 'none')
-
-    def test_malformed_address_skipped(self):
-        relay = _preprocess(['garbage', '[2001:db8::2]:443'])
-        self.assertEqual(relay['ipv6_display_address'], '2001:db8::2')
-        self.assertEqual(relay['ipv6_support'], 'ipv6_only')
-
-    def test_first_ipv6_wins(self):
-        relay = _preprocess(['[2001:db8::1]:9001', '[2001:db8::2]:9001'])
-        self.assertEqual(relay['ipv6_display_address'], '2001:db8::1')
-        self.assertEqual(relay['ipv6_support'], 'ipv6_only')
-
-    def test_ipv6_address_normalized(self):
-        """Uncompressed/zero-padded input is normalized to canonical form."""
-        relay = _preprocess(['[2001:0db8:0000:0000:0000:0000:0000:0001]:9001'])
-        self.assertEqual(relay['ipv6_display_address'], '2001:db8::1')
-
-    def test_ipv6_after_ipv4(self):
-        """Real-world onionoo ordering: IPv4 first, IPv6 second (reporter's relay)."""
-        relay = _preprocess(['195.133.23.252:443', '[2001:470:1f15:16b::1337:c0de]:443'])
-        self.assertEqual(relay['ipv6_display_address'], '2001:470:1f15:16b::1337:c0de')
-        self.assertEqual(relay['ipv6_support'], 'both')
-
-
-class TestIPv6SupportSetDuringPreprocessing(unittest.TestCase):
+def test_ipv6_support_present_without_network_health(process_relays):
     """ipv6_support must be a guaranteed preprocessing output (not a
     network_health side effect), so header gating and contact_sorting see it
     even if network health metrics were never calculated."""
-
-    def test_ipv6_support_present_without_network_health(self):
-        relay_data = {'relays': [
-            _make_relay('A' * 40, ['1.2.3.4:9001', '[2001:db8::1]:9001']),
-            _make_relay('B' * 40, ['5.6.7.8:9001']),
-        ]}
-        relays_obj = Relays(
-            output_dir='/tmp/test-ipv6-preprocessing',
-            onionoo_url='https://test.example.com',
-            relay_data=relay_data,
-            use_bits=False,
-            progress=False,
-        )
-        # No _calculate_network_health_metrics() call — preprocessing alone
-        # must have set the attribute on every relay.
-        self.assertNotIn('network_health', relays_obj.json)
-        supports = {r['fingerprint']: r['ipv6_support'] for r in relays_obj.json['relays']}
-        self.assertEqual(supports['A' * 40], 'both')
-        self.assertEqual(supports['B' * 40], 'ipv4_only')
-
-
-if __name__ == '__main__':
-    unittest.main()
+    relays_obj = process_relays([
+        _make_relay('A' * 40, ['1.2.3.4:9001', '[2001:db8::1]:9001']),
+        _make_relay('B' * 40, ['5.6.7.8:9001']),
+    ])
+    # No _calculate_network_health_metrics() call — preprocessing alone
+    # must have set the attribute on every relay.
+    assert 'network_health' not in relays_obj.json
+    supports = {r['fingerprint']: r['ipv6_support'] for r in relays_obj.json['relays']}
+    assert supports['A' * 40] == 'both'
+    assert supports['B' * 40] == 'ipv4_only'

--- a/tests/unit/relays/test_ipv6_preprocessing.py
+++ b/tests/unit/relays/test_ipv6_preprocessing.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Test per-relay IPv6 preprocessing in Relays._preprocess_template_data.
+
+Covers the fix for the contact/family page IPv6 column that always rendered
+"N/A" due to a Jinja2 for-loop scoping bug: {% set %} inside {% for %} does
+not survive past {% endfor %}. The fix precomputes relay['ipv6_display_address']
+(and guarantees relay['ipv6_support']) in Python during preprocessing.
+
+NOTE: These tests construct Relays() directly (full unpatched __init__) so the
+real _preprocess_template_data runs. Do NOT use
+TestSetupHelpers.create_test_relays_instance here — it patches
+_preprocess_template_data out.
+"""
+
+import unittest
+
+from allium.lib.relays import Relays
+
+
+def _make_relay(fingerprint, or_addresses):
+    """Minimal onionoo-shaped relay dict accepted by the full Relays pipeline."""
+    relay = {
+        'fingerprint': fingerprint,
+        'nickname': f'relay{fingerprint[0]}',
+        'contact': 'operator@example.com',
+        'observed_bandwidth': 1000000,
+        'consensus_weight': 100,
+        'flags': ['Running', 'Valid'],
+        'running': True,
+        'country': 'us',
+        'country_name': 'United States',
+        'as': 'AS1',
+        'as_name': 'Test AS',
+        'first_seen': '2023-01-01 00:00:00',
+        'last_seen': '2024-01-01 00:00:00',
+        'last_restarted': '2024-01-01 00:00:00',
+        'platform': 'Tor 0.4.8.10 on Linux',
+        'effective_family': [],
+    }
+    if or_addresses is not None:
+        relay['or_addresses'] = or_addresses
+    return relay
+
+
+def _preprocess(or_addresses):
+    """Run the full Relays init pipeline on one relay, return the processed dict."""
+    relay_data = {'relays': [_make_relay('A' * 40, or_addresses)]}
+    relays_obj = Relays(
+        output_dir='/tmp/test-ipv6-preprocessing',
+        onionoo_url='https://test.example.com',
+        relay_data=relay_data,
+        use_bits=False,
+        progress=False,
+    )
+    return relays_obj.json['relays'][0]
+
+
+class TestIPv6DisplayAddressPreprocessing(unittest.TestCase):
+    """relay['ipv6_display_address'] extraction from or_addresses."""
+
+    def test_dual_stack_relay(self):
+        relay = _preprocess(['1.2.3.4:9001', '[2001:db8::1]:9001'])
+        self.assertEqual(relay['ipv6_display_address'], '2001:db8::1')
+        self.assertEqual(relay['ipv6_support'], 'both')
+
+    def test_ipv4_only_relay(self):
+        relay = _preprocess(['1.2.3.4:9001'])
+        self.assertEqual(relay['ipv6_display_address'], '')
+        self.assertEqual(relay['ipv6_support'], 'ipv4_only')
+
+    def test_ipv6_only_relay(self):
+        relay = _preprocess(['[2001:db8::1]:9001'])
+        self.assertEqual(relay['ipv6_display_address'], '2001:db8::1')
+        self.assertEqual(relay['ipv6_support'], 'ipv6_only')
+
+    def test_empty_or_addresses(self):
+        relay = _preprocess([])
+        self.assertEqual(relay['ipv6_display_address'], '')
+        self.assertEqual(relay['ipv6_support'], 'none')
+
+    def test_missing_or_addresses(self):
+        relay = _preprocess(None)
+        self.assertEqual(relay['ipv6_display_address'], '')
+        self.assertEqual(relay['ipv6_support'], 'none')
+
+    def test_malformed_address_skipped(self):
+        relay = _preprocess(['garbage', '[2001:db8::2]:443'])
+        self.assertEqual(relay['ipv6_display_address'], '2001:db8::2')
+        self.assertEqual(relay['ipv6_support'], 'ipv6_only')
+
+    def test_first_ipv6_wins(self):
+        relay = _preprocess(['[2001:db8::1]:9001', '[2001:db8::2]:9001'])
+        self.assertEqual(relay['ipv6_display_address'], '2001:db8::1')
+        self.assertEqual(relay['ipv6_support'], 'ipv6_only')
+
+    def test_ipv6_address_normalized(self):
+        """Uncompressed/zero-padded input is normalized to canonical form."""
+        relay = _preprocess(['[2001:0db8:0000:0000:0000:0000:0000:0001]:9001'])
+        self.assertEqual(relay['ipv6_display_address'], '2001:db8::1')
+
+    def test_ipv6_after_ipv4(self):
+        """Real-world onionoo ordering: IPv4 first, IPv6 second (reporter's relay)."""
+        relay = _preprocess(['195.133.23.252:443', '[2001:470:1f15:16b::1337:c0de]:443'])
+        self.assertEqual(relay['ipv6_display_address'], '2001:470:1f15:16b::1337:c0de')
+        self.assertEqual(relay['ipv6_support'], 'both')
+
+
+class TestIPv6SupportSetDuringPreprocessing(unittest.TestCase):
+    """ipv6_support must be a guaranteed preprocessing output (not a
+    network_health side effect), so header gating and contact_sorting see it
+    even if network health metrics were never calculated."""
+
+    def test_ipv6_support_present_without_network_health(self):
+        relay_data = {'relays': [
+            _make_relay('A' * 40, ['1.2.3.4:9001', '[2001:db8::1]:9001']),
+            _make_relay('B' * 40, ['5.6.7.8:9001']),
+        ]}
+        relays_obj = Relays(
+            output_dir='/tmp/test-ipv6-preprocessing',
+            onionoo_url='https://test.example.com',
+            relay_data=relay_data,
+            use_bits=False,
+            progress=False,
+        )
+        # No _calculate_network_health_metrics() call — preprocessing alone
+        # must have set the attribute on every relay.
+        self.assertNotIn('network_health', relays_obj.json)
+        supports = {r['fingerprint']: r['ipv6_support'] for r in relays_obj.json['relays']}
+        self.assertEqual(supports['A' * 40], 'both')
+        self.assertEqual(supports['B' * 40], 'ipv4_only')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/templates/test_jinja_scoping_lint.py
+++ b/tests/unit/templates/test_jinja_scoping_lint.py
@@ -24,14 +24,7 @@ Benign same-iteration set-and-use (e.g. css_class per row) and list
 mutation via {% set _ = list.append(...) %} are not flagged.
 """
 
-import glob
-import os
 import re
-import unittest
-
-TEMPLATE_DIR = os.path.join(
-    os.path.dirname(__file__), '..', '..', '..', 'allium', 'templates'
-)
 
 _TAG_RE = re.compile(r'({%-?.*?-?%}|{{-?.*?-?}})', re.DOTALL)
 _COMMENT_RE = re.compile(r'{#.*?#}', re.DOTALL)
@@ -65,7 +58,7 @@ def find_set_in_for_scoping_bugs(source):
             # For each candidate, scan tags after this endfor: a read of the
             # var before a re-{% set %} is a violation.
             for var, set_pos in frame['candidates'].items():
-                word_re = re.compile(r'\b%s\b' % re.escape(var))
+                word_re = re.compile(r'\b{}\b'.format(re.escape(var)))
                 for _, later_tag in tags[idx + 1:]:
                     set_match = _SET_RE.match(later_tag)
                     if set_match and set_match.group(1) == var:
@@ -91,63 +84,59 @@ def find_set_in_for_scoping_bugs(source):
     return violations
 
 
-class TestJinjaScopingLint(unittest.TestCase):
-
-    def test_detector_catches_known_bug_pattern(self):
-        """Self-test: the detector must flag the exact pattern that broke the
-        IPv6 column (guards against detector rot)."""
-        buggy = (
-            "{% set ipv6_found = false %}\n"
-            "{% for addr in relay['or_addresses'] %}\n"
-            "    {% if ':' in addr %}{% set ipv6_found = true %}{% endif %}\n"
-            "{% endfor %}\n"
-            "{% if ipv6_found %}yes{% else %}N/A{% endif %}\n"
-        )
-        violations = find_set_in_for_scoping_bugs(buggy)
-        self.assertEqual([v[1] for v in violations], ['ipv6_found'])
-
-    def test_detector_allows_benign_patterns(self):
-        """Same-iteration set-and-use, list mutation, post-loop re-init, and
-        namespace() must not be flagged."""
-        benign = (
-            # set before loop, re-set + read within the same iteration only
-            "{% set css = '' %}\n"
-            "{% for row in rows %}\n"
-            "    {% set css = 'x' %}<td class=\"{{ css }}\">{{ row }}</td>\n"
-            "{% endfor %}\n"
-            # list mutation via throwaway var
-            "{% set vals = [] %}\n"
-            "{% for row in rows %}{% set _ = vals.append(row) %}{% endfor %}\n"
-            "{{ vals|join(',') }}\n"
-            # namespace pattern (the correct fix)
-            "{% set ns = namespace(found=false) %}\n"
-            "{% for row in rows %}{% set ns.found = true %}{% endfor %}\n"
-            "{% if ns.found %}yes{% endif %}\n"
-            # re-initialized after the loop before any read
-            "{% set flag = false %}\n"
-            "{% for row in rows %}{% set flag = true %}{% endfor %}\n"
-            "{% set flag = rows|length > 0 %}\n"
-            "{% if flag %}yes{% endif %}\n"
-        )
-        self.assertEqual(find_set_in_for_scoping_bugs(benign), [])
-
-    def test_no_scoping_bugs_in_templates(self):
-        """No template may read a set-inside-for variable after endfor."""
-        template_files = sorted(glob.glob(os.path.join(TEMPLATE_DIR, '*.html')))
-        self.assertGreater(len(template_files), 0, "no templates found")
-
-        all_violations = []
-        for path in template_files:
-            with open(path, encoding='utf8') as f:
-                violations = find_set_in_for_scoping_bugs(f.read())
-            for line, var in violations:
-                all_violations.append(f"{os.path.basename(path)}:{line}: "
-                                      f"'{var}' set inside for-loop is read after endfor "
-                                      f"(Jinja2 loop-local scoping — value never escapes the loop)")
-
-        self.assertEqual(all_violations, [],
-                         "Jinja2 set-inside-for scoping bugs found:\n" + "\n".join(all_violations))
+def test_detector_catches_known_bug_pattern():
+    """Self-test: the detector must flag the exact pattern that broke the
+    IPv6 column (guards against detector rot)."""
+    buggy = (
+        "{% set ipv6_found = false %}\n"
+        "{% for addr in relay['or_addresses'] %}\n"
+        "    {% if ':' in addr %}{% set ipv6_found = true %}{% endif %}\n"
+        "{% endfor %}\n"
+        "{% if ipv6_found %}yes{% else %}N/A{% endif %}\n"
+    )
+    violations = find_set_in_for_scoping_bugs(buggy)
+    assert [v[1] for v in violations] == ['ipv6_found']
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_detector_allows_benign_patterns():
+    """Same-iteration set-and-use, list mutation, post-loop re-init, and
+    namespace() must not be flagged."""
+    benign = (
+        # set before loop, re-set + read within the same iteration only
+        "{% set css = '' %}\n"
+        "{% for row in rows %}\n"
+        "    {% set css = 'x' %}<td class=\"{{ css }}\">{{ row }}</td>\n"
+        "{% endfor %}\n"
+        # list mutation via throwaway var
+        "{% set vals = [] %}\n"
+        "{% for row in rows %}{% set _ = vals.append(row) %}{% endfor %}\n"
+        "{{ vals|join(',') }}\n"
+        # namespace pattern (the correct fix)
+        "{% set ns = namespace(found=false) %}\n"
+        "{% for row in rows %}{% set ns.found = true %}{% endfor %}\n"
+        "{% if ns.found %}yes{% endif %}\n"
+        # re-initialized after the loop before any read
+        "{% set flag = false %}\n"
+        "{% for row in rows %}{% set flag = true %}{% endfor %}\n"
+        "{% set flag = rows|length > 0 %}\n"
+        "{% if flag %}yes{% endif %}\n"
+    )
+    assert find_set_in_for_scoping_bugs(benign) == []
+
+
+def test_no_scoping_bugs_in_templates(templates_dir):
+    """No template may read a set-inside-for variable after endfor."""
+    template_files = sorted(templates_dir.glob('*.html'))
+    assert len(template_files) > 0, "no templates found"
+
+    all_violations = []
+    for path in template_files:
+        violations = find_set_in_for_scoping_bugs(path.read_text(encoding='utf8'))
+        for line, var in violations:
+            all_violations.append(
+                f"{path.name}:{line}: "
+                f"'{var}' set inside for-loop is read after endfor "
+                f"(Jinja2 loop-local scoping — value never escapes the loop)")
+
+    assert all_violations == [], (
+        "Jinja2 set-inside-for scoping bugs found:\n" + "\n".join(all_violations))

--- a/tests/unit/templates/test_jinja_scoping_lint.py
+++ b/tests/unit/templates/test_jinja_scoping_lint.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Template lint: detect the Jinja2 "set-inside-for" scoping bug class.
+
+In Jinja2, {% set %} inside a {% for %} block creates a loop-local binding
+that does NOT survive past {% endfor %}. Code like:
+
+    {% set found = false %}
+    {% for item in items %}
+        {% if ... %}{% set found = true %}{% endif %}
+    {% endfor %}
+    {% if found %}...{% endif %}      {# always reads the outer false! #}
+
+silently always reads the pre-loop value. This caused the contact/family
+page IPv6 column to render "N/A" for every relay. The correct patterns are
+namespace() objects or precomputing in Python.
+
+This lint flags a variable that is:
+  (a) {% set %}-initialized OUTSIDE any for loop,
+  (b) re-{% set %} INSIDE a for loop (plain assignment, not ns.attr),
+  (c) read after that loop's {% endfor %} before being re-initialized.
+
+Benign same-iteration set-and-use (e.g. css_class per row) and list
+mutation via {% set _ = list.append(...) %} are not flagged.
+"""
+
+import glob
+import os
+import re
+import unittest
+
+TEMPLATE_DIR = os.path.join(
+    os.path.dirname(__file__), '..', '..', '..', 'allium', 'templates'
+)
+
+_TAG_RE = re.compile(r'({%-?.*?-?%}|{{-?.*?-?}})', re.DOTALL)
+_COMMENT_RE = re.compile(r'{#.*?#}', re.DOTALL)
+_SET_RE = re.compile(r'{%-?\s*set\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*=')
+_FOR_RE = re.compile(r'{%-?\s*for\s')
+_ENDFOR_RE = re.compile(r'{%-?\s*endfor')
+_STRING_RE = re.compile(r"'[^']*'|\"[^\"]*\"")
+
+
+def find_set_in_for_scoping_bugs(source):
+    """Return list of (line_number, variable) scoping violations in a template."""
+    source = _COMMENT_RE.sub(lambda m: ' ' * len(m.group(0)), source)
+    tags = [(m.start(), m.group(0)) for m in _TAG_RE.finditer(source)]
+
+    def line_of(pos):
+        return source.count('\n', 0, pos) + 1
+
+    outer_sets = set()      # vars {% set %} outside any for loop
+    for_stack = []          # list of dicts: {candidates: {var: pos_of_set}}
+    violations = []
+
+    for idx, (pos, tag) in enumerate(tags):
+        if _FOR_RE.match(tag):
+            for_stack.append({'candidates': {}})
+            continue
+
+        if _ENDFOR_RE.match(tag):
+            if not for_stack:
+                continue
+            frame = for_stack.pop()
+            # For each candidate, scan tags after this endfor: a read of the
+            # var before a re-{% set %} is a violation.
+            for var, set_pos in frame['candidates'].items():
+                word_re = re.compile(r'\b%s\b' % re.escape(var))
+                for _, later_tag in tags[idx + 1:]:
+                    set_match = _SET_RE.match(later_tag)
+                    if set_match and set_match.group(1) == var:
+                        break  # re-initialized before any read: OK
+                    # Ignore var-name occurrences inside string literals.
+                    stripped = _STRING_RE.sub('', later_tag)
+                    if word_re.search(stripped):
+                        violations.append((line_of(set_pos), var))
+                        break
+            continue
+
+        set_match = _SET_RE.match(tag)
+        if not set_match:
+            continue
+        var = set_match.group(1)
+        if not for_stack:
+            outer_sets.add(var)
+        elif var in outer_sets:
+            # Plain re-assignment inside a for loop of a var initialized
+            # outside it — candidate for the scoping bug.
+            for_stack[-1]['candidates'].setdefault(var, pos)
+
+    return violations
+
+
+class TestJinjaScopingLint(unittest.TestCase):
+
+    def test_detector_catches_known_bug_pattern(self):
+        """Self-test: the detector must flag the exact pattern that broke the
+        IPv6 column (guards against detector rot)."""
+        buggy = (
+            "{% set ipv6_found = false %}\n"
+            "{% for addr in relay['or_addresses'] %}\n"
+            "    {% if ':' in addr %}{% set ipv6_found = true %}{% endif %}\n"
+            "{% endfor %}\n"
+            "{% if ipv6_found %}yes{% else %}N/A{% endif %}\n"
+        )
+        violations = find_set_in_for_scoping_bugs(buggy)
+        self.assertEqual([v[1] for v in violations], ['ipv6_found'])
+
+    def test_detector_allows_benign_patterns(self):
+        """Same-iteration set-and-use, list mutation, post-loop re-init, and
+        namespace() must not be flagged."""
+        benign = (
+            # set before loop, re-set + read within the same iteration only
+            "{% set css = '' %}\n"
+            "{% for row in rows %}\n"
+            "    {% set css = 'x' %}<td class=\"{{ css }}\">{{ row }}</td>\n"
+            "{% endfor %}\n"
+            # list mutation via throwaway var
+            "{% set vals = [] %}\n"
+            "{% for row in rows %}{% set _ = vals.append(row) %}{% endfor %}\n"
+            "{{ vals|join(',') }}\n"
+            # namespace pattern (the correct fix)
+            "{% set ns = namespace(found=false) %}\n"
+            "{% for row in rows %}{% set ns.found = true %}{% endfor %}\n"
+            "{% if ns.found %}yes{% endif %}\n"
+            # re-initialized after the loop before any read
+            "{% set flag = false %}\n"
+            "{% for row in rows %}{% set flag = true %}{% endfor %}\n"
+            "{% set flag = rows|length > 0 %}\n"
+            "{% if flag %}yes{% endif %}\n"
+        )
+        self.assertEqual(find_set_in_for_scoping_bugs(benign), [])
+
+    def test_no_scoping_bugs_in_templates(self):
+        """No template may read a set-inside-for variable after endfor."""
+        template_files = sorted(glob.glob(os.path.join(TEMPLATE_DIR, '*.html')))
+        self.assertGreater(len(template_files), 0, "no templates found")
+
+        all_violations = []
+        for path in template_files:
+            with open(path, encoding='utf8') as f:
+                violations = find_set_in_for_scoping_bugs(f.read())
+            for line, var in violations:
+                all_violations.append(f"{os.path.basename(path)}:{line}: "
+                                      f"'{var}' set inside for-loop is read after endfor "
+                                      f"(Jinja2 loop-local scoping — value never escapes the loop)")
+
+        self.assertEqual(all_violations, [],
+                         "Jinja2 set-inside-for scoping bugs found:\n" + "\n".join(all_violations))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

User report: all 15 relays on https://metrics.1aeo.com/relays.brokenbotnet.com/ show IPv6 as "N/A" despite having valid IPv6 addresses on Tor Metrics (e.g. ShinobiKuma: `2001:470:1f15:16b::1337:c0de`).

Investigation confirmed the bug is **site-wide and deterministic**: every relay row on every contact page (including AROI vanity-domain copies) and every family page renders "N/A" in the IPv6 column — even though onionoo returns the IPv6 address in `or_addresses` and the by-ipv6 sort order is correct. Present since the IPv6 column was introduced (`2f74bf3018`).

## Root cause

Jinja2 for-loop scoping bug in the `relay_row` macro of `contact-relay-list.html`:

```jinja
{% set ipv6_found = false %}
{% for addr in relay['or_addresses'] %}
    {% if ... %}{% set ipv6_found = true %}{% endif %}
{% endfor %}
{% if ipv6_found %}{{ ipv6_addr|escape }}{% else %}N/A{% endif %}
```

In Jinja2, `{% set %}` inside `{% for %}` creates a **loop-local** binding that does not survive past `{% endfor %}` — the post-loop check always reads the pre-loop `false`, so every cell rendered N/A. (Reproduced with a minimal template on Jinja2 3.1.2.)

The column *header* still appeared because its gate uses the separate `ipv6_support` attribute set in Python — detection and sorting worked; only the per-row display was broken.

## Fix

- **`relays.py` `_preprocess_template_data`**: precompute `relay['ipv6_display_address']` — first IPv6 from `or_addresses` via `safe_parse_ip_address` (normalized, `''` when none). Named `ipv6_display_address` because `ipv6_address` already exists in the collector/consensus vote dicts with different semantics (raw `a`-line incl. brackets+port).
- Also set `relay['ipv6_support']` during preprocessing. Previously it was only written as a side effect of `network_health.calculate_network_health_metrics()` — a hidden pipeline-ordering dependency for the template's header gate and `contact_sorting.relay_has_ipv6`. network_health keeps its idempotent assignment. This also resolves the previously-unused `determine_ipv6_support` import.
- **Template**: replace the broken 18-line loop with a plain dict lookup (small perf win — the loop ran per row across ~22k pages × up to 19 sort variants). Fixes contact pages (index + all `by-*.html` variants + vanity domains) and family pages via the shared base template.

## Tests

- `tests/unit/relays/test_ipv6_preprocessing.py` — 10 cases through the real pipeline: dual-stack, v4-only, v6-only, empty/missing, malformed-address skip, first-IPv6-wins, normalization, and `ipv6_support` present without network-health calculation.
- `tests/integration/test_contact_template.py` — direct-render regression tests for single-table **and** sectioned-AROI layouts, plus an end-to-end assertion in the sort-variant generation test (full pipeline → generated files contain the address). **All 3 verified to FAIL against the original buggy template** and pass with the fix.
- `tests/unit/templates/test_jinja_scoping_lint.py` — template lint that flags the set-inside-for read-after-endfor bug class anywhere in `allium/templates/`. Verified to catch the original bug (`contact-relay-list.html:292: 'ipv6_found'`) with zero false positives on current templates (includes detector self-tests).

Full suite: **1012 passed**. flake8 (`E9,F63,F7,F82`): clean on all touched files (2 pre-existing `F821`s in unrelated test files exist on master).

## Output comparison (per repo workflow)

`www_baseline` (unmodified code) vs `www_after` (this fix), ~28.4k files, live APIs ~9 min apart:

```
Common files:         28401
  Identical:            312
  Timestamp only:     18340
  Content diffs:       9749   (contact: 5400, family: 4249, drift: ~100)
Only in baseline / after:  0
```

Scripted verification (normalize the IPv6 `<td>` cells, re-diff everything):
- **9,631 contact/family files**: diffs are the IPv6 cell (`N/A` → address) + volatile timestamps **only** — 559,808 cells fixed site-wide.
- **Zero anomalies on contact/family pages.** Residual 61 diffs are all on unrelated pages (relay/index/misc) and are live-API drift: uptime-threshold class flips at exactly `7.2d | 7.2d`, AROI leaderboard rare-country drift, and a `4w↔1mo` time-ago boundary the compare tool's volatile regex doesn't cover.
- Reporter's page: all 15 rows now show valid IPv6; ShinobiKuma renders `2001:470:1f15:16b::1337:c0de`.

```diff
 <td title="2026-07-03">
-6d 12h 4m ago
+6d 12h 13m ago
 </td>
 <td>
-N/A
+2001:470:1f15:16b::1337:c0de
 </td>
```

### Before (baseline) — IPv6 column all N/A
[Before: IPv6 column shows N/A for all 15 relays](https://cursor.com/agents/bc-e36f3931-6f0d-4bff-a618-e44fdd52224d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fipv6_before_full.png)

### After (this fix) — real addresses
[After: IPv6 column shows real addresses for all 15 relays](https://cursor.com/agents/bc-e36f3931-6f0d-4bff-a618-e44fdd52224d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fipv6_after_full.png)

To answer the reporter's question: it was a display bug, not the field tracking something more specific — IPv6 detection, column gating, and by-ipv6 sort order were already correct.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e36f3931-6f0d-4bff-a618-e44fdd52224d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e36f3931-6f0d-4bff-a618-e44fdd52224d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relay contact pages now reliably show the correct IPv6 value (or `N/A`) in the IPv6 column, including dual-stack, IPv4-only, and IPv6-only relays.
  * IPv6 display values are computed during relay preprocessing for consistent rendering, normalized formatting, and predictable `ipv6_support`.
  * The IPv6 column is omitted when no listed relays support IPv6.

* **Tests**
  * Added unit and integration regression coverage for IPv6 preprocessing and contact page rendering (including sorting variants/sectioned layouts).
  * Added a template scoping lint test to prevent Jinja loop/set rendering regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->