### PR TITLE
Polish overload indicators and relay-table navigation

### DIFF
--- a/allium/templates/contact-relay-list.html
+++ b/allium/templates/contact-relay-list.html
@@ -29,12 +29,14 @@
    2. When operator has no AROI (not_configured): Single table (original behavior)
    ============================================================================= #}
 
+{% macro relay_table_start() -%}
 <div id="relay-table"></div>
 {% if contact_sort_mode == 'overload' -%}
-<p class="al-status-danger-bold" style="margin: 0 0 8px;">
+<p class="al-status-danger-bold" style="margin: 20px 0 0;">
     ⚡︎ Overloaded relays are shown first{% if overload_summary %} ({{ overload_summary.overloaded }} currently overloaded){% endif %}.
 </p>
 {% endif -%}
+{%- endmacro %}
 
 {# Pre-compute fingerprint sets for O(1) lookups #}
 {% set validated_fps = contact_validation_status.validated_fingerprints if contact_validation_status else {} -%}
@@ -410,6 +412,8 @@
     {%- endif -%}
 {%- endif %}
 
+{{ relay_table_start() }}
+
 {# =============================================================================
    B1.1: PEER ISSUE SECTIONS (rendered above the cascade so urgent
    problems surface first regardless of operator-level status).
@@ -570,6 +574,7 @@
    SINGLE TABLE LAYOUT (original behavior for operators without AROI)
    DRY: Reuses relay_table_header and relay_row macros
    ============================================================================= #}
+{{ relay_table_start() }}
 {% set relay_list = relay_subset[:500] if is_index else relay_subset %}
 {% set single_table_has_ipv6 = relay_list|selectattr('ipv6_support', 'equalto', 'both')|list|length > 0 or relay_list|selectattr('ipv6_support', 'equalto', 'ipv6_only')|list|length > 0 %}
 <table class="table table-condensed">

--- a/allium/templates/contact-relay-list.html
+++ b/allium/templates/contact-relay-list.html
@@ -30,6 +30,11 @@
    ============================================================================= #}
 
 <div id="relay-table"></div>
+{% if contact_sort_mode == 'overload' -%}
+<p class="al-status-danger-bold" style="margin: 0 0 8px;">
+    ⚡︎ Overloaded relays are shown first{% if overload_summary %} ({{ overload_summary.overloaded }} currently overloaded){% endif %}.
+</p>
+{% endif -%}
 
 {# Pre-compute fingerprint sets for O(1) lookups #}
 {% set validated_fps = contact_validation_status.validated_fingerprints if contact_validation_status else {} -%}
@@ -118,7 +123,7 @@
 <tr>
     {% set obs_unit = relay['observed_bandwidth']|determine_unit(relays.use_bits) -%}
     {% set obs_bandwidth = relay['observed_bandwidth']|format_bandwidth_with_unit(obs_unit) -%}
-    <td>
+    <td style="white-space: nowrap;">
         {% if relay['running'] -%}
             <span class="circle circle-online" title="This relay is online"></span>
         {% else -%}
@@ -140,7 +145,7 @@
         {% endif -%}
         {# Overload badge: links to the relay's #overload detail section (tooltip = reason) #}
         {% if relay.get('stability_is_overloaded') -%}
-            <a href="{{ page_ctx.path_prefix }}relay/{{ relay['fingerprint']|escape }}/#overload" class="al-link-plain" title="Overloaded — {{ relay['stability_tooltip']|escape }}. Click for overload details." aria-label="{{ relay['nickname']|escape }} is overloaded; view overload details"><span class="al-status-danger-bold" style="margin-left: 3px;">⚡</span></a>
+            <a href="{{ page_ctx.path_prefix }}relay/{{ relay['fingerprint']|escape }}/#overload" class="al-link-plain" title="Overloaded — {{ relay['stability_tooltip']|escape }}. Click for overload details." aria-label="{{ relay['nickname']|escape }} is overloaded; view overload details"><span class="al-status-danger-bold" style="margin-left: 3px;">⚡︎</span></a>
         {% endif -%}
     </td>
     {% if relay['effective_family']|length > 1 -%}

--- a/allium/templates/contact-relay-list.html
+++ b/allium/templates/contact-relay-list.html
@@ -125,7 +125,7 @@
 <tr>
     {% set obs_unit = relay['observed_bandwidth']|determine_unit(relays.use_bits) -%}
     {% set obs_bandwidth = relay['observed_bandwidth']|format_bandwidth_with_unit(obs_unit) -%}
-    <td style="white-space: nowrap;">
+    <td{% if relay.get('stability_is_overloaded') %} style="white-space: nowrap;"{% endif %}>
         {% if relay['running'] -%}
             <span class="circle circle-online" title="This relay is online"></span>
         {% else -%}

--- a/allium/templates/macros.html
+++ b/allium/templates/macros.html
@@ -190,7 +190,7 @@
     <span class="al-status-danger">{{ summary.pct_formatted }} ({{ summary.overloaded }} of {{ summary.total }} relay{{ 's' if summary.total != 1 else '' }})</span>
 {%- endif %}
 {%- if path_prefix is not none and summary.relays %}
-    <ul style="list-style-type: circle; padding-left: 20px; margin-top: 3px; margin-bottom: 0;">
+    <ul style="list-style-type: circle; padding-left: 20px; margin-top: 0; margin-bottom: 0;">
         <li style="font-size: 13px;">
             {%- for r in summary.relays %}<a href="{{ path_prefix }}relay/{{ r['fingerprint']|escape }}/#overload" class="al-status-danger" title="{{ r['stability_tooltip']|escape }}">{{ r['nickname']|escape }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
         </li>
@@ -614,4 +614,4 @@
 {% macro aroi_validation_issues_section(contact_validation_status, aroi_validation_timestamp, page_ctx) -%}
 {# This macro is deprecated - issues are now shown in per-category sections #}
 {# Kept empty for backwards compatibility during transition #}
-{%- endmacro %} 
+{%- endmacro %}

--- a/tests/unit/relays/test_overload_summary.py
+++ b/tests/unit/relays/test_overload_summary.py
@@ -186,6 +186,7 @@ def test_overload_bullet_path_prefix_renders_expanded_relay_links(jinja_env):
     # Impact order (highest bandwidth first) and reason tooltips
     assert rendered.index('BigRelay') < rendered.index('SmallRelay')
     assert 'Rate limits hit W:2 R:0 (limit: 10 MB/s)' in rendered
+    assert 'margin-top: 0' in rendered
     # Fully expanded per user requirement — no collapse mechanism
     assert '<details' not in rendered
 
@@ -264,6 +265,15 @@ def test_contact_html_bullet_count_links_variant_when_available(jinja_env):
     assert '20.0% (2 of 10 relays)' in rendered
 
 
+def test_contact_overload_sort_mode_is_clearly_labeled(jinja_env):
+    """The special sort page should make its overloaded-first order explicit."""
+    context = _contact_context(SAMPLE_SUMMARY)
+    context['contact_sort_mode'] = 'overload'
+    rendered = jinja_env.get_template('contact.html').render(**context)
+
+    assert '⚡︎ Overloaded relays are shown first (2 currently overloaded).' in rendered
+
+
 def test_contact_relay_row_overload_badge(jinja_env):
     """Option 1: overloaded relays get a ⚡ in the Status column linking to
     their #overload section; healthy relays get no badge."""
@@ -273,7 +283,10 @@ def test_contact_relay_row_overload_badge(jinja_env):
     relay['stability_tooltip'] = 'General overload at 2026-07-31 06:12 UTC'
     rendered = jinja_env.get_template('contact.html').render(**context)
     assert '⚡' in rendered
+    # Text presentation keeps the glyph CSS-colorable by the red danger class.
+    assert '<span class="al-status-danger-bold" style="margin-left: 3px;">⚡︎</span>' in rendered
     assert f'href="../relay/{relay["fingerprint"]}/#overload"' in rendered
+    assert '<td style="white-space: nowrap;">' in rendered
     assert 'aria-label="TestRelay is overloaded; view overload details"' in rendered
     assert 'General overload at 2026-07-31 06:12 UTC. Click for overload details.' in rendered
 

--- a/tests/unit/relays/test_overload_summary.py
+++ b/tests/unit/relays/test_overload_summary.py
@@ -345,3 +345,4 @@ def test_contact_relay_row_no_badge_when_not_overloaded(jinja_env):
     """Do not render an overload badge for a healthy relay."""
     rendered = jinja_env.get_template('contact.html').render(**_contact_context(None))
     assert '⚡' not in rendered
+    assert '<td style="white-space: nowrap;">' not in rendered

--- a/tests/unit/relays/test_overload_summary.py
+++ b/tests/unit/relays/test_overload_summary.py
@@ -271,7 +271,57 @@ def test_contact_overload_sort_mode_is_clearly_labeled(jinja_env):
     context['contact_sort_mode'] = 'overload'
     rendered = jinja_env.get_template('contact.html').render(**context)
 
-    assert '⚡︎ Overloaded relays are shown first (2 currently overloaded).' in rendered
+    label = '⚡︎ Overloaded relays are shown first (2 currently overloaded).'
+    assert label in rendered
+    assert rendered.count('id="relay-table"') == 1
+    assert rendered.index('id="relay-table"') < rendered.index(label) < rendered.index('<table')
+
+
+def test_contact_overload_anchor_follows_v3_upgrade_nudge(jinja_env):
+    """The overload anchor should skip the upgrade card and land on the table label."""
+    context = _contact_context(SAMPLE_SUMMARY)
+    context['contact_sort_mode'] = 'overload'
+    relay = context['relay_subset'][0]
+    context['contact_validation_status'] = {
+        'has_aroi': True,
+        'validation_status': 'validated',
+        'validation_summary': {
+            'total_relays': 1,
+            'validated_count': 1,
+            'unauthorized_count': 0,
+            'misconfigured_count': 0,
+            'incomplete_count': 0,
+            'not_configured_count': 0,
+            'security_incident_count': 0,
+            'v2_relay_count': 1,
+            'v2_validated_count': 1,
+            'v3_relay_count': 0,
+            'v3_validated_count': 0,
+            'is_mixed_migration': False,
+        },
+        'validated_fingerprints': {relay['fingerprint']},
+        'unauthorized_fingerprints': set(),
+        'misconfigured_fingerprints': set(),
+        'security_incident_fingerprints': set(),
+        'pending_onionoo_fingerprints': set(),
+        'validated_relays': [{'relay': relay, 'aroi_domain': 'example.org'}],
+        'unauthorized_relays': [],
+        'misconfigured_relays': [],
+        'security_incident_relays': [],
+        'pending_onionoo_relays': [],
+        'incomplete_relays': [],
+        'not_configured_relays': [],
+    }
+
+    rendered = jinja_env.get_template('contact.html').render(**context)
+    upgrade = 'Want to upgrade to ciissversion:3?'
+    anchor = 'id="relay-table"'
+    label = '⚡︎ Overloaded relays are shown first (2 currently overloaded).'
+    validated = 'VALIDATED RELAYS'
+
+    assert rendered.count(anchor) == 1
+    assert rendered.index(upgrade) < rendered.index(anchor) < rendered.index(label)
+    assert rendered.index(label) < rendered.index(validated)
 
 
 def test_contact_relay_row_overload_badge(jinja_env):


### PR DESCRIPTION
## What changed

- Render overload lightning badges as CSS-colorable red text glyphs.
- Keep the status dot, AROI check, and overload badge on one line, scoped only to overloaded rows.
- Remove the extra top gap above overloaded relay names in Network Summary.
- Add an explicit red “Overloaded relays are shown first” label to the overload-sorted variant.
- Place the `#relay-table` target after the CIISS v3 upgrade card so overload links land at the label and top of the table.

## Why

The overload sort worked, but the result was not visually obvious. The emoji glyph remained yellow, narrow status cells wrapped the badge, the summary sub-list spacing was inconsistent, and the anchor landed above the upgrade card instead of at the relay table.

## Verification

- Full test suite: **1,107 passed, 1 skipped, 55 deselected**.
- Focused overload tests: **27 passed**.
- Contact template integration tests: **53 passed**.
- `flake8 --select=E9,F63,F7,F82`: clean.
- `git diff --check`: clean.
- Generated-site comparison: produced `origin/master` and this branch concurrently from identical frozen API/cache inputs, then audited **29,978 common files**. There were no added/removed routes and **zero unexplained content differences** after accounting for only the intended overload label, anchor placement, text-presentation bolt, summary spacing, and overloaded-row no-wrap changes (plus runtime-only timestamp/authority timing noise).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved overload sorting labels and navigation anchors on contact pages.
  * Added clearer overload indicators and consistent spacing in relay tables.
  * Preserved compact, readable relay status cells when overload details are shown.

* **Bug Fixes**
  * Healthy relay rows no longer display overload-specific styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->