### PR TITLE
Surface overloaded relays on operator pages: linked bullet, expanded relay list, table ⚡ badges

### DIFF
--- a/allium/lib/contact_sorting.py
+++ b/allium/lib/contact_sorting.py
@@ -30,6 +30,7 @@ CONTACT_SORT_FILE_MAP = {
     'ipv4': 'by-ipv4.html',
     'flags': 'by-flags.html',
     'dns': 'by-dns.html',
+    'overload': 'by-overload.html',  # linked from the Overloaded summary bullet, not a column header
     'family': 'by-family.html',
     'country': 'by-country.html',
     'as_number': 'by-as-number.html',
@@ -254,6 +255,10 @@ def relay_sort_key(relay, sort_mode):
     if sort_mode == 'dns':
         rank = DNS_SORT_RANK.get(relay.get('exit_dns_health_status'), 3)
         return (rank, safe_lower(relay.get('nickname')), fingerprint)
+    if sort_mode == 'overload':
+        # Overloaded relays first, highest bandwidth (impact) first within each group
+        return (0 if relay.get('stability_is_overloaded') else 1,
+                -int(relay.get('observed_bandwidth', 0) or 0), fingerprint)
     if sort_mode == 'family':
         family_type = relay.get('family_support_type', 'none')
         family_len = len(relay.get('effective_family') or [])

--- a/allium/lib/stability_utils.py
+++ b/allium/lib/stability_utils.py
@@ -221,7 +221,10 @@ def compute_group_overload_summary(members):
     overloaded = [r for r in members if r.get('stability_is_overloaded')]
     if not overloaded:
         return None
-    overloaded.sort(key=lambda r: -(r.get('observed_bandwidth') or 0))
+    overloaded.sort(key=lambda r: (
+        -int(r.get('observed_bandwidth', 0) or 0),
+        r.get('fingerprint', ''),
+    ))
     pct = 100.0 * len(overloaded) / total
     return {
         'overloaded': len(overloaded),
@@ -229,4 +232,3 @@ def compute_group_overload_summary(members):
         'pct_formatted': f"{pct:.1f}%" if pct >= 0.05 else "<0.1%",
         'relays': overloaded,
     }
-

--- a/allium/lib/stability_utils.py
+++ b/allium/lib/stability_utils.py
@@ -208,17 +208,25 @@ def compute_relay_stability(relay, now_timestamp=None, bandwidth_formatter=None)
 
 
 def compute_group_overload_summary(members):
-    """Count overloaded relays in a group; None if zero (hides the bullet)."""
+    """Summarize overloaded relays in a group; None if zero (hides the bullet).
+
+    Returns a dict with the count fields plus 'relays': the overloaded member
+    dicts themselves (references, not copies) sorted by observed bandwidth
+    descending — impact order, matching the by-overload.html table sort — so
+    templates can link each relay (nickname/fingerprint/stability_tooltip).
+    """
     total = len(members)
     if not total:
         return None
-    n = sum(1 for r in members if r.get('stability_is_overloaded'))
-    if not n:
+    overloaded = [r for r in members if r.get('stability_is_overloaded')]
+    if not overloaded:
         return None
-    pct = 100.0 * n / total
+    overloaded.sort(key=lambda r: -(r.get('observed_bandwidth') or 0))
+    pct = 100.0 * len(overloaded) / total
     return {
-        'overloaded': n,
+        'overloaded': len(overloaded),
         'total': total,
         'pct_formatted': f"{pct:.1f}%" if pct >= 0.05 else "<0.1%",
+        'relays': overloaded,
     }
 

--- a/allium/templates/contact-relay-list.html
+++ b/allium/templates/contact-relay-list.html
@@ -63,7 +63,7 @@
 {% macro relay_table_header(table_has_ipv6) -%}
 <tr>
     {% if is_contact_sortable %}
-        {{ sort_header('Status', 'status', 'Relay online/offline status') }}
+        {{ sort_header('Status', 'status', 'Relay online/offline status. ⚡ = currently overloaded (click it for details).') }}
         {{ sort_header('Nickname', 'nickname') }}
         {{ sort_header('BW Cap (' ~ bandwidth ~ ' ' ~ bandwidth_unit ~ ')', 'bandwidth', 'Observed bandwidth capacity: An estimate of the capacity this relay can handle. The relay remembers the max bandwidth sustained output over any ten second period in the past 5 days, and another sustained input. The observed value is the lesser of these two numbers.') }}
         {{ sort_header('Total Data', 'total_data', 'Total data transferred by this relay (read + write, 5yr). Source: Onionoo /bandwidth.') }}
@@ -137,6 +137,10 @@
             {% else -%}
                 {{- aroi_validation_icon(relay['fingerprint'], relay['aroi_domain'], validated_fps, unauthorized_fps, misconfigured_fps, security_fps, pending_fps, relay.get('aroi_version')) }}
             {% endif -%}
+        {% endif -%}
+        {# Overload badge: links to the relay's #overload detail section (tooltip = reason) #}
+        {% if relay.get('stability_is_overloaded') -%}
+            <a href="{{ page_ctx.path_prefix }}relay/{{ relay['fingerprint']|escape }}/#overload" class="al-link-plain" title="Overloaded — {{ relay['stability_tooltip']|escape }}. Click for overload details."><span class="al-status-danger-bold" style="margin-left: 3px;">⚡</span></a>
         {% endif -%}
     </td>
     {% if relay['effective_family']|length > 1 -%}

--- a/allium/templates/contact-relay-list.html
+++ b/allium/templates/contact-relay-list.html
@@ -140,7 +140,7 @@
         {% endif -%}
         {# Overload badge: links to the relay's #overload detail section (tooltip = reason) #}
         {% if relay.get('stability_is_overloaded') -%}
-            <a href="{{ page_ctx.path_prefix }}relay/{{ relay['fingerprint']|escape }}/#overload" class="al-link-plain" title="Overloaded — {{ relay['stability_tooltip']|escape }}. Click for overload details."><span class="al-status-danger-bold" style="margin-left: 3px;">⚡</span></a>
+            <a href="{{ page_ctx.path_prefix }}relay/{{ relay['fingerprint']|escape }}/#overload" class="al-link-plain" title="Overloaded — {{ relay['stability_tooltip']|escape }}. Click for overload details." aria-label="{{ relay['nickname']|escape }} is overloaded; view overload details"><span class="al-status-danger-bold" style="margin-left: 3px;">⚡</span></a>
         {% endif -%}
     </td>
     {% if relay['effective_family']|length > 1 -%}

--- a/allium/templates/contact.html
+++ b/allium/templates/contact.html
@@ -200,7 +200,11 @@
                     {% if contact_display_data and contact_display_data.total_data_formatted and contact_display_data.total_data_formatted != 'N/A' %}
                     <li><strong><span title="Total data transferred by all relays belonging to this operator (read + write). Source: Onionoo /bandwidth endpoint.">Total Data Transferred</span>:</strong> {{ contact_display_data.total_data_formatted }}{% if contact_display_data.total_data_pct %} ({{ contact_display_data.total_data_pct }}){% endif %}</li>
                     {% endif -%}
-                    {{- overload_bullet(overload_summary) -}}
+                    {#- Overloaded bullet: count links to the by-overload.html sort variant
+                        (only when that variant exists for this contact, i.e. ≥3 relays);
+                        sub-list links every overloaded relay to its #overload section. -#}
+                    {%- set _ov_file = contact_sort_links.get('overload') if contact_sort_links else none -%}
+                    {{- overload_bullet(overload_summary, (_ov_file ~ '#relay-table') if _ov_file else none, page_ctx.path_prefix) -}}
                     {% if exit_dns_health_summary %}
                     <li><strong><span title="Exit DNS Health: DNS resolution capability of this operator's exit relays. Source: exitdnshealth.1aeo.com">Exit DNS Health</span>:</strong>
                         <span class="al-status-success">{{ exit_dns_health_summary.healthy }} healthy ({{ exit_dns_health_summary.healthy_pct }}%)</span>,

--- a/allium/templates/macros.html
+++ b/allium/templates/macros.html
@@ -176,11 +176,27 @@
 
 {# DRY: Overload summary bullet — used by detail_summary (family/AS pages) and contact.html.
    Hidden entirely when summary is none/empty (0 overloaded relays).
-   Whitespace-stripped so a missing bullet leaves no blank-line residue in the <ul>. #}
-{%- macro overload_bullet(summary) -%}
+   Whitespace-stripped so a missing bullet leaves no blank-line residue in the <ul>.
+   Optional (contact pages): link_href wraps the count in a link to the by-overload.html
+   sort variant; path_prefix renders a fully expanded sub-list linking every overloaded
+   relay (impact order) to its relay/<FP>/#overload detail section. Defaults keep
+   family/AS output unchanged. #}
+{%- macro overload_bullet(summary, link_href=none, path_prefix=none) -%}
 {%- if summary -%}
 <li><strong><span title="Relays in this group currently flagged as overloaded. A relay is overloaded when it reports a general overload event within the last 72 hours (Tor proposal 328: out-of-memory, onionskin drops, TCP port exhaustion), hits its configured bandwidth rate limits, or exhausts file descriptors. Sources: Onionoo /details and /bandwidth endpoints.">Overloaded</span>:</strong>
-    <span class="al-status-danger">{{ summary.pct_formatted }} ({{ summary.overloaded }} of {{ summary.total }} relay{{ 's' if summary.total != 1 else '' }})</span></li>
+{% if link_href %}
+    <a href="{{ link_href }}" class="al-status-danger" title="Show the relay table with overloaded relays sorted first">{{ summary.pct_formatted }} ({{ summary.overloaded }} of {{ summary.total }} relay{{ 's' if summary.total != 1 else '' }})</a>
+{%- else %}
+    <span class="al-status-danger">{{ summary.pct_formatted }} ({{ summary.overloaded }} of {{ summary.total }} relay{{ 's' if summary.total != 1 else '' }})</span>
+{%- endif %}
+{%- if path_prefix is not none and summary.relays %}
+    <ul style="list-style-type: circle; padding-left: 20px; margin-top: 3px; margin-bottom: 0;">
+        <li style="font-size: 13px;">
+            {%- for r in summary.relays %}<a href="{{ path_prefix }}relay/{{ r['fingerprint']|escape }}/#overload" class="al-status-danger" title="{{ r['stability_tooltip']|escape }}">{{ r['nickname']|escape }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+        </li>
+    </ul>
+{%- endif -%}
+</li>
 {%- endif -%}
 {%- endmacro -%}
 

--- a/tests/integration/test_contact_template.py
+++ b/tests/integration/test_contact_template.py
@@ -509,20 +509,10 @@ class TestContactTemplateIntegration(unittest.TestCase):
         context['contact_sort_links'] = CONTACT_SORT_FILE_MAP
         context['contact_sort_enabled'] = True
         context['contact_has_ipv6'] = True
-        # Overloaded bullet: count links to the by-overload.html variant (no column header)
-        context['overload_summary'] = {
-            'overloaded': 1, 'total': 3, 'pct_formatted': '33.3%',
-            'relays': [{'nickname': 'TestRelay', 'fingerprint': 'ABC123DEF456',
-                        'stability_tooltip': 'FD exhaustion reported'}],
-        }
-
         template = self.jinja_env.get_template('contact.html')
         rendered = template.render(**context)
 
         # Non-default sort links should point to by-*.html pages with #relay-table anchor
-        self.assertIn('href="by-overload.html#relay-table"', rendered)
-        # Each overloaded relay links straight to its #overload detail section
-        self.assertIn('href="../relay/ABC123DEF456/#overload"', rendered)
         self.assertIn('href="by-nickname.html#relay-table"', rendered)
         self.assertIn('href="by-total-data.html#relay-table"', rendered)
         self.assertIn('href="by-uptime-percentage.html#relay-table"', rendered)
@@ -1448,6 +1438,21 @@ class TestContactTemplateIPv6Column:
         assert '2001:db8::1' not in v4_row
         last_cell = v4_row.rsplit('<td>', 1)[-1]
         assert 'N/A' in last_cell
+
+
+def test_contact_template_overload_links(jinja_env, overload_relay_set):
+    """Render overload listing and relay-detail links with shared pytest fixtures."""
+    contact, group = next(iter(overload_relay_set.json['sorted']['contact'].items()))
+    context = build_template_args(
+        overload_relay_set, 'contact', contact, group, [], set())
+
+    template = jinja_env.get_template('contact.html')
+    rendered = template.render(relays=overload_relay_set, **context)
+
+    assert 'href="by-overload.html#relay-table"' in rendered
+    path_prefix = context['page_ctx']['path_prefix']
+    for relay in context['overload_summary']['relays']:
+        assert f'href="{path_prefix}relay/{relay["fingerprint"]}/#overload"' in rendered
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_contact_template.py
+++ b/tests/integration/test_contact_template.py
@@ -509,11 +509,20 @@ class TestContactTemplateIntegration(unittest.TestCase):
         context['contact_sort_links'] = CONTACT_SORT_FILE_MAP
         context['contact_sort_enabled'] = True
         context['contact_has_ipv6'] = True
+        # Overloaded bullet: count links to the by-overload.html variant (no column header)
+        context['overload_summary'] = {
+            'overloaded': 1, 'total': 3, 'pct_formatted': '33.3%',
+            'relays': [{'nickname': 'TestRelay', 'fingerprint': 'ABC123DEF456',
+                        'stability_tooltip': 'FD exhaustion reported'}],
+        }
 
         template = self.jinja_env.get_template('contact.html')
         rendered = template.render(**context)
 
         # Non-default sort links should point to by-*.html pages with #relay-table anchor
+        self.assertIn('href="by-overload.html#relay-table"', rendered)
+        # Each overloaded relay links straight to its #overload detail section
+        self.assertIn('href="../relay/ABC123DEF456/#overload"', rendered)
         self.assertIn('href="by-nickname.html#relay-table"', rendered)
         self.assertIn('href="by-total-data.html#relay-table"', rendered)
         self.assertIn('href="by-uptime-percentage.html#relay-table"', rendered)

--- a/tests/unit/relays/test_contact_sorting.py
+++ b/tests/unit/relays/test_contact_sorting.py
@@ -140,7 +140,8 @@ def test_contact_sort_modes_have_expected_mapping():
     assert "bandwidth" in CONTACT_SORT_MODES
     assert CONTACT_SORT_FILE_MAP["bandwidth"] == "index.html"
     assert "by-bandwidth.html" not in CONTACT_SORT_FILE_MAP.values()
-    assert len(CONTACT_SORT_MODES) == 18
+    assert CONTACT_SORT_FILE_MAP["overload"] == "by-overload.html"
+    assert len(CONTACT_SORT_MODES) == 19
 
 
 def test_contact_sorting_produces_deterministic_order_for_all_modes():
@@ -163,10 +164,21 @@ def test_selected_sort_mode_expected_first_rows():
     assert sort_contact_relays(relays, "flag_uptime")[0]["nickname"] == "beta"
     assert sort_contact_relays(relays, "ipv4")[0]["nickname"] == "beta"
     assert sort_contact_relays(relays, "dns")[0]["nickname"] == "beta"
+    assert sort_contact_relays(relays, "overload")[0]["nickname"] == "beta"  # none overloaded -> bandwidth order
     assert sort_contact_relays(relays, "family")[0]["nickname"] == "beta"
     assert sort_contact_relays(relays, "first_seen")[0]["nickname"] == "beta"  # newest first
     assert sort_contact_relays(relays, "last_restarted")[0]["nickname"] == "beta"  # newest first
     assert sort_contact_relays(relays, "ipv6")[0]["nickname"] == "beta"
+
+
+def test_overload_sort_groups_overloaded_first_by_bandwidth():
+    """Overloaded relays sort first (bandwidth desc within each group)."""
+    relays = _sample_relays()
+    relays[0]["stability_is_overloaded"] = True   # alpha, bw 100
+    relays[2]["stability_is_overloaded"] = True   # gamma, bw 200
+    ordered = [r["nickname"] for r in sort_contact_relays(relays, "overload")]
+    # gamma (overloaded, 200) > alpha (overloaded, 100) > beta (not overloaded, 300)
+    assert ordered == ["gamma", "alpha", "beta"]
 
 
 def test_contact_sort_tie_breaker_uses_fingerprint():

--- a/tests/unit/relays/test_overload_summary.py
+++ b/tests/unit/relays/test_overload_summary.py
@@ -52,6 +52,18 @@ def test_summary_relays_are_references_in_impact_order():
     assert summary['relays'][0] is big  # reference, not a copy
 
 
+def test_summary_relay_order_uses_fingerprint_for_bandwidth_ties():
+    """Expanded summary order must match the overload table's tie-breaker."""
+    relay_b = {'stability_is_overloaded': True, 'observed_bandwidth': 9,
+               'fingerprint': 'B' * 40}
+    relay_a = {'stability_is_overloaded': True, 'observed_bandwidth': 9,
+               'fingerprint': 'A' * 40}
+
+    summary = compute_group_overload_summary([relay_b, relay_a])
+
+    assert summary['relays'] == [relay_a, relay_b]
+
+
 def test_tiny_fraction_uses_floor():
     """1 of 3000 would round to 0.0% — must show <0.1% instead."""
     members = [{'stability_is_overloaded': True}] + [{}] * 2999
@@ -152,17 +164,20 @@ BULLET_TMPL = ("{% from 'macros.html' import overload_bullet %}"
 
 
 def _render_bullet(jinja_env, link_href=None, path_prefix=None, summary=SAMPLE_SUMMARY):
+    """Render overload_bullet with its optional contact-page link arguments."""
     return jinja_env.from_string(BULLET_TMPL).render(
         summary=summary, link_href=link_href, path_prefix=path_prefix)
 
 
 def test_overload_bullet_link_href_wraps_count(jinja_env):
+    """Link the summary count to the overload sort variant when provided."""
     rendered = _render_bullet(jinja_env, link_href='by-overload.html#relay-table')
     assert '<a href="by-overload.html#relay-table" class="al-status-danger"' in rendered
     assert '20.0% (2 of 10 relays)' in rendered
 
 
 def test_overload_bullet_path_prefix_renders_expanded_relay_links(jinja_env):
+    """List every overloaded relay when a relay-detail path is available."""
     rendered = _render_bullet(jinja_env, path_prefix='../../')
     # Every overloaded relay linked straight to its #overload detail section
     assert f'href="../../relay/{"A" * 40}/#overload"' in rendered
@@ -176,6 +191,7 @@ def test_overload_bullet_path_prefix_renders_expanded_relay_links(jinja_env):
 
 
 def test_overload_bullet_no_relay_list_without_path_prefix(jinja_env):
+    """Do not expose relay-detail links without a path prefix."""
     rendered = _render_bullet(jinja_env, link_href='by-overload.html#relay-table')
     assert '#overload' not in rendered.replace('by-overload.html', '')
 
@@ -258,9 +274,11 @@ def test_contact_relay_row_overload_badge(jinja_env):
     rendered = jinja_env.get_template('contact.html').render(**context)
     assert '⚡' in rendered
     assert f'href="../relay/{relay["fingerprint"]}/#overload"' in rendered
+    assert 'aria-label="TestRelay is overloaded; view overload details"' in rendered
     assert 'General overload at 2026-07-31 06:12 UTC. Click for overload details.' in rendered
 
 
 def test_contact_relay_row_no_badge_when_not_overloaded(jinja_env):
+    """Do not render an overload badge for a healthy relay."""
     rendered = jinja_env.get_template('contact.html').render(**_contact_context(None))
     assert '⚡' not in rendered

--- a/tests/unit/relays/test_overload_summary.py
+++ b/tests/unit/relays/test_overload_summary.py
@@ -10,7 +10,13 @@ import pytest
 from allium.lib.page_writer import build_template_args
 from allium.lib.stability_utils import compute_group_overload_summary
 
-SAMPLE_SUMMARY = {'overloaded': 2, 'total': 10, 'pct_formatted': '20.0%'}
+SAMPLE_RELAYS = [
+    {'nickname': 'BigRelay', 'fingerprint': 'A' * 40, 'observed_bandwidth': 2000000,
+     'stability_is_overloaded': True, 'stability_tooltip': 'Rate limits hit W:2 R:0 (limit: 10 MB/s)'},
+    {'nickname': 'SmallRelay', 'fingerprint': 'B' * 40, 'observed_bandwidth': 1000000,
+     'stability_is_overloaded': True, 'stability_tooltip': 'FD exhaustion reported'},
+]
+SAMPLE_SUMMARY = {'overloaded': 2, 'total': 10, 'pct_formatted': '20.0%', 'relays': SAMPLE_RELAYS}
 
 
 # ---------------------------------------------------------------------------
@@ -22,14 +28,28 @@ SAMPLE_SUMMARY = {'overloaded': 2, 'total': 10, 'pct_formatted': '20.0%'}
     ([{'stability_is_overloaded': False}, {}], None),                # zero overloaded / missing key
     ([{'stability_is_overloaded': True}] * 3
      + [{'stability_is_overloaded': False}] * 5,
-     {'overloaded': 3, 'total': 8, 'pct_formatted': '37.5%'}),       # mixed
+     {'overloaded': 3, 'total': 8, 'pct_formatted': '37.5%',
+      'relays': [{'stability_is_overloaded': True}] * 3}),           # mixed
     ([{'stability_is_overloaded': True}] * 4,
-     {'overloaded': 4, 'total': 4, 'pct_formatted': '100.0%'}),      # all overloaded
+     {'overloaded': 4, 'total': 4, 'pct_formatted': '100.0%',
+      'relays': [{'stability_is_overloaded': True}] * 4}),           # all overloaded
     ([{'stability_is_overloaded': True}, {}, {'nickname': 'x'}],
-     {'overloaded': 1, 'total': 3, 'pct_formatted': '33.3%'}),       # missing keys mixed in
+     {'overloaded': 1, 'total': 3, 'pct_formatted': '33.3%',
+      'relays': [{'stability_is_overloaded': True}]}),               # missing keys mixed in
 ])
 def test_compute_group_overload_summary(members, expected):
     assert compute_group_overload_summary(members) == expected
+
+
+def test_summary_relays_are_references_in_impact_order():
+    """'relays' holds the member dicts themselves (no copies), sorted by
+    observed_bandwidth desc; missing bandwidth is treated as 0 (sorts last)."""
+    small = {'stability_is_overloaded': True, 'observed_bandwidth': 1, 'nickname': 's'}
+    big = {'stability_is_overloaded': True, 'observed_bandwidth': 9, 'nickname': 'b'}
+    no_bw = {'stability_is_overloaded': True, 'nickname': 'n'}
+    summary = compute_group_overload_summary([small, {'healthy': True}, big, no_bw])
+    assert [r['nickname'] for r in summary['relays']] == ['b', 's', 'n']
+    assert summary['relays'][0] is big  # reference, not a copy
 
 
 def test_tiny_fraction_uses_floor():
@@ -53,8 +73,10 @@ def _args(relay_set, page_key):
 
 @pytest.mark.parametrize('page_key', ['contact', 'family', 'as'])
 def test_build_template_args_includes_overload_summary(overload_relay_set, page_key):
-    assert _args(overload_relay_set, page_key)['overload_summary'] == {
-        'overloaded': 2, 'total': 4, 'pct_formatted': '50.0%'}
+    summary = _args(overload_relay_set, page_key)['overload_summary']
+    assert (summary['overloaded'], summary['total'], summary['pct_formatted']) == (2, 4, '50.0%')
+    # relays 0 and 1 are the overloaded ones (fixture flags i < 2)
+    assert sorted(r['fingerprint'] for r in summary['relays']) == [f'{i:040d}' for i in range(2)]
 
 
 def test_build_template_args_skips_out_of_scope_pages(overload_relay_set):
@@ -106,6 +128,10 @@ def test_detail_summary_shows_overload_before_dns(jinja_env):
     assert '20.0% (2 of 10 relays)' in rendered
     assert 'al-status-danger' in rendered
     assert rendered.index('Overloaded') < rendered.index('Exit DNS Health')
+    # Regression guard: family/AS pages (via detail_summary) keep the plain
+    # bullet — no variant link and no per-relay #overload links.
+    assert 'by-overload.html' not in rendered
+    assert '#overload' not in rendered
 
 
 def test_detail_summary_hides_overload_when_none(jinja_env):
@@ -118,6 +144,40 @@ def test_overload_bullet_macro_singular(jinja_env):
     ).render(summary={'overloaded': 1, 'total': 1, 'pct_formatted': '100.0%'})
     assert '100.0% (1 of 1 relay)' in rendered
     assert '1 relays' not in rendered
+    assert '<a ' not in rendered  # defaults render no links at all
+
+
+BULLET_TMPL = ("{% from 'macros.html' import overload_bullet %}"
+               "{{ overload_bullet(summary, link_href, path_prefix) }}")
+
+
+def _render_bullet(jinja_env, link_href=None, path_prefix=None, summary=SAMPLE_SUMMARY):
+    return jinja_env.from_string(BULLET_TMPL).render(
+        summary=summary, link_href=link_href, path_prefix=path_prefix)
+
+
+def test_overload_bullet_link_href_wraps_count(jinja_env):
+    rendered = _render_bullet(jinja_env, link_href='by-overload.html#relay-table')
+    assert '<a href="by-overload.html#relay-table" class="al-status-danger"' in rendered
+    assert '20.0% (2 of 10 relays)' in rendered
+
+
+def test_overload_bullet_path_prefix_renders_expanded_relay_links(jinja_env):
+    rendered = _render_bullet(jinja_env, path_prefix='../../')
+    # Every overloaded relay linked straight to its #overload detail section
+    assert f'href="../../relay/{"A" * 40}/#overload"' in rendered
+    assert f'href="../../relay/{"B" * 40}/#overload"' in rendered
+    assert '>BigRelay</a>' in rendered and '>SmallRelay</a>' in rendered
+    # Impact order (highest bandwidth first) and reason tooltips
+    assert rendered.index('BigRelay') < rendered.index('SmallRelay')
+    assert 'Rate limits hit W:2 R:0 (limit: 10 MB/s)' in rendered
+    # Fully expanded per user requirement — no collapse mechanism
+    assert '<details' not in rendered
+
+
+def test_overload_bullet_no_relay_list_without_path_prefix(jinja_env):
+    rendered = _render_bullet(jinja_env, link_href='by-overload.html#relay-table')
+    assert '#overload' not in rendered.replace('by-overload.html', '')
 
 
 def _contact_context(overload_summary):
@@ -166,3 +226,41 @@ def test_contact_html_shows_overload_before_dns(jinja_env):
 def test_contact_html_hides_overload_when_none(jinja_env):
     rendered = jinja_env.get_template('contact.html').render(**_contact_context(None))
     assert 'Overloaded' not in rendered
+
+
+def test_contact_html_bullet_lists_overloaded_relays_expanded(jinja_env):
+    """Option 2: all overloaded relays linked to their #overload sections,
+    fully expanded (no collapse), even when the sort variant doesn't exist."""
+    rendered = jinja_env.get_template('contact.html').render(**_contact_context(SAMPLE_SUMMARY))
+    assert f'href="../relay/{"A" * 40}/#overload"' in rendered
+    assert f'href="../relay/{"B" * 40}/#overload"' in rendered
+    assert '<details' not in rendered
+    # No by-overload.html variant for this contact (contact_sort_links={}) -> unlinked count
+    assert 'by-overload.html' not in rendered
+
+
+def test_contact_html_bullet_count_links_variant_when_available(jinja_env):
+    """Option 1: the count links to the by-overload.html sort variant."""
+    context = _contact_context(SAMPLE_SUMMARY)
+    context['contact_sort_links'] = {'overload': 'by-overload.html'}
+    rendered = jinja_env.get_template('contact.html').render(**context)
+    assert '<a href="by-overload.html#relay-table" class="al-status-danger"' in rendered
+    assert '20.0% (2 of 10 relays)' in rendered
+
+
+def test_contact_relay_row_overload_badge(jinja_env):
+    """Option 1: overloaded relays get a ⚡ in the Status column linking to
+    their #overload section; healthy relays get no badge."""
+    context = _contact_context(SAMPLE_SUMMARY)
+    relay = context['relay_subset'][0]
+    relay['stability_is_overloaded'] = True
+    relay['stability_tooltip'] = 'General overload at 2026-07-31 06:12 UTC'
+    rendered = jinja_env.get_template('contact.html').render(**context)
+    assert '⚡' in rendered
+    assert f'href="../relay/{relay["fingerprint"]}/#overload"' in rendered
+    assert 'General overload at 2026-07-31 06:12 UTC. Click for overload details.' in rendered
+
+
+def test_contact_relay_row_no_badge_when_not_overloaded(jinja_env):
+    rendered = jinja_env.get_template('contact.html').render(**_contact_context(None))
+    assert '⚡' not in rendered


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Operator (contact) pages showed an **"Overloaded: X% (N of M relays)"** summary bullet with no way to see *which* relays are overloaded or click into them. This PR adds three complementary affordances (Options 1 + 2 from the design review):

1. **Clickable bullet count** → links to a new `by-overload.html` static sort variant that groups overloaded relays at the top of the relay table (overloaded first, then observed bandwidth desc). Reuses the existing no-JS sort-variant machinery — vanity-URL copies and stale-file cleanup come free via `CONTACT_SORT_FILE_MAP`.
2. **Expanded relay list under the bullet** — every overloaded relay listed as a red link straight to its `relay/<FP>/#overload` detail section, in impact order (bandwidth desc), hover shows the overload reason. Always fully expanded: no cap, no collapse.
3. **⚡ badge in the existing Status column** for each overloaded relay row (zero new columns in the already 17–18-column table), linking to `relay/<FP>/#overload` with the reason as tooltip. Visible in every sort order and every AROI section.

### Real generated page (operator with 4 of 8 relays overloaded)

Summary area — linked count + expanded relay links:
[Operator page overload bullet with relay links](https://cursor.com/agents/bc-7e400f3d-fb9b-48dc-b6e5-309303c0daa1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffinal%2Freal-operator-page-overload-bullet.png)

`by-overload.html` — overloaded relays grouped at top, ⚡ badges in Status column:
[by-overload table with badges](https://cursor.com/agents/bc-7e400f3d-fb9b-48dc-b6e5-309303c0daa1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffinal%2Freal-operator-table-badges.png)

## How

- `stability_utils.compute_group_overload_summary()` — single pass now also returns `relays`: the overloaded member dicts (references, no copies) sorted by bandwidth desc.
- `contact_sorting.py` — new `overload` sort mode + `by-overload.html` file mapping.
- `macros.html` `overload_bullet(summary, link_href=none, path_prefix=none)` — defaults render **byte-identical** output for existing family/AS callers (verified against the pre-change template).
- `contact.html` — passes the variant link (only when the variant exists, i.e. ≥3 relays) and `path_prefix`.
- `contact-relay-list.html` `relay_row()` — one conditional adds the ⚡ badge; Status header tooltip documents it.

Note: `family.html` shares `contact-relay-list.html`, so family-page relay tables also show the ⚡ badge (consistent and useful — the family page renders the same Overloaded bullet). Family/AS summary bullets themselves are unchanged.

## Verification

- `pytest`: 1129 passed (new unit tests for the sort mode, summary shape/ordering/reference-reuse, bullet link/list rendering, badge rendering, family/AS byte-identity regression guards).
- `flake8 --select=E9,F63,F7,F82`: clean.
- **Identical-input output diff** (user requirement): generated the full ~28k-page site before and after the change against byte-identical cached API data (network tarpitted so all 7 APIs fell back to the same cache). Audited every changed line across all 8,458 differing contact/family files plus all other categories:
  - 320 new `by-overload.html` files (contacts with ≥3 relays) — intended
  - contact pages: only the linked bullet, relay sub-list, ⚡ badges, Status tooltip — intended
  - family pages: only ⚡ badges (shared table) — intended
  - AS/country/flag/platform/first_seen/misc/relay/root: only time-relative noise (`8mo`→`9mo` age rollovers, uptime-hour ticks, cache-age displays)
  - **zero unexplained content changes**


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e400f3d-fb9b-48dc-b6e5-309303c0daa1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e400f3d-fb9b-48dc-b6e5-309303c0daa1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an overload-focused relay sorting option.
  * Overloaded relays now appear first, ordered by observed bandwidth with consistent tie-breaking.
  * Overload summaries link to filtered relay listings and individual relay details.
  * Added overload badges and explanatory tooltips to relay tables.
* **Tests**
  * Expanded coverage for overload sorting, summary links, badges, tooltips, and relay ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->