### PR TITLE
ci: add Python 3.12 + 3.13 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     
     steps:
     - name: Checkout code
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]  # Test on minimum and latest supported versions
+        python-version: ["3.8", "3.13"]  # Test on minimum and latest supported versions
     
     steps:
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Prod runs Python 3.13.5 but CI only tests 3.8-3.11 — untested interpreter in production. Adds 3.12 + 3.13 to matrix.

Also bumps the setup-script end-to-end test's "latest supported" version from 3.11 to 3.13 so that job actually exercises the production interpreter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Broadened CI test runs to cover Python 3.8 through 3.13.
  * Updated setup validation to run on Python 3.8 (minimum supported) and Python 3.13 (latest supported).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->