### PR TITLE
Add search-index contract checks

### DIFF
--- a/allium/lib/aroi_validation.py
+++ b/allium/lib/aroi_validation.py
@@ -94,6 +94,21 @@ V3_TIER_COMPLETE = 1.0      # 100% of relays on v3
 V3_LISTING_ICON_THRESHOLD = V3_TIER_MIGRATING
 
 
+def get_v3_search_index_thresholds() -> Dict[str, int]:
+    """Return v3 tier thresholds in search-index JSON units.
+
+    The search index exposes percentages as integers because the Pages
+    Function is JavaScript and should not duplicate Allium's float constants.
+    ``explorer`` is the one count-based threshold: at least one v3 relay.
+    """
+    return {
+        'explorer': 1,
+        'migrating': int(round(V3_TIER_MIGRATING * 100)),
+        'mostly': int(round(V3_TIER_MOSTLY * 100)),
+        'complete': int(round(V3_TIER_COMPLETE * 100)),
+    }
+
+
 # Module-state for one-time schema warning logging.
 _warned_schema_versions = set()
 

--- a/allium/lib/aroi_validation.py
+++ b/allium/lib/aroi_validation.py
@@ -103,9 +103,9 @@ def get_v3_search_index_thresholds() -> Dict[str, int]:
     """
     return {
         'explorer': 1,
-        'migrating': int(round(V3_TIER_MIGRATING * 100)),
-        'mostly': int(round(V3_TIER_MOSTLY * 100)),
-        'complete': int(round(V3_TIER_COMPLETE * 100)),
+        'migrating': round(V3_TIER_MIGRATING * 100),
+        'mostly': round(V3_TIER_MOSTLY * 100),
+        'complete': round(V3_TIER_COMPLETE * 100),
     }
 
 

--- a/allium/lib/consensus/collector_fetcher.py
+++ b/allium/lib/consensus/collector_fetcher.py
@@ -440,8 +440,8 @@ class CollectorFetcher:
             result['errors'].append(f"consensus_method_info: {e}")
             result['consensus_method_info'] = {}
         
-        result['bw_authorities'] = list(self.bw_authorities)
-        result['ipv6_testing_authorities'] = list(self.ipv6_testing_authorities)
+        result['bw_authorities'] = sorted(self.bw_authorities)
+        result['ipv6_testing_authorities'] = sorted(self.ipv6_testing_authorities)
         result['timings'] = self._timings
         
         # Log performance metrics
@@ -604,20 +604,23 @@ class CollectorFetcher:
                 future = executor.submit(self._fetch_and_parse_vote, url, auth_fp)
                 future_to_auth[future] = auth_fp
             
+            fetched_votes = {}
             for future in concurrent.futures.as_completed(future_to_auth):
                 auth_fp = future_to_auth[future]
                 try:
                     vote_data = future.result()
                     if vote_data:
                         auth_name = AUTHORITIES.get(auth_fp, auth_fp[:8])
-                        votes[auth_name] = vote_data
-                        
+                        fetched_votes[auth_name] = vote_data
+
                         # Track if this authority runs a bandwidth scanner
                         if vote_data.get('has_bandwidth_file_headers'):
                             self.bw_authorities.add(auth_name)
                 except Exception as e:
                     logger.warning(f"Failed to fetch vote for {auth_fp}: {e}")
-        
+
+        votes = {auth_name: fetched_votes[auth_name]
+                 for auth_name in sorted(fetched_votes)}
         logger.info(f"Fetched {len(votes)} authority votes")
         return votes
     
@@ -872,7 +875,7 @@ class CollectorFetcher:
         self.relay_index = {}
         self.flag_thresholds = {}  # Extract thresholds in same loop
         
-        for auth_name, vote_data in self.votes.items():
+        for auth_name, vote_data in sorted(self.votes.items()):
             if not vote_data:
                 continue
             
@@ -885,7 +888,7 @@ class CollectorFetcher:
             if not relays:
                 continue
             
-            for fingerprint, relay_data in relays.items():
+            for fingerprint, relay_data in sorted(relays.items()):
                 if fingerprint not in self.relay_index:
                     self.relay_index[fingerprint] = {
                         'fingerprint': fingerprint,
@@ -908,7 +911,7 @@ class CollectorFetcher:
                 }
         
         # Add bandwidth measurements from bandwidth files
-        for fingerprint, bw_data in self.bandwidth_files.items():
+        for fingerprint, bw_data in sorted(self.bandwidth_files.items()):
             if fingerprint in self.relay_index:
                 self.relay_index[fingerprint]['bandwidth_measurements'] = bw_data
         

--- a/allium/lib/file_io_utils.py
+++ b/allium/lib/file_io_utils.py
@@ -89,8 +89,8 @@ class FileIOManager:
         return None
     
     @handle_file_io_errors("write JSON file", context="")
-    def write_json_file(self, filename: str, data: Any, encoding: str = "utf-8", 
-                       indent: int = 2) -> bool:
+    def write_json_file(self, filename: str, data: Any, encoding: str = "utf-8",
+                       indent: int = 2, sort_keys: bool = False) -> bool:
         """
         Write data to JSON file with error handling.
         
