### PR TITLE
Strip redundant unit words from AROI diversity Key Metric cells

### DIFF
--- a/allium/lib/aroileaders.py
+++ b/allium/lib/aroileaders.py
@@ -1377,10 +1377,12 @@ def _format_leaderboard_entries(leaderboards, aroi_operators, relays_instance):
                 'platforms': metrics['platforms'][:3],  # Top 3 platforms for display
                 'non_eu_count_with_percentage': f"{metrics['non_eu_count']} ({non_eu_percentage:.0f}%)",
                 # === VOLUME/BREADTH SUMMARIES (diversity cluster) ===
-                'platform_volume_summary': f"{_nl_n} non-Linux {_nl_word} ({_os_n} {_os_word})",
-                'platform_breadth_summary': f"{_os_n} {_os_word} ({_nl_n} non-Linux {_nl_word})",
-                'non_eu_volume_summary': f"{_neu_n} {_neu_word} ({_neuc_n} {_neuc_word})",
-                'non_eu_breadth_summary': f"{_neuc_n} {_neuc_word} ({_neu_n} {_neu_word})",
+                # Primary metric is a bare count (column header already names the
+                # unit); parenthetical keeps the tiebreaker label for clarity.
+                'platform_volume_summary': f"{_nl_n} ({_os_n} {_os_word})",
+                'platform_breadth_summary': f"{_os_n} ({_nl_n} non-Linux {_nl_word})",
+                'non_eu_volume_summary': f"{_neu_n} ({_neuc_n} {_neuc_word})",
+                'non_eu_breadth_summary': f"{_neuc_n} ({_neu_n} {_neu_word})",
                 'diversity_score': f"{metrics['diversity_score']:.1f}",
                 'uptime_percentage': f"{metrics['uptime_percentage']:.1f}%",
                 'veteran_score': f"{metrics['veteran_score']:.0f}",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -370,6 +370,13 @@ def uptime_data():
 
 
 @pytest.fixture
