### PR TITLE
Add search verification and crawler discovery

### DIFF
--- a/allium/allium.py
+++ b/allium/allium.py
@@ -267,10 +267,10 @@ if __name__ == "__main__":
     # Page generation: details-loaded + section start, generating+generated
     # per standalone page, misc sorted pages x2, one completion per detail
     # page key, then relay pages / static files / search index / prometheus
-    # metrics x2 each, section end + completion message.
+    # metrics and search-discovery files x2 each, section end + completion message.
     page_generation_steps = (2 + 2 * len(STANDALONE_PAGES)
                              + 2 + len(SORTED_PAGE_KEYS)
-                             + 2 + 2 + 2 + 2 + 2)
+                             + 2 + 2 + 2 + 2 + 2 + 2)
 
     total_steps = setup_steps + coordinator_steps + page_generation_steps
 

--- a/allium/lib/search_discovery.py
+++ b/allium/lib/search_discovery.py
@@ -1,0 +1,118 @@
+"""Generate crawler discovery files for a completed static site build."""
+
+from pathlib import Path
+from urllib.parse import quote, urlsplit, urlunsplit
+import xml.etree.ElementTree as ET
+
+
+SITEMAP_NAMESPACE = "http://www.sitemaps.org/schemas/sitemap/0.9"
+MAX_URLS_PER_SITEMAP = 50_000
+
+ET.register_namespace("", SITEMAP_NAMESPACE)
+
+
+def _public_base_url(base_url):
+    """Return a normalized public HTTPS origin, or ``None`` for local builds."""
+    parsed = urlsplit(base_url or "")
+    if parsed.scheme != "https" or not parsed.netloc:
+        return None
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError("base_url must be a public HTTPS origin")
+    if parsed.path not in ("", "/"):
+        raise ValueError("base_url must not contain a path")
+    return urlunsplit(("https", parsed.netloc, "", "", ""))
+
+
+def _route_for_html(relative_path):
+    """Map a generated HTML file to its extensionless canonical route."""
+    relative_path = Path(relative_path)
+    if relative_path.as_posix() == "404.html":
+        return None
+    if relative_path.name == "index.html":
+        parent = relative_path.parent.as_posix()
+        route = "/" if parent == "." else f"/{parent}/"
+    else:
+        route = f"/{relative_path.with_suffix('').as_posix()}"
+    return quote(route, safe="/-._~")
+
+
+def _generated_urls(output_dir, base_url):
+    """Enumerate the real HTML routes present in the completed output tree."""
+    output_path = Path(output_dir)
+    urls = []
+    for html_path in output_path.rglob("*.html"):
+        if not html_path.is_file():
+            continue
+        route = _route_for_html(html_path.relative_to(output_path))
+        if route is not None:
+            urls.append(f"{base_url}{route}")
+    return sorted(set(urls))
+
+
+def _write_xml(root, destination):
+    tree = ET.ElementTree(root)
+    tree.write(destination, encoding="utf-8", xml_declaration=True)
+
+
+def _urlset(urls):
+    root = ET.Element(f"{{{SITEMAP_NAMESPACE}}}urlset")
+    for url in urls:
+        entry = ET.SubElement(root, f"{{{SITEMAP_NAMESPACE}}}url")
+        ET.SubElement(entry, f"{{{SITEMAP_NAMESPACE}}}loc").text = url
+    return root
+
+
+def _remove_old_shards(output_path):
+    for candidate in output_path.glob("sitemap-*.xml"):
+        suffix = candidate.stem[len("sitemap-"):]
+        if suffix.isdigit() and candidate.is_file():
+            candidate.unlink()
+
+
+def generate_search_discovery(output_dir, base_url):
+    """Write production robots and sitemap files.
+
+    Local builds without an absolute HTTPS base URL are intentionally skipped,
+    since sitemap ``loc`` values must be absolute public URLs.
+    """
+    public_base_url = _public_base_url(base_url)
+    if public_base_url is None:
+        return {"generated": False, "url_count": 0, "sitemap_count": 0}
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    urls = _generated_urls(output_path, public_base_url)
+    if not urls:
+        raise ValueError("cannot generate a sitemap without public HTML routes")
+
+    _remove_old_shards(output_path)
+    sitemap_path = output_path / "sitemap.xml"
+    if len(urls) <= MAX_URLS_PER_SITEMAP:
+        _write_xml(_urlset(urls), sitemap_path)
+        sitemap_count = 1
+    else:
+        sitemap_count = 0
+        sitemap_index = ET.Element(f"{{{SITEMAP_NAMESPACE}}}sitemapindex")
+        for offset in range(0, len(urls), MAX_URLS_PER_SITEMAP):
+            sitemap_count += 1
+            shard_name = f"sitemap-{sitemap_count}.xml"
+            shard_urls = urls[offset:offset + MAX_URLS_PER_SITEMAP]
+            _write_xml(_urlset(shard_urls), output_path / shard_name)
+            entry = ET.SubElement(
+                sitemap_index, f"{{{SITEMAP_NAMESPACE}}}sitemap")
+            ET.SubElement(
+                entry, f"{{{SITEMAP_NAMESPACE}}}loc"
+            ).text = f"{public_base_url}/{shard_name}"
+        _write_xml(sitemap_index, sitemap_path)
+
+    robots = (
+        "User-agent: *\n"
+        "Allow: /\n"
+        f"Sitemap: {public_base_url}/sitemap.xml\n"
+    )
+    (output_path / "robots.txt").write_text(robots, encoding="utf-8")
+    return {
+        "generated": True,
+        "url_count": len(urls),
+        "sitemap_count": sitemap_count,
+    }