@@ -99,6 +99,7 @@ class FileIOManager:
             data: Data to serialize as JSON
             encoding: Text encoding (default: utf-8)
             indent: JSON indentation (default: 2)
+            sort_keys: Whether to sort object keys for deterministic output
             
         Returns:
             bool: True if successful, False if error
@@ -107,7 +108,7 @@ class FileIOManager:
         # Atomic write: a crash mid-dump must not corrupt the existing file
         tmp_path = file_path.with_suffix(file_path.suffix + ".tmp")
         with open(tmp_path, "w", encoding=encoding) as f:
-            json.dump(data, f, indent=indent)
+            json.dump(data, f, indent=indent, sort_keys=sort_keys)
         tmp_path.replace(file_path)
         return True
     
@@ -146,7 +147,7 @@ class CacheManager(FileIOManager):
             bool: True if successful, False if error
         """
         cache_filename = f"{cache_key}.json"
-        return self.write_json_file(cache_filename, data)
+        return self.write_json_file(cache_filename, data, sort_keys=True)
     
     def load_cache(self, cache_key: str) -> Optional[Dict[str, Any]]:
         """

--- a/allium/lib/search_index.py
+++ b/allium/lib/search_index.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 # Import existing utilities (DRY - avoid reimplementing)
 from .ip_utils import safe_parse_ip_address as _safe_parse_ip_address
 from .string_utils import is_valid_aroi
+from .aroi_validation import get_v3_search_index_thresholds
 
 
 # =============================================================================
@@ -458,16 +459,10 @@ def generate_search_index(
             'flags': sorted(flags),
             'validated_aroi_domains': validated_aroi_list,
             # B5.1 (v1.6): tier thresholds for the Cloudflare Pages Function
-            # to use without hardcoding. Mirrors V3_TIER_* constants in
-            # aroi_validation.py exactly so contact-page pills, listing
-            # icons, leaderboard badges, and search-frontend badges
-            # all agree.
-            'v3_thresholds': {
-                'explorer': 1,    # >=1 v3 relay (special: count, not pct)
-                'migrating': 25,
-                'mostly': 75,
-                'complete': 100,
-            },
+            # to use without hardcoding. Sourced from aroi_validation.py so
+            # contact-page pills, listing icons, leaderboard badges, and
+            # search-frontend badges all agree.
+            'v3_thresholds': get_v3_search_index_thresholds(),
         }
     }
 

--- a/allium/lib/workers.py
+++ b/allium/lib/workers.py
@@ -1229,7 +1229,8 @@ def _group_family_keys(fp_to_key):
     family_groups = {}
     for fp, key in fp_to_key.items():
         family_groups.setdefault(key, []).append(fp)
-    return {k: sorted(v) for k, v in family_groups.items() if v}
+    return {k: sorted(family_groups[k]) for k in sorted(family_groups)
+            if family_groups[k]}
 
 
 def _parse_descriptor_published(value):