+def stub_bandwidth_formatter():
+    """Lightweight bandwidth formatter stub for AROI leaderboard unit tests."""
+    from helpers.fixtures import StubBandwidthFormatter
+    return StubBandwidthFormatter()
+
+
+@pytest.fixture
 def mock_aroi_leaderboard_entry():
     """Fixture that creates a mock AROI leaderboard entry.
 

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -213,10 +213,10 @@ class TestDataFactory:
         entry.non_eu_count = 1 + (rank // 2)
         entry.non_eu_count_with_percentage = f'{1 + (rank // 2)} ({50 + rank}%)'
         entry.non_eu_country_count = 1 + (rank // 4)
-        entry.platform_volume_summary = f'{1 + (rank // 3)} non-Linux relays ({1 + (rank // 3)} OSes)'
-        entry.platform_breadth_summary = f'{1 + (rank // 3)} OSes ({1 + (rank // 3)} non-Linux relays)'
-        entry.non_eu_volume_summary = f'{1 + (rank // 2)} relays ({1 + (rank // 4)} countries)'
-        entry.non_eu_breadth_summary = f'{1 + (rank // 4)} countries ({1 + (rank // 2)} relays)'
+        entry.platform_volume_summary = f'{1 + (rank // 3)} ({1 + (rank // 3)} OSes)'
+        entry.platform_breadth_summary = f'{1 + (rank // 3)} ({1 + (rank // 3)} non-Linux relays)'
+        entry.non_eu_volume_summary = f'{1 + (rank // 2)} ({1 + (rank // 4)} countries)'
+        entry.non_eu_breadth_summary = f'{1 + (rank // 4)} ({1 + (rank // 2)} relays)'
         entry.rare_country_count = 1 + (rank // 10)
         entry.relays_in_rare_countries = 1 + (rank // 8)
         entry.veteran_days = 100 + (rank * 10)

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -53,6 +53,20 @@ AROI_CATEGORY_TITLES = {
 }
 
 
+class StubBandwidthFormatter:
+    """Minimal bandwidth formatter for AROI leaderboard unit tests.
+
+    Matches the methods ``_format_leaderboard_entries`` calls without
+    pulling in the full production formatter.
+    """
+
+    def determine_unit(self, _value) -> str:
+        return 'MB/s'
+
+    def format_bandwidth_with_unit(self, value, _unit, decimal_places=1) -> str:
+        return f'{value / 1e6:.{decimal_places}f}'
+
+
 class TestDataFactory:
     """Factory class for creating common test data structures."""
     
@@ -213,10 +227,23 @@ class TestDataFactory:
         entry.non_eu_count = 1 + (rank // 2)
         entry.non_eu_count_with_percentage = f'{1 + (rank // 2)} ({50 + rank}%)'
         entry.non_eu_country_count = 1 + (rank // 4)
-        entry.platform_volume_summary = f'{1 + (rank // 3)} ({1 + (rank // 3)} OSes)'
-        entry.platform_breadth_summary = f'{1 + (rank // 3)} ({1 + (rank // 3)} non-Linux relays)'
-        entry.non_eu_volume_summary = f'{1 + (rank // 2)} ({1 + (rank // 4)} countries)'
-        entry.non_eu_breadth_summary = f'{1 + (rank // 4)} ({1 + (rank // 2)} relays)'
+        # Match production singular/plural labels in aroileaders summaries.
+        platform_word = 'OS' if entry.platform_count == 1 else 'OSes'
+        non_linux_word = 'relay' if entry.non_linux_count == 1 else 'relays'
+        country_word = 'country' if entry.non_eu_country_count == 1 else 'countries'
+        non_eu_word = 'relay' if entry.non_eu_count == 1 else 'relays'
+        entry.platform_volume_summary = (
+            f'{entry.non_linux_count} ({entry.platform_count} {platform_word})'
+        )
+        entry.platform_breadth_summary = (
+            f'{entry.platform_count} ({entry.non_linux_count} non-Linux {non_linux_word})'
+        )
+        entry.non_eu_volume_summary = (
+            f'{entry.non_eu_count} ({entry.non_eu_country_count} {country_word})'
+        )
+        entry.non_eu_breadth_summary = (
+            f'{entry.non_eu_country_count} ({entry.non_eu_count} {non_eu_word})'
+        )
         entry.rare_country_count = 1 + (rank // 10)
         entry.relays_in_rare_countries = 1 + (rank // 8)
         entry.veteran_days = 100 + (rank * 10)

--- a/tests/unit/aroi/test_leaders_scoring.py
+++ b/tests/unit/aroi/test_leaders_scoring.py
@@ -275,7 +275,7 @@ class TestDistinctDiversityMetrics:
         # ...but only 2 distinct non-EU countries (breadth metric)
         assert metrics['non_eu_country_count'] == 2
 
-    def _format_boards(self, relay_specs, stub_bandwidth_formatter):
+    def _format_boards(self, relay_specs, stub_bandwidth_formatter) -> dict:
         """Build relays, attach shared stub formatter, return formatted boards."""
         from allium.lib.aroileaders import (
             _collect_operator_metrics,

--- a/tests/unit/aroi/test_leaders_scoring.py
+++ b/tests/unit/aroi/test_leaders_scoring.py
@@ -316,6 +316,64 @@ class TestDistinctDiversityMetrics:
         assert entry['geographic_achievement'] == 'North America Champion'
         assert 'Europe' not in entry['geographic_achievement']
 
+    def test_diversity_summary_cells_omit_primary_unit_words(self):
+        """Key Metric cells for the four diversity boards use a bare primary
+        count (column header already names the unit) with a labeled
+        parenthetical for the tiebreaker — matching other numeric columns.
+        """
+        import re
+        from allium.lib.aroileaders import (
+            _collect_operator_metrics,
+            _rank_operators,
+            _format_leaderboard_entries,
+        )
+
+        # Multi-OS, multi-non-EU operator so all four boards have an entry.
+        instance = self._build_relays_instance([
+            ('Linux', 'DE'),      # EU, Linux
+            ('FreeBSD', 'US'),    # non-EU, non-Linux
+            ('FreeBSD', 'US'),    # non-EU, non-Linux (same country)
+            ('OpenBSD', 'JP'),    # non-EU, non-Linux
+        ])
+
+        class _StubFormatter:
+            def determine_unit(self, value):
+                return 'MB/s'
+
+            def format_bandwidth_with_unit(self, value, unit, decimal_places=1):
+                return f'{value / 1e6:.{decimal_places}f}'
+
+        instance.bandwidth_formatter = _StubFormatter()
+        instance.timestamp = '2026-01-01 00:00:00'
+
+        ops = _collect_operator_metrics(instance)
+        boards = _rank_operators(ops)
+        formatted = _format_leaderboard_entries(boards, ops, instance)
+        lbs = formatted['leaderboards']
+
+        # Metrics: platform_count=3 (Linux/FreeBSD/OpenBSD), non_linux=3,
+        # non_eu_count=3, non_eu_country_count=2 (US, JP)
+        pv = lbs['platform_volume'][0]['platform_volume_summary']
+        pb = lbs['platform_breadth'][0]['platform_breadth_summary']
+        nv = lbs['non_eu_volume'][0]['non_eu_volume_summary']
+        nb = lbs['non_eu_breadth'][0]['non_eu_breadth_summary']
+
+        assert pv == '3 (3 OSes)'
+        assert pb == '3 (3 non-Linux relays)'
+        assert nv == '3 (2 countries)'
+        assert nb == '2 (3 relays)'
+
+        assert re.fullmatch(r'\d+ \(\d+ OS(es)?\)', pv)
+        assert re.fullmatch(r'\d+ \(\d+ non-Linux relays?\)', pb)
+        assert re.fullmatch(r'\d+ \(\d+ countr(y|ies)\)', nv)
+        assert re.fullmatch(r'\d+ \(\d+ relays?\)', nb)
+
+        # Primary unit words must not appear outside the parenthetical.
+        assert 'non-Linux' not in pv.split('(')[0]
+        assert 'OS' not in pb.split('(')[0]
+        assert 'relay' not in nv.split('(')[0]
+        assert 'countr' not in nb.split('(')[0]
+
 
 class TestV3TierLeaderboardPropagation:
     """B4.test (re-opened): verify aroileaders.py uses the same tier