--- a/allium/lib/search_discovery.py
+++ b/allium/lib/search_discovery.py
@@ -7,6 +7,7 @@ import xml.etree.ElementTree as ET
 
 SITEMAP_NAMESPACE = "http://www.sitemaps.org/schemas/sitemap/0.9"
 MAX_URLS_PER_SITEMAP = 50_000
+MAX_BYTES_PER_SITEMAP = 52_428_800
 
 ET.register_namespace("", SITEMAP_NAMESPACE)
 
@@ -50,8 +51,11 @@ def _generated_urls(output_dir, base_url):
 
 
 def _write_xml(root, destination):
-    tree = ET.ElementTree(root)
-    tree.write(destination, encoding="utf-8", xml_declaration=True)
+    Path(destination).write_bytes(_serialize_xml(root))
+
+
+def _serialize_xml(root):
+    return ET.tostring(root, encoding="utf-8", xml_declaration=True)
 
 
 def _urlset(urls):
@@ -60,6 +64,39 @@ def _urlset(urls):
         entry = ET.SubElement(root, f"{{{SITEMAP_NAMESPACE}}}url")
         ET.SubElement(entry, f"{{{SITEMAP_NAMESPACE}}}loc").text = url
     return root
+
+
+def _pack_sitemap_urls(
+        urls,
+        max_urls=MAX_URLS_PER_SITEMAP,
+        max_bytes=MAX_BYTES_PER_SITEMAP):
+    """Pack URLs without exceeding either sitemap protocol limit."""
+    sentinel = "x"
+    one_entry_size = len(_serialize_xml(_urlset([sentinel])))
+    added_entry_size = (
+        len(_serialize_xml(_urlset([sentinel, sentinel]))) - one_entry_size
+    )
+    base_size = one_entry_size - added_entry_size
+    groups = []
+    current = []
+    current_size = base_size
+
+    for url in urls:
+        entry_size = len(_serialize_xml(_urlset([url]))) - base_size
+        if base_size + entry_size > max_bytes:
+            raise ValueError(f"sitemap URL is too large to serialize: {url}")
+        if current and (
+                len(current) >= max_urls
+                or current_size + entry_size > max_bytes):
+            groups.append(current)
+            current = []
+            current_size = base_size
+        current.append(url)
+        current_size += entry_size
+
+    if current:
+        groups.append(current)
+    return groups
 
 
 def _remove_old_shards(output_path):
@@ -97,16 +134,16 @@ def generate_search_discovery(output_dir, base_url):
 
     _remove_old_shards(output_path)
     sitemap_path = output_path / "sitemap.xml"
-    if len(urls) <= MAX_URLS_PER_SITEMAP:
-        _write_xml(_urlset(urls), sitemap_path)
+    url_groups = _pack_sitemap_urls(urls)
+    if len(url_groups) == 1:
+        _write_xml(_urlset(url_groups[0]), sitemap_path)
         sitemap_count = 1
     else:
         sitemap_count = 0
         sitemap_index = ET.Element(f"{{{SITEMAP_NAMESPACE}}}sitemapindex")
-        for offset in range(0, len(urls), MAX_URLS_PER_SITEMAP):
+        for shard_urls in url_groups:
             sitemap_count += 1
             shard_name = f"sitemap-{sitemap_count}.xml"
-            shard_urls = urls[offset:offset + MAX_URLS_PER_SITEMAP]
             _write_xml(_urlset(shard_urls), output_path / shard_name)
             entry = ET.SubElement(
                 sitemap_index, f"{{{SITEMAP_NAMESPACE}}}sitemap")

--- a/allium/lib/search_discovery.py
+++ b/allium/lib/search_discovery.py
@@ -106,7 +106,7 @@ def _remove_old_shards(output_path):
             candidate.unlink()
 
 