@@ -1477,8 +1478,8 @@ def fetch_collector_descriptors(progress_logger=None):
                     
                     # Cache this file's parsed result
                     file_cache[filename] = {
-                        'cert': list(cert_fps),
-                        'no_cert': list(no_cert_fps),
+                        'cert': sorted(cert_fps),
+                        'no_cert': sorted(no_cert_fps),
                         'cert_keys': fp_to_family_key,
                         'cert_published': cert_published,
                         'no_cert_published': no_cert_published,
@@ -1584,7 +1585,7 @@ def fetch_collector_descriptors(progress_logger=None):
                     (prior_line_cert_fps - raw_line_cert_fps)
                     | (set(prior_fp_to_key.keys()) - set(raw_fp_to_key.keys()))
                 )
-                for fp in downgrade_candidates:
+                for fp in sorted(downgrade_candidates):
                     prev = pending_no_cert.get(fp, {})
                     count = int(prev.get('count', 0)) + 1
                     pending_no_cert[fp] = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -314,6 +314,70 @@ def sample_relay_data():
 
 
 @pytest.fixture
+def search_index_contract_relays_data():
+    """Small relay set for the search-index public contract tests."""
+    return {
+        'relays': [
+            {
+                'fingerprint': 'A' * 40,
+                'nickname': 'contractRelay',
+                'aroi_domain': 'example.org',
+                'contact_md5': '0123456789abcdef0123456789abcdef',
+                'as': 'AS64500',
+                'as_name': 'Example Network',
+                'country': 'DE',
+                'country_name': 'Germany',
+                'or_addresses': ['203.0.113.7:9001'],
+                'platform': 'Tor 0.4.8.x on Linux',
+                'flags': ['Running', 'Fast', 'Guard'],
+            }
+        ],
+        'sorted': {'family': {}},
+        'relays_published': '2026-05-05 00:00:00',
+    }
+
+
+@pytest.fixture
+def search_index_parallel_contract_relays_data():
+    """Relay set large enough to force search-index threaded processing."""
+    from allium.lib.search_index import PARALLEL_THRESHOLD
+
+    countries = [('de', 'Germany'), ('us', 'United States'),
+                 ('fr', 'France'), ('nl', 'Netherlands'), ('se', 'Sweden')]
+    relays = []
+    for i in range(PARALLEL_THRESHOLD + 200):
+        country, country_name = countries[i % len(countries)]
+        relays.append({
+            'fingerprint': f'{i:040X}',
+            'nickname': f'contractRelay{i}',
+            'aroi_domain': 'example.org' if i % 17 == 0 else '',
+            'contact_md5': f'{i % 65536:032x}',
+            'as': f'AS{i % 400}',
+            'as_name': f'Provider {i % 400}',
+            'country': country,
+            'country_name': country_name,
+            'or_addresses': [f'203.0.113.{i % 255}:9001'],
+            'platform': f'Tor 0.4.{i % 3}.x on Linux',
+            'flags': ['Running', 'Fast'] + (['Exit'] if i % 4 == 0 else []),
+        })
+
+    return {
+        'relays': relays,
+        'sorted': {'family': {}},
+        'relays_published': '2026-05-05 00:00:00',
+    }
+
+
+@pytest.fixture
+def sorted_json_cache_payload():
+    """Nested payload for verifying deterministic JSON cache rendering."""
+    return {
+        'z': 1,
+        'a': {'d': 4, 'b': 2},
+    }
+
+
+@pytest.fixture
 def onionoo_response():
     """Fixture that provides realistic onionoo API response data with 5 relays."""
     relays = []

--- a/tests/unit/templates/test_search_index_contract.py
+++ b/tests/unit/templates/test_search_index_contract.py
@@ -33,7 +33,14 @@ def _assert_search_index_contract(index) -> None:
         'flags',
         'validated_aroi_domains',
     }.issubset(lookups)