--- a/tests/unit/aroi/test_leaders_scoring.py
+++ b/tests/unit/aroi/test_leaders_scoring.py
@@ -275,40 +275,36 @@ class TestDistinctDiversityMetrics:
         # ...but only 2 distinct non-EU countries (breadth metric)
         assert metrics['non_eu_country_count'] == 2
 
-    def test_geographic_achievement_uses_non_eu_countries_only(self):
-        """Regression test (PR #217 Bugbot): the non-EU boards' achievement
-        title must be derived from the operator's NON-EU countries only.
-        An EU-heavy operator with a single US relay must get a North
-        America title, not a 'Europe Champion' title, on the non-EU
-        podium."""
+    def _format_boards(self, relay_specs, stub_bandwidth_formatter):
+        """Build relays, attach shared stub formatter, return formatted boards."""
         from allium.lib.aroileaders import (
             _collect_operator_metrics,
             _rank_operators,
             _format_leaderboard_entries,
         )
 
-        instance = self._build_relays_instance([
+        instance = self._build_relays_instance(relay_specs)
+        instance.bandwidth_formatter = stub_bandwidth_formatter
+        instance.timestamp = '2026-01-01 00:00:00'
+        ops = _collect_operator_metrics(instance)
+        boards = _rank_operators(ops)
+        return _format_leaderboard_entries(boards, ops, instance)
+
+    def test_geographic_achievement_uses_non_eu_countries_only(
+        self, stub_bandwidth_formatter
+    ):
+        """Regression test (PR #217 Bugbot): the non-EU boards' achievement
+        title must be derived from the operator's NON-EU countries only.
+        An EU-heavy operator with a single US relay must get a North
+        America title, not a 'Europe Champion' title, on the non-EU
+        podium."""
+        formatted = self._format_boards([
             ('Linux', 'DE'),   # EU
             ('Linux', 'FR'),   # EU
             ('Linux', 'NL'),   # EU
             ('Linux', 'ES'),   # EU
             ('Linux', 'US'),   # the ONLY non-EU relay
-        ])
-
-        # Stub bandwidth formatter for _format_leaderboard_entries
-        class _StubFormatter:
-            def determine_unit(self, value):
-                return 'MB/s'
-
-            def format_bandwidth_with_unit(self, value, unit, decimal_places=1):
-                return f'{value / 1e6:.{decimal_places}f}'
-
-        instance.bandwidth_formatter = _StubFormatter()
-        instance.timestamp = '2026-01-01 00:00:00'
-
-        ops = _collect_operator_metrics(instance)
-        boards = _rank_operators(ops)
-        formatted = _format_leaderboard_entries(boards, ops, instance)
+        ], stub_bandwidth_formatter)
 
         entry = formatted['leaderboards']['non_eu_breadth'][0]
         # Derived from ['US'] only -> North America title, never a
@@ -316,39 +312,22 @@ class TestDistinctDiversityMetrics:
         assert entry['geographic_achievement'] == 'North America Champion'
         assert 'Europe' not in entry['geographic_achievement']
 
-    def test_diversity_summary_cells_omit_primary_unit_words(self):
+    def test_diversity_summary_cells_omit_primary_unit_words(
+        self, stub_bandwidth_formatter
+    ):
         """Key Metric cells for the four diversity boards use a bare primary
         count (column header already names the unit) with a labeled
         parenthetical for the tiebreaker — matching other numeric columns.
         """
         import re
-        from allium.lib.aroileaders import (
-            _collect_operator_metrics,
-            _rank_operators,
-            _format_leaderboard_entries,
-        )
 
         # Multi-OS, multi-non-EU operator so all four boards have an entry.