-def _remove_search_discovery(output_path):
+def _remove_search_discovery(output_path) -> None:
     """Remove generated crawler files that are invalid for a local build."""
     for filename in ("robots.txt", "sitemap.xml"):
         candidate = output_path / filename

--- a/allium/lib/search_discovery.py
+++ b/allium/lib/search_discovery.py
@@ -69,17 +69,27 @@ def _remove_old_shards(output_path):
             candidate.unlink()
 
 
+def _remove_search_discovery(output_path):
+    """Remove generated crawler files that are invalid for a local build."""
+    for filename in ("robots.txt", "sitemap.xml"):
+        candidate = output_path / filename
+        if candidate.is_file():
+            candidate.unlink()
+    _remove_old_shards(output_path)
+
+
 def generate_search_discovery(output_dir, base_url):
     """Write production robots and sitemap files.
 
     Local builds without an absolute HTTPS base URL are intentionally skipped,
     since sitemap ``loc`` values must be absolute public URLs.
     """
+    output_path = Path(output_dir)
     public_base_url = _public_base_url(base_url)
     if public_base_url is None:
+        _remove_search_discovery(output_path)
         return {"generated": False, "url_count": 0, "sitemap_count": 0}
 
-    output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
     urls = _generated_urls(output_path, public_base_url)
     if not urls:

--- a/allium/lib/site_generator.py
+++ b/allium/lib/site_generator.py
@@ -204,6 +204,20 @@ def generate_site(relay_set, args, progress_logger):
         prom_msg += " [AROI source unavailable]"
     progress_logger.log(prom_msg)
 
+    # --- Search-engine discovery files ---
+    progress_logger.log("Generating search-engine discovery files...")
+    from .search_discovery import generate_search_discovery
+    discovery_stats = generate_search_discovery(args.output_dir, args.base_url)
+    if discovery_stats["generated"]:
+        progress_logger.log(
+            f"Generated robots.txt and {discovery_stats['sitemap_count']} sitemap "
+            f"file(s) for {discovery_stats['url_count']} public routes"
+        )
+    else:
+        progress_logger.log(
+            "Skipped search-engine discovery files for non-production base URL"
+        )
+
     # End page generation section
     progress_logger.end_section("Page Generation")
     progress_logger.log("Allium static site generation completed successfully!")

--- a/allium/templates/skeleton.html
+++ b/allium/templates/skeleton.html
@@ -8,6 +8,8 @@
             <meta name="description"
                   content="Javascript-free Tor metrics generated from a 30 minute API request.">
             <meta charset="utf-8">
+            <meta name="google-site-verification" content="XaJCH6-K355pE6DNYj50QvpVDHrmcGT_NBUey3dXiKc">
+            <meta name="msvalidate.01" content="8B983F2DC788493BCD2FC9B8C74AAEDD">
             <meta name="viewport" content="width=device-width, initial-scale=1">
             {% block canonical_link %}{% endblock %}
             <link rel="stylesheet" href="{{ page_ctx.path_prefix }}static/css/bootstrap.min.css">

--- a/tests/unit/test_search_discovery.py
+++ b/tests/unit/test_search_discovery.py
@@ -50,12 +50,18 @@ def test_generates_exact_robots_and_valid_sitemap(temp_dir):
 
 
 def test_local_build_skips_public_discovery_files(temp_dir):
+    for filename in ("robots.txt", "sitemap.xml", "sitemap-1.xml"):
+        with open(os.path.join(temp_dir, filename), "w", encoding="utf-8") as handle:
+            handle.write("stale production content")
+
     assert generate_search_discovery(temp_dir, "") == {
         "generated": False,
         "url_count": 0,
         "sitemap_count": 0,
     }
+    assert not os.path.exists(os.path.join(temp_dir, "robots.txt"))
     assert not os.path.exists(os.path.join(temp_dir, "sitemap.xml"))