-    assert lookups['v3_thresholds'] == get_v3_search_index_thresholds()
+    expected_v3_thresholds = {
+        'explorer': 1,
+        'migrating': 25,
+        'mostly': 75,
+        'complete': 100,
+    }
+    assert get_v3_search_index_thresholds() == expected_v3_thresholds
+    assert lookups['v3_thresholds'] == expected_v3_thresholds
 
     relay = index['relays'][0]
     assert {'f', 'n', 'as', 'cc', 'ip', 'a', 'c'}.issubset(relay)

--- a/tests/unit/templates/test_search_index_contract.py
+++ b/tests/unit/templates/test_search_index_contract.py
@@ -1,0 +1,69 @@
+"""Search-index schema contract consumed by allium-deploy's Pages Function."""
+
+import json
+import re
+
+from allium.lib.aroi_validation import get_v3_search_index_thresholds
+from allium.lib.search_index import generate_search_index
+
+
+def test_generated_search_index_contract(tmp_path):
+    relays_data = {
+        'relays': [
+            {
+                'fingerprint': 'A' * 40,
+                'nickname': 'contractRelay',
+                'aroi_domain': 'example.org',
+                'contact_md5': '0123456789abcdef0123456789abcdef',
+                'as': 'AS64500',
+                'as_name': 'Example Network',
+                'country': 'DE',
+                'country_name': 'Germany',
+                'or_addresses': ['203.0.113.7:9001'],
+                'platform': 'Tor 0.4.8.x on Linux',
+                'flags': ['Running', 'Fast', 'Guard'],
+            }
+        ],
+        'sorted': {'family': {}},
+        'relays_published': '2026-05-05 00:00:00',
+    }
+
+    output_path = tmp_path / 'search-index.json'
+    generate_search_index(
+        relays_data,
+        str(output_path),
+        validated_aroi_domains={'example.org'},
+        use_parallel=False,
+    )
+    index = json.loads(output_path.read_text(encoding='utf-8'))
+
+    assert {'meta', 'relays', 'families', 'lookups'}.issubset(index)
+    assert isinstance(index['meta'].get('version'), str)
+    assert re.fullmatch(r'\d+\.\d+', index['meta']['version'])
+
+    lookups = index['lookups']
+    assert {
+        'as_names',
+        'country_names',
+        'platforms',
+        'flags',
+        'validated_aroi_domains',
+    }.issubset(lookups)
+    assert lookups['v3_thresholds'] == get_v3_search_index_thresholds()
+
+    relay = index['relays'][0]
+    assert {'f', 'n', 'as', 'cc', 'ip', 'a', 'c'}.issubset(relay)
+
+
+def test_cache_manager_writes_sorted_json_keys(tmp_path):
+    from allium.lib.file_io_utils import create_cache_manager
+
+    cache_manager = create_cache_manager(str(tmp_path))
+    assert cache_manager.save_cache('deterministic', {
+        'z': 1,
+        'a': {'d': 4, 'b': 2},
+    })
+
+    rendered = (tmp_path / 'deterministic.json').read_text(encoding='utf-8')
+    assert rendered.index('"a"') < rendered.index('"z"')
+    assert rendered.index('"b"') < rendered.index('"d"')

--- a/tests/unit/templates/test_search_index_contract.py
+++ b/tests/unit/templates/test_search_index_contract.py
@@ -2,23 +2,25 @@
 
 import json
 import re
+from typing import Any, Dict
 
 from allium.lib.aroi_validation import get_v3_search_index_thresholds
 from allium.lib.search_index import PARALLEL_THRESHOLD, generate_search_index
 
 
-def _generate_index(tmp_path, relays_data, filename, use_parallel):
+def _generate_index(
+        tmp_path, relays_data, filename, use_parallel) -> Dict[str, Any]:
     output_path = tmp_path / filename
     generate_search_index(
         relays_data,
         str(output_path),
-        validated_aroi_domains={'example.org'},
+        validated_aroi_domains={'zeta.example', 'example.org'},
         use_parallel=use_parallel,
     )
     return json.loads(output_path.read_text(encoding='utf-8'))
 
 
-def _assert_search_index_contract(index):
+def _assert_search_index_contract(index) -> None:
     assert {'meta', 'relays', 'families', 'lookups'}.issubset(index)
     assert isinstance(index['meta'].get('version'), str)
     assert re.fullmatch(r'\d+\.\d+', index['meta']['version'])