-        instance = self._build_relays_instance([
+        formatted = self._format_boards([
             ('Linux', 'DE'),      # EU, Linux
             ('FreeBSD', 'US'),    # non-EU, non-Linux
             ('FreeBSD', 'US'),    # non-EU, non-Linux (same country)
             ('OpenBSD', 'JP'),    # non-EU, non-Linux
-        ])
-
-        class _StubFormatter:
-            def determine_unit(self, value):
-                return 'MB/s'
-
-            def format_bandwidth_with_unit(self, value, unit, decimal_places=1):
-                return f'{value / 1e6:.{decimal_places}f}'
-
-        instance.bandwidth_formatter = _StubFormatter()
-        instance.timestamp = '2026-01-01 00:00:00'
-
-        ops = _collect_operator_metrics(instance)
-        boards = _rank_operators(ops)
-        formatted = _format_leaderboard_entries(boards, ops, instance)
+        ], stub_bandwidth_formatter)
         lbs = formatted['leaderboards']
 
         # Metrics: platform_count=3 (Linux/FreeBSD/OpenBSD), non_linux=3,
@@ -373,6 +352,33 @@ class TestDistinctDiversityMetrics:
         assert 'OS' not in pb.split('(')[0]
         assert 'relay' not in nv.split('(')[0]
         assert 'countr' not in nb.split('(')[0]
+
+    def test_diversity_summary_cells_use_singular_labels(
+        self, stub_bandwidth_formatter
+    ):
+        """Parenthetical tiebreaker labels use singular forms when count is 1."""
+        # FreeBSD-only non-EU: exercises singular OS / country / relay.
+        formatted = self._format_boards([
+            ('FreeBSD', 'US'),
+        ], stub_bandwidth_formatter)
+        lbs = formatted['leaderboards']
+
+        assert lbs['platform_volume'][0]['platform_volume_summary'] == '1 (1 OS)'
+        assert lbs['non_eu_volume'][0]['non_eu_volume_summary'] == '1 (1 country)'
+        assert lbs['non_eu_breadth'][0]['non_eu_breadth_summary'] == '1 (1 relay)'
+        # Single-OS operators do not qualify for OS Polyglots (>= 2 OSes).
+        assert not any(
+            (e.get('display_name') or e.get('aroi_domain')) == 'example.com'
+            for e in lbs.get('platform_breadth', [])
+        )
+
+        # Linux + one FreeBSD: breadth qualifies with singular non-Linux relay.
+        formatted2 = self._format_boards([
+            ('Linux', 'DE'),
+            ('FreeBSD', 'US'),
+        ], stub_bandwidth_formatter)
+        pb = formatted2['leaderboards']['platform_breadth'][0]['platform_breadth_summary']
+        assert pb == '2 (1 non-Linux relay)'
 
 
 class TestV3TierLeaderboardPropagation:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

AROI leaderboard Key Metric cells for the four diversity boards repeated their column-header wording inside each cell (e.g. `5 non-Linux relays (3 OSes)` under **Non-Linux Relays**). Other numeric columns show bare numbers. This change removes the redundant primary-metric labels while keeping parenthetical tiebreaker labels.

| Column | Before | After |
|---|---|---|
| Non-Linux Relays | `4 non-Linux relays (2 OSes)` | `4 (2 OSes)` |
| Distinct OSes | `2 OSes (2 non-Linux relays)` | `2 (2 non-Linux relays)` |
| Non-EU Relays | `30 relays (17 countries)` | `30 (17 countries)` |
| Distinct Countries | `5 countries (9 relays)` | `5 (9 relays)` |

## Changes

- `allium/lib/aroileaders.py` — update the four `*_summary` f-strings
- `tests/helpers/fixtures.py` — align mock summaries
- `tests/unit/aroi/test_leaders_scoring.py` — assert new formats

Column headers, ranking logic, tooltips, and champion badges are unchanged.

## Testing

- `pytest tests/unit/aroi/test_leaders_scoring.py` — 44 passed
- `pytest tests/integration/test_aroi_pagination.py` — 12 passed
- Full site generation (`--apis details`) before/after with `compare_outputs.py`: intended content diffs only on `index.html` and `misc/aroi-leaderboards.html` (plus expected timestamp/API noise on authorities/diagnostics/search-index)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55388e36-f95c-4d62-8059-ea6ee7f3258e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55388e36-f95c-4d62-8059-ea6ee7f3258e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated AROI diversity leaderboard summaries to show the primary count first, with the clarifying label moved into parentheses.
  * Refined singular/plural wording for platform and non-EU diversity summary cells, including edge cases.

* **Tests**
  * Added/extended unit tests to assert exact summary string formats and correct omission of primary unit words outside the parenthetical portion.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->