+    assert not os.path.exists(os.path.join(temp_dir, "sitemap-1.xml"))
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_search_discovery.py
+++ b/tests/unit/test_search_discovery.py
@@ -1,0 +1,75 @@
+"""Tests for robots.txt and sitemap generation."""
+
+import os
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from allium.lib.search_discovery import (
+    SITEMAP_NAMESPACE,
+    _route_for_html,
+    generate_search_discovery,
+)
+
+
+def test_route_for_html_uses_public_canonical_forms():
+    assert _route_for_html("index.html") == "/"
+    assert _route_for_html("relay/ABC/index.html") == "/relay/ABC/"
+    assert _route_for_html("misc/all.html") == "/misc/all"
+    assert _route_for_html("404.html") is None
+
+
+def test_generates_exact_robots_and_valid_sitemap(temp_dir):
+    os.makedirs(os.path.join(temp_dir, "relay", "ABC"))
+    for relative in ("index.html", "top500.html", "relay/ABC/index.html", "404.html"):
+        destination = os.path.join(temp_dir, relative)
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        with open(destination, "w", encoding="utf-8") as handle:
+            handle.write("<!doctype html><title>public</title>")
+
+    stats = generate_search_discovery(temp_dir, "https://metrics.1aeo.com/")
+
+    assert stats == {"generated": True, "url_count": 3, "sitemap_count": 1}
+    with open(os.path.join(temp_dir, "robots.txt"), encoding="utf-8") as handle:
+        assert handle.read() == (
+            "User-agent: *\n"
+            "Allow: /\n"
+            "Sitemap: https://metrics.1aeo.com/sitemap.xml\n"
+        )
+
+    root = ET.parse(os.path.join(temp_dir, "sitemap.xml")).getroot()
+    assert root.tag == f"{{{SITEMAP_NAMESPACE}}}urlset"
+    locations = [
+        node.text for node in root.findall(f"{{{SITEMAP_NAMESPACE}}}url/{{{SITEMAP_NAMESPACE}}}loc")
+    ]
+    assert locations == [
+        "https://metrics.1aeo.com/",
+        "https://metrics.1aeo.com/relay/ABC/",
+        "https://metrics.1aeo.com/top500",
+    ]
+
+
+def test_local_build_skips_public_discovery_files(temp_dir):
+    assert generate_search_discovery(temp_dir, "") == {
+        "generated": False,
+        "url_count": 0,
+        "sitemap_count": 0,
+    }
+    assert not os.path.exists(os.path.join(temp_dir, "sitemap.xml"))
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://metrics.1aeo.com",
+        "https://user:pass@metrics.1aeo.com",
+        "https://metrics.1aeo.com/private",
+        "https://metrics.1aeo.com?preview=1",
+    ],
+)
+def test_non_public_base_urls_are_rejected_or_skipped(temp_dir, base_url):
+    if base_url.startswith("http://"):
+        assert generate_search_discovery(temp_dir, base_url)["generated"] is False
+    else:
+        with pytest.raises(ValueError):
+            generate_search_discovery(temp_dir, base_url)

--- a/tests/unit/test_search_discovery.py
+++ b/tests/unit/test_search_discovery.py
@@ -7,7 +7,10 @@ import pytest
 
 from allium.lib.search_discovery import (
     SITEMAP_NAMESPACE,
+    _pack_sitemap_urls,
     _route_for_html,
+    _serialize_xml,
+    _urlset,
     generate_search_discovery,
 )
 
@@ -62,6 +65,23 @@ def test_local_build_skips_public_discovery_files(temp_dir):
     assert not os.path.exists(os.path.join(temp_dir, "robots.txt"))
     assert not os.path.exists(os.path.join(temp_dir, "sitemap.xml"))
     assert not os.path.exists(os.path.join(temp_dir, "sitemap-1.xml"))
+
+
+def test_long_nested_routes_are_sharded_before_byte_limit():
+    urls = [
+        "https://metrics.1aeo.com/" + "nested-route/" * 20 + str(index)
+        for index in range(6)
+    ]
+    two_url_size = len(_serialize_xml(_urlset(urls[:2])))
+
+    groups = _pack_sitemap_urls(urls, max_urls=50_000, max_bytes=two_url_size)
+
+    assert len(groups) == 3
+    assert [len(group) for group in groups] == [2, 2, 2]
+    assert all(
+        len(_serialize_xml(_urlset(group))) <= two_url_size
+        for group in groups
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

- add the Google and Bing verification tags to the authoritative Jinja site layout
- generate the production `robots.txt` and XML sitemap from the HTML routes produced by each build
- omit inaccurate `lastmod` values and shard automatically if the site exceeds the sitemap URL limit
- add unit coverage for canonical route mapping, robots policy, and sitemap validity

## Why

This makes the verification tags and crawler-discovery artifacts part of the Metrics source build so scheduled deployments retain them.

## Validation

- 1,127 tests passed, 1 skipped, 56 deselected
- production-style build against live Onionoo completed with 10,598 relays and 28,074 sitemap URLs
- built homepage contains each verification tag exactly once in `<head>`
- generated `robots.txt` matches the requested policy exactly
- generated sitemap parses as valid XML and contains only absolute HTTPS URLs on `metrics.1aeo.com`
- critical flake8 checks and Jinja template rendering passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically generates `robots.txt` and XML sitemaps for eligible production sites.
  * Supports sitemap sharding by URL count and file size, and removes outdated sitemap files.
  * Adds Google and Bing site-verification metadata to generated pages.
* **Bug Fixes**
  * Excludes error pages and normalizes routes in discovery files.
  * Skips discovery-file generation for local or non-public builds.
* **Tests**
  * Added coverage for sitemap, robots.txt, URL validation, size limits, and route handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->