@@ -37,12 +39,15 @@ def _assert_search_index_contract(index):
     assert {'f', 'n', 'as', 'cc', 'ip', 'a', 'c'}.issubset(relay)
 
 
-def _assert_lookup_key_order(index):
+def _assert_lookup_key_order(index) -> None:
     lookups = index['lookups']
     assert list(lookups['as_names']) == sorted(lookups['as_names'])
     assert list(lookups['country_names']) == sorted(lookups['country_names'])
     assert lookups['platforms'] == sorted(lookups['platforms'])
     assert lookups['flags'] == sorted(lookups['flags'])
+    assert len(lookups['validated_aroi_domains']) >= 2
+    assert lookups['validated_aroi_domains'] == sorted(
+        lookups['validated_aroi_domains'])
 
 
 def test_generated_search_index_contract(
@@ -60,22 +65,27 @@ def test_generated_search_index_contract(
 
 def test_generated_search_index_contract_parallel(
         tmp_path, search_index_parallel_contract_relays_data):
+    parallel_filename = 'parallel-search-index.json'
+    sequential_filename = 'sequential-search-index.json'
+
     parallel_index = _generate_index(
         tmp_path,
         search_index_parallel_contract_relays_data,
-        'parallel-search-index.json',
+        parallel_filename,
         use_parallel=True,
     )
     sequential_index = _generate_index(
         tmp_path,
         search_index_parallel_contract_relays_data,
-        'sequential-search-index.json',
+        sequential_filename,
         use_parallel=False,
     )
 
     assert parallel_index['meta']['relay_count'] > PARALLEL_THRESHOLD
     _assert_search_index_contract(parallel_index)
     _assert_lookup_key_order(parallel_index)
+    assert ((tmp_path / parallel_filename).read_bytes() ==
+            (tmp_path / sequential_filename).read_bytes())
     assert parallel_index['lookups'] == sequential_index['lookups']
     assert parallel_index['relays'] == sequential_index['relays']
 

--- a/tests/unit/templates/test_search_index_contract.py
+++ b/tests/unit/templates/test_search_index_contract.py
@@ -4,39 +4,21 @@ import json
 import re
 
 from allium.lib.aroi_validation import get_v3_search_index_thresholds
-from allium.lib.search_index import generate_search_index
+from allium.lib.search_index import PARALLEL_THRESHOLD, generate_search_index
 
 
-def test_generated_search_index_contract(tmp_path):
-    relays_data = {
-        'relays': [
-            {
-                'fingerprint': 'A' * 40,
-                'nickname': 'contractRelay',
-                'aroi_domain': 'example.org',
-                'contact_md5': '0123456789abcdef0123456789abcdef',
-                'as': 'AS64500',
-                'as_name': 'Example Network',
-                'country': 'DE',
-                'country_name': 'Germany',
-                'or_addresses': ['203.0.113.7:9001'],
-                'platform': 'Tor 0.4.8.x on Linux',
-                'flags': ['Running', 'Fast', 'Guard'],
-            }
-        ],
-        'sorted': {'family': {}},
-        'relays_published': '2026-05-05 00:00:00',
-    }
-
-    output_path = tmp_path / 'search-index.json'
+def _generate_index(tmp_path, relays_data, filename, use_parallel):
+    output_path = tmp_path / filename
     generate_search_index(
         relays_data,
         str(output_path),
         validated_aroi_domains={'example.org'},
-        use_parallel=False,
+        use_parallel=use_parallel,
     )
-    index = json.loads(output_path.read_text(encoding='utf-8'))
+    return json.loads(output_path.read_text(encoding='utf-8'))
 
+
+def _assert_search_index_contract(index):
     assert {'meta', 'relays', 'families', 'lookups'}.issubset(index)
     assert isinstance(index['meta'].get('version'), str)
     assert re.fullmatch(r'\d+\.\d+', index['meta']['version'])
@@ -55,14 +37,55 @@ def test_generated_search_index_contract(tmp_path):
     assert {'f', 'n', 'as', 'cc', 'ip', 'a', 'c'}.issubset(relay)
 
 
-def test_cache_manager_writes_sorted_json_keys(tmp_path):
+def _assert_lookup_key_order(index):
+    lookups = index['lookups']
+    assert list(lookups['as_names']) == sorted(lookups['as_names'])
+    assert list(lookups['country_names']) == sorted(lookups['country_names'])
+    assert lookups['platforms'] == sorted(lookups['platforms'])
+    assert lookups['flags'] == sorted(lookups['flags'])
+
+
+def test_generated_search_index_contract(
+        tmp_path, search_index_contract_relays_data):
+    index = _generate_index(
+        tmp_path,
+        search_index_contract_relays_data,
+        'search-index.json',
+        use_parallel=False,
+    )
+
+    _assert_search_index_contract(index)
+    _assert_lookup_key_order(index)
+
+
+def test_generated_search_index_contract_parallel(
+        tmp_path, search_index_parallel_contract_relays_data):
+    parallel_index = _generate_index(
+        tmp_path,
+        search_index_parallel_contract_relays_data,
+        'parallel-search-index.json',
+        use_parallel=True,
+    )
+    sequential_index = _generate_index(
+        tmp_path,
+        search_index_parallel_contract_relays_data,
+        'sequential-search-index.json',
+        use_parallel=False,
+    )
+
+    assert parallel_index['meta']['relay_count'] > PARALLEL_THRESHOLD
+    _assert_search_index_contract(parallel_index)
+    _assert_lookup_key_order(parallel_index)
+    assert parallel_index['lookups'] == sequential_index['lookups']
+    assert parallel_index['relays'] == sequential_index['relays']
+
+
+def test_cache_manager_writes_sorted_json_keys(
+        tmp_path, sorted_json_cache_payload):
     from allium.lib.file_io_utils import create_cache_manager
 
     cache_manager = create_cache_manager(str(tmp_path))
-    assert cache_manager.save_cache('deterministic', {
-        'z': 1,
-        'a': {'d': 4, 'b': 2},
-    })
+    assert cache_manager.save_cache('deterministic', sorted_json_cache_payload)
 
     rendered = (tmp_path / 'deterministic.json').read_text(encoding='utf-8')
     assert rendered.index('"a"') < rendered.index('"z"')


### PR DESCRIPTION
## Summary
- add a fixture-based search-index schema contract test for the Pages Function JSON surface
- source search-index v3 thresholds from `aroi_validation.py` instead of duplicating constants
- make cache JSON writes and CollecTor cache inputs deterministic where set/thread ordering could affect serialized bytes

## Notes
- This intentionally skips the already-fixed country/platform ordering issue and the docs-only attribution chip, since current `master` already sorts the emitted country/platform lists and no in-tree misc-page misattribution was found.
- The search-index contract is wired through the existing unit-test job rather than live site generation, avoiding external API flakiness.

## Validation
- `.venv/bin/python -m pytest tests/unit/templates/test_search_index_contract.py tests/unit/templates/test_search_index_v3.py tests/unit/templates/test_search_index_determinism.py tests/unit/workers/test_cache_state.py::TestCacheManagement::test_cache_file_format_and_structure tests/unit/workers/test_workers_descriptors.py`
- `.venv/bin/python -m flake8 allium/lib/aroi_validation.py allium/lib/search_index.py allium/lib/file_io_utils.py allium/lib/consensus/collector_fetcher.py allium/lib/workers.py tests/unit/templates/test_search_index_contract.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`
- PII/secrets grep: no real secrets found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared v3 migration tier threshold helper and wired it into search-index generation.
  * Added optional `sort_keys` when writing JSON to enable stable cached output.
* **Improvements**
  * Improved determinism across search-index creation (consistent ordering for lookups, families, fingerprints, relays) and collector aggregation.
* **Bug Fixes**
  * Ensured the generated search index `v3_thresholds` matches the shared validation values.
* **Tests**
  * Added contract and determinism tests covering required schema, parallel vs sequential output equality, and sorted JSON key ